### PR TITLE
Split TDI main module

### DIFF
--- a/stratum/hal/bin/tdi/BUILD
+++ b/stratum/hal/bin/tdi/BUILD
@@ -71,6 +71,8 @@ stratum_cc_binary(
     name = "stratum_tdi",
     srcs = [
         "tdi_main.cc",
+        "tdi_main.h",
+        "main.cc",
     ],
     arches = HOST_ARCHES,
     defines = target_defines,

--- a/stratum/hal/bin/tdi/main.cc
+++ b/stratum/hal/bin/tdi/main.cc
@@ -1,0 +1,9 @@
+// Copyright 2022 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#include "stratum/hal/bin/tdi/tdi_main.h"
+
+int main(int argc, char* argv[]) {
+  return stratum::hal::barefoot::TdiMain(argc, argv).error_code();
+}
+

--- a/stratum/hal/bin/tdi/tdi_main.cc
+++ b/stratum/hal/bin/tdi/tdi_main.cc
@@ -3,6 +3,8 @@
 // Copyright 2022 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
+#include "stratum/hal/bin/tdi/tdi_main.h"
+
 #include "gflags/gflags.h"
 #include "stratum/glue/init_google.h"
 #include "stratum/glue/logging.h"
@@ -110,7 +112,3 @@ namespace barefoot {
 }  // namespace barefoot
 }  // namespace hal
 }  // namespace stratum
-
-int main(int argc, char* argv[]) {
-  return stratum::hal::barefoot::TdiMain(argc, argv).error_code();
-}

--- a/stratum/hal/bin/tdi/tdi_main.h
+++ b/stratum/hal/bin/tdi/tdi_main.h
@@ -1,0 +1,19 @@
+// Copyright 2022 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef STRATUM_HAL_BIN_TDI_TDI_MAIN_H_
+#define STRATUM_HAL_BIN_TDI_TDI_MAIN_H_
+
+#include "stratum/glue/status/status.h"
+
+namespace stratum {
+namespace hal {
+namespace barefoot {
+
+::util::Status TdiMain(int argc, char* argv[]);
+
+}  // namespace barefoot
+}  // namespace hal
+}  // namespace stratum
+
+#endif  // STRATUM_HAL_BIN_TDI_TDI_MAIN_H_

--- a/stratum/tools/gnmi/gnmi_cli.cc
+++ b/stratum/tools/gnmi/gnmi_cli.cc
@@ -254,6 +254,7 @@ void BuildGnmiPath(std::string path_str, ::gnmi::Path* path) {
 
   std::shared_ptr<::grpc::ChannelCredentials> channel_credentials =
       ::grpc::InsecureChannelCredentials();
+#if 0
   if (!FLAGS_ca_cert.empty()) {
     ::grpc::string pem_root_certs;
     ::grpc::experimental::TlsKeyMaterialsConfig::PemKeyCertPair
@@ -280,6 +281,7 @@ void BuildGnmiPath(std::string path_str, ::gnmi::Path* path) {
       channel_credentials = ::grpc::experimental::TlsCredentials(cred_opts);
     }
   }
+#endif
   auto channel = ::grpc::CreateChannel(FLAGS_grpc_addr, channel_credentials);
   auto stub = ::gnmi::gNMI::NewStub(channel);
   std::string cmd = std::string(argv[1]);


### PR DESCRIPTION
- Separated the Stratum main() program from the TdiMain class, to make it easier to customize startup.

- Conditionalized out a section of gnmi_cli.cc that depends on an experimental class that is not present in recent versions of gRPC.

Signed-off-by: Derek G Foster <derek.foster@intel.com>