### PR TITLE
Remove DPDK specific code from common p4_service

### DIFF
--- a/stratum/hal/lib/common/p4_service.cc
+++ b/stratum/hal/lib/common/p4_service.cc
@@ -384,18 +384,6 @@ void LogReadRequest(uint64 node_id, const ::p4::v1::ReadRequest& req,
                      node_id, "."));
   }
 
-#ifdef P4OVS_CHANGES
-  // FIXME: We do not support overwrite of an already configured pipeline
-  // for a single device. Remove this check when support for overwriting an
-  // already configured forwarding pipeline is available.
-  if (forwarding_pipeline_configs_ != nullptr &&
-      forwarding_pipeline_configs_->node_id_to_config_size() != 0) {
-    return ::grpc::Status(::grpc::StatusCode::FAILED_PRECONDITION,
-                          "Only a single forwarding pipeline can be pushed "
-                          "for any node so far.");
-  }
-#endif
-
   ::util::Status status = ::util::OkStatus();
   switch (req->action()) {
     case ::p4::v1::SetForwardingPipelineConfigRequest::VERIFY:


### PR DESCRIPTION
Signed-off-by: Ravi Vantipalli <ravi.vantipalli@intel.com>

SetForwardingPipeline should be allowed repetitively. We cannot have this check in the common p4_service.cc file.
If this check is indeed required for non Tofino targets, it has to happen from within the per target implementation.