### PR TITLE
Make tdi_id_mapper target-neutral

### DIFF
--- a/stratum/hal/bin/tdi/dpdk/BUILD
+++ b/stratum/hal/bin/tdi/dpdk/BUILD
@@ -34,13 +34,14 @@ stratum_cc_binary(
     arches = HOST_ARCHES,
     defines = ["DPDK_TARGET"],
     data = [
-	# NOTE: Replace with dpdk conf files
+        # NOTE: Replace with dpdk conf files
         "//stratum/hal/bin/barefoot:tofino_skip_p4.conf",
         "//stratum/hal/bin/barefoot:tofino_skip_p4_no_bsp.conf",
     ],
     deps = [
         "//stratum/hal/lib/tdi/dpdk:dpdk_chassis_manager",
         "//stratum/hal/lib/tdi/dpdk:dpdk_hal",
+        "//stratum/hal/lib/tdi/dpdk:dpdk_sde_utils",
         "//stratum/hal/lib/tdi/dpdk:dpdk_sde_wrapper",
         "//stratum/hal/lib/tdi/dpdk:dpdk_switch",
         "//stratum/hal/lib/tdi:tdi_action_profile_manager",

--- a/stratum/hal/bin/tdi/tofino/BUILD
+++ b/stratum/hal/bin/tdi/tofino/BUILD
@@ -40,6 +40,7 @@ stratum_cc_binary(
     deps = [
         "//stratum/hal/lib/tdi/tofino:tofino_chassis_manager",
         "//stratum/hal/lib/tdi/tofino:tofino_hal",
+        "//stratum/hal/lib/tdi/tofino:tofino_sde_utils",
         "//stratum/hal/lib/tdi/tofino:tofino_sde_wrapper",
         "//stratum/hal/lib/tdi/tofino:tofino_switch",
         "//stratum/hal/lib/tdi:tdi_action_profile_manager",

--- a/stratum/hal/lib/tdi/BUILD
+++ b/stratum/hal/lib/tdi/BUILD
@@ -275,7 +275,10 @@ stratum_cc_test(
 stratum_cc_library(
     name = "tdi_id_mapper",
     srcs = ["tdi_id_mapper.cc"],
-    hdrs = ["tdi_id_mapper.h"],
+    hdrs = [
+        "tdi_id_mapper.h",
+        "tdi_sde_utils.h",
+    ],
     defines = target_defines,
     deps = [
         ":tdi_cc_proto",
@@ -297,7 +300,7 @@ stratum_cc_library(
         "@com_github_p4lang_p4runtime//:p4info_cc_proto",
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/strings",
-    ] + target_sdk,
+    ],
 )
 
 stratum_cc_library(

--- a/stratum/hal/lib/tdi/dpdk/BUILD
+++ b/stratum/hal/lib/tdi/dpdk/BUILD
@@ -56,11 +56,19 @@ stratum_cc_library(
 )
 
 stratum_cc_library(
-    name = "dpdk_sde_wrapper",
-    srcs = [
-        "dpdk_sde_wrapper.cc",
+    name = "dpdk_sde_utils",
+    srcs = ["dpdk_sde_utils.cc"],
+    hdrs = [
+        "//stratum/hal/lib/tdi:tdi_sde_utils.h",
     ],
-    defines = ["DPDK_TARGET"],
+    deps = [
+        "@local_dpdk_bin//:dpdk_sde",
+    ],
+)
+
+stratum_cc_library(
+    name = "dpdk_sde_wrapper",
+    srcs = ["dpdk_sde_wrapper.cc"],
     deps = [
         "//stratum/glue:integral_types",
         "//stratum/glue:logging",

--- a/stratum/hal/lib/tdi/dpdk/dpdk_sde_utils.cc
+++ b/stratum/hal/lib/tdi/dpdk/dpdk_sde_utils.cc
@@ -1,0 +1,34 @@
+// Copyright 2022 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+// Target-agnostic utility functions exposed for use outside TdiSdeWrapper.
+
+#include "stratum/hal/lib/tdi/tdi_sde_utils.h"
+
+#include "tdi/common/tdi_table.hpp"
+#include "tdi_rt/tdi_rt_defs.h"
+
+namespace stratum {
+namespace hal {
+namespace tdi {
+
+tdi_sde_table_type GetSdeTableType(const ::tdi::Table& table) {
+  auto table_type =
+      static_cast<tdi_rt_table_type_e>(table.tableInfoGet()->tableTypeGet());
+  switch (table_type) {
+  case TDI_RT_TABLE_TYPE_ACTION_PROFILE:
+    return TDI_SDE_TABLE_TYPE_ACTION_PROFILE;
+  case TDI_RT_TABLE_TYPE_COUNTER:
+    return TDI_SDE_TABLE_TYPE_ACTION_PROFILE;
+  case TDI_RT_TABLE_TYPE_METER:
+    return TDI_SDE_TABLE_TYPE_METER;
+  case TDI_RT_TABLE_TYPE_SELECTOR:
+    return TDI_SDE_TABLE_TYPE_SELECTOR;
+  default:
+    return TDI_SDE_TABLE_TYPE_NONE;
+  }
+}
+
+}  // namespace tdi
+}  // namespace hal
+}  // namespace stratum

--- a/stratum/hal/lib/tdi/dpdk/dpdk_sde_wrapper.cc
+++ b/stratum/hal/lib/tdi/dpdk/dpdk_sde_wrapper.cc
@@ -42,19 +42,6 @@ namespace tdi {
 
 using namespace stratum::hal::tdi::helpers;
 
-namespace helpers {
-
-// TDI does not provide a target-neutral way for us to determine whether a
-// table is preallocated, so we provide our own means of detection.
-bool IsPreallocatedTable(const ::tdi::Table& table) {
-  auto table_type = static_cast<tdi_rt_table_type_e>(
-      table.tableInfoGet()->tableTypeGet());
-  return (table_type == TDI_RT_TABLE_TYPE_COUNTER ||
-          table_type == TDI_RT_TABLE_TYPE_METER);
-}
-
-} // namespace helpers
-
 ::util::StatusOr<PortState> TdiSdeWrapper::GetPortState(int device, int port) {
   return PORT_STATE_UP;
 }

--- a/stratum/hal/lib/tdi/tdi_sde_helpers.cc
+++ b/stratum/hal/lib/tdi/tdi_sde_helpers.cc
@@ -2,7 +2,7 @@
 // Copyright 2022 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-// Target-agnostic helper functions for dealing with the SDE API.
+// Helper functions for use within TdiSdeWrapper.
 
 #include "stratum/hal/lib/tdi/tdi_sde_helpers.h"
 
@@ -14,6 +14,7 @@
 #include "absl/strings/str_cat.h"
 #include "stratum/glue/gtl/stl_util.h"
 #include "stratum/hal/lib/tdi/tdi_sde_common.h"
+#include "stratum/hal/lib/tdi/tdi_sde_utils.h"
 #include "stratum/hal/lib/tdi/utils.h"
 #include "stratum/lib/macros.h"
 #include "stratum/lib/utils.h"
@@ -459,6 +460,14 @@ namespace helpers {
   CHECK(table_keys->size() == entries);
 
   return ::util::OkStatus();
+}
+
+// TDI does not provide a target-neutral way for us to determine whether a
+// table is preallocated, so we provide our own means of detection.
+bool IsPreallocatedTable(const ::tdi::Table& table) {
+  auto table_type = GetSdeTableType(table);
+  return (table_type == TDI_SDE_TABLE_TYPE_COUNTER ||
+          table_type == TDI_SDE_TABLE_TYPE_METER);
 }
 
 }  // namespace helpers

--- a/stratum/hal/lib/tdi/tdi_sde_helpers.h
+++ b/stratum/hal/lib/tdi/tdi_sde_helpers.h
@@ -2,7 +2,7 @@
 // Copyright 2022 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-// Helper functions for dealing with the SDE API.
+// Helper functions for use within TdiSdeWrapper.
 
 #ifndef STRATUM_HAL_LIB_TDI_TDI_SDE_HELPERS_H_
 #define STRATUM_HAL_LIB_TDI_TDI_SDE_HELPERS_H_
@@ -118,8 +118,6 @@ template <typename T>
     ::tdi::Target tdi_dev_target, const ::tdi::Table* table,
     std::vector<std::unique_ptr<::tdi::TableKey>>* table_keys,
     std::vector<std::unique_ptr<::tdi::TableData>>* table_values);
-
-// Target-specific helper functions
 
 bool IsPreallocatedTable(const ::tdi::Table& table);
 

--- a/stratum/hal/lib/tdi/tdi_sde_utils.h
+++ b/stratum/hal/lib/tdi/tdi_sde_utils.h
@@ -1,0 +1,35 @@
+// Copyright 2022 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+// Target-agnostic utility functions exposed for use outside TdiSdeWrapper.
+
+#ifndef STRATUM_HAL_LIB_TDI_TDI_SDE_UTILS_H_
+#define STRATUM_HAL_LIB_TDI_TDI_SDE_UTILS_H_
+
+namespace tdi { class Table; }
+
+namespace stratum {
+namespace hal {
+namespace tdi {
+
+// Target-neutral SDE table types.
+// Note that this is not a comprehensive set of table types.
+// It consists solely of table types we need to be able to test for
+// in vendor-neutral code.
+enum tdi_sde_table_type {
+    TDI_SDE_TABLE_TYPE_NONE = 0,
+    TDI_SDE_TABLE_TYPE_ACTION_PROFILE,
+    TDI_SDE_TABLE_TYPE_COUNTER,
+    TDI_SDE_TABLE_TYPE_METER,
+    TDI_SDE_TABLE_TYPE_SELECTOR,
+};
+
+tdi_sde_table_type GetSdeTableType(const ::tdi::Table& table);
+
+bool IsPreallocatedTable(const ::tdi::Table& table);
+
+}  // namespace tdi
+}  // namespace hal
+}  // namespace stratum
+
+#endif  // STRATUM_HAL_LIB_TDI_TDI_SDE_UTILS_H_

--- a/stratum/hal/lib/tdi/tofino/BUILD
+++ b/stratum/hal/lib/tdi/tofino/BUILD
@@ -47,6 +47,17 @@ stratum_cc_library(
 )
 
 stratum_cc_library(
+    name = "tofino_sde_utils",
+    srcs = ["tofino_sde_utils.cc"],
+    hdrs = [
+        "//stratum/hal/lib/tdi:tdi_sde_utils.h",
+    ],
+    deps = [
+        "@local_tofino_bin//:tofino_sde",
+    ],
+)
+
+stratum_cc_library(
     name = "tofino_sde_wrapper",
     srcs = [
         "tofino_sde_wrapper.cc",

--- a/stratum/hal/lib/tdi/tofino/tofino_sde_utils.cc
+++ b/stratum/hal/lib/tdi/tofino/tofino_sde_utils.cc
@@ -1,0 +1,34 @@
+// Copyright 2022 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+// Target-agnostic utility functions exposed for use outside TdiSdeWrapper.
+
+#include "stratum/hal/lib/tdi/tdi_sde_utils.h"
+
+#include "tdi/common/tdi_table.hpp"
+#include "tdi_tofino/tdi_tofino_defs.h"
+
+namespace stratum {
+namespace hal {
+namespace tdi {
+
+tdi_sde_table_type GetSdeTableType(const ::tdi::Table& table) {
+  auto table_type =
+      static_cast<tdi_tofino_table_type_e>(table.tableInfoGet()->tableTypeGet());
+  switch (table_type) {
+  case TDI_TOFINO_TABLE_TYPE_ACTION_PROFILE:
+    return TDI_SDE_TABLE_TYPE_ACTION_PROFILE;
+  case TDI_TOFINO_TABLE_TYPE_COUNTER:
+    return TDI_SDE_TABLE_TYPE_ACTION_PROFILE;
+  case TDI_TOFINO_TABLE_TYPE_METER:
+    return TDI_SDE_TABLE_TYPE_METER;
+  case TDI_TOFINO_TABLE_TYPE_SELECTOR:
+    return TDI_SDE_TABLE_TYPE_SELECTOR;
+  default:
+    return TDI_SDE_TABLE_TYPE_NONE;
+  }
+}
+
+}  // namespace tdi
+}  // namespace hal
+}  // namespace stratum

--- a/stratum/hal/lib/tdi/tofino/tofino_sde_wrapper.cc
+++ b/stratum/hal/lib/tdi/tofino/tofino_sde_wrapper.cc
@@ -61,19 +61,6 @@ namespace tdi {
 
 using namespace stratum::hal::tdi::helpers;
 
-namespace helpers {
-
-// TDI does not provide a target-neutral way for us to determine whether a
-// table is preallocated, so we provide our own means of detection.
-bool IsPreallocatedTable(const ::tdi::Table& table) {
-  auto table_type = static_cast<tdi_tofino_table_type_e>(
-      table.tableInfoGet()->tableTypeGet());
-  return (table_type == TDI_TOFINO_TABLE_TYPE_COUNTER ||
-          table_type == TDI_TOFINO_TABLE_TYPE_METER);
-}
-
-} // namespace helpers
-
 namespace {
 
 ::util::StatusOr<bf_port_speed_t> PortSpeedHalToBf(uint64 speed_bps) {


### PR DESCRIPTION
Implemented an internal function to return a target-neutral table type for a specified table. Used this to remove the target-specific code from tdi_id_mapper. Updated the Bazel and CMake build files to reflect the change.

Signed-off-by: Derek G Foster <derek.foster@intel.com>