### PR TITLE
Normalize DPDK port parameter names

### DIFF
--- a/stratum/hal/lib/common/common.proto
+++ b/stratum/hal/lib/common/common.proto
@@ -64,14 +64,14 @@ enum TrafficClass {
 };
 
 // Mode of hotplug request
-enum SWBackendQemuHotplugStatus {
-  NO_HOTPLUG = 0;
-  HOTPLUG_ADD = 1;
-  HOTPLUG_DEL = 2;
+enum QemuHotplugMode {
+  HOTPLUG_MODE_NONE = 0;
+  HOTPLUG_MODE_ADD = 1;
+  HOTPLUG_MODE_DEL = 2;
 }
 
 // Packet Direction type
-enum SWBackendPktDirType {
+enum PacketDirection {
   DIRECTION_HOST = 0;
   DIRECTION_NETWORK = 1;
   DIRECTION_NONE = 2;
@@ -257,8 +257,8 @@ enum FecMode {
   FEC_MODE_AUTO = 3;
 }
 
-// SW backend port Types
-enum SWBackendPortType {
+// DPDK port types.
+enum DpdkPortType {
   PORT_TYPE_NONE = 0;
   PORT_TYPE_VHOST = 1;
   PORT_TYPE_TAP = 2;
@@ -267,19 +267,19 @@ enum SWBackendPortType {
   PORT_TYPE_SINK = 5;
 }
 
-// SW backend device type:
-enum SWBackendDeviceType {
+// DPDK device types.
+enum DpdkDeviceType {
   DEVICE_TYPE_NONE = 0;
   DEVICE_TYPE_VIRTIO_NET = 1;
   DEVICE_TYPE_VIRTIO_BLK = 2;
 }
 
-// SW backend Hotplug params
-enum SWBackendHotplugParams {
+// QEMU Hotplug parameters.
+enum DpdkHotplugParam {
   PARAM_NONE = 0;
   PARAM_SOCK_IP = 1;
   PARAM_SOCK_PORT = 2;
-  PARAM_HOTPLUG = 3;
+  PARAM_HOTPLUG_MODE = 3;
   PARAM_VM_MAC = 4;
   PARAM_NETDEV_ID = 5;
   PARAM_CHARDEV_ID = 6;
@@ -287,21 +287,21 @@ enum SWBackendHotplugParams {
   PARAM_DEVICE_ID = 8;
 }
 
-// Hotplug config parameters for qemu based VM
+// Hotplug config parameters for QEMU-based VM.
 message HotplugConfig {
-  // Socket ip for qemu monitor socket
+  // IP address for qemu monitor socket
   string qemu_socket_ip = 1;
-  // Socket port for qemu monitor socket
+  // Port number for qemu monitor socket
   uint32 qemu_socket_port = 2;
-  // Qemu Hotplug status
-  SWBackendQemuHotplugStatus qemu_hotplug = 3;
+  // Qemu Hotplug mode
+  QemuHotplugMode qemu_hotplug_mode = 3;
   // The configured mac address for this port.
   uint64 qemu_vm_mac_address = 4;
   // VM netdev id for hotplug
   string qemu_vm_netdev_id = 5;
   // VM chardev id for hotplug
   string qemu_vm_chardev_id = 6;
-  // Native socket path ( applicable for containers)
+  // Native socket path (applicable for containers)
   string native_socket_path = 7;
   // VM device id for hotplug
   string qemu_vm_device_id = 8;
@@ -341,7 +341,7 @@ message PortConfigParams {
   // The configured loopback state for this port.
   LoopbackState loopback_mode = 8;
   // Type of this port.
-  SWBackendPortType type = 9;
+  DpdkPortType port_type = 9;
   // Flag to trigger SW backed pipeline.
   bool build_pipeline = 10;
   // VM associated in the OpenConfig.
@@ -349,21 +349,21 @@ message PortConfigParams {
   // Queues to be configured
   int32 queues  = 12;
   // Socket path to be used
-  string socket = 13;
+  string socket_path = 13;
   // Backend device type
-  SWBackendDeviceType device_type = 14;
+  DpdkDeviceType device_type = 14;
   // Pipeline name to be used
-  string pipeline = 15;
+  string pipeline_name = 15;
   // Mempool name to be used
-  string mempool = 16;
+  string mempool_name = 16;
   // Flag to trigger Auto creation of back-end control TAP ports and rules.
-  string control = 17;
+  string control_port = 17;
   // PCI BDF value to be used for the LINK port
-  string pci = 18;
+  string pci_bdf = 18;
   // Per Qemu VM hotplug config
   HotplugConfig hotplug_config = 19;
   // Packet direction
-  SWBackendPktDirType packet_dir = 20;
+  PacketDirection packet_dir = 20;
 }
 
 // Chassis uniquely identifies a switch with a single management interface,
@@ -1203,18 +1203,18 @@ message LoopbackStatus {
   LoopbackState state = 1;  // required
 }
 
-// Specifies backend port type to be used
-message SWBackendPortStatus {
-  SWBackendPortType type = 1; // required
+// Wrapper around DPDK port type.
+message DpdkPortTypeValue {
+  DpdkPortType type = 1; // required
 }
 
-// Specifies backend device type to be used
-message SWBackendDeviceStatus {
-  SWBackendDeviceType device_type = 1; // required
+// Wrapper around DPDK device type
+message DpdkDeviceTypeValue {
+  DpdkDeviceType device_type = 1; // required
 }
 
 // Specifies host to be used by the device
-message HostConfigName {
+message HostNameValue {
   string host_name = 1; // required
 }
 
@@ -1239,8 +1239,8 @@ message MempoolNameConfigured {
 }
 
 // Specifies packet direction to be used for port association
-message SWBackendPktDirStatus {
-  SWBackendPktDirType packet_dir = 1; // required
+message PacketDirValue {
+  PacketDirection packet_dir = 1; // required
 }
 
 // Specifies if Auto creation of back-end control TAP ports is needed.
@@ -1452,11 +1452,11 @@ message DataResponse {
     LoopbackStatus loopback_status = 20;
     NodeInfo node_info = 21;
     SdnPortId sdn_port_id = 22;
-    SWBackendPortStatus port_type = 23;
-    HostConfigName host_config = 24;
+    DpdkPortTypeValue port_type = 23;
+    HostNameValue host_config = 24;
     QueuesConfigured queue_count = 25;
     SocketPathConfigured sock_path = 26;
-    SWBackendDeviceStatus device_type = 27;
+    DpdkDeviceTypeValue device_type = 27;
     PipelineNameConfigured pipeline_name = 28;
     MempoolNameConfigured mempool_name = 29;
     ControlPortConfigured control_port = 30;
@@ -1464,7 +1464,7 @@ message DataResponse {
     MtuValue mtu_value = 32;
     HotplugConfig hotplug_config = 33;
     TargetDatapathId target_dp_id = 34;
-    SWBackendPktDirStatus packet_dir = 35;
+    PacketDirValue packet_dir = 35;
   }
 }
 
@@ -1495,11 +1495,11 @@ message SetRequest {
         // The intended loopback state of the port.
         LoopbackStatus loopback_status = 11;
         // The new port type to be used.
-        SWBackendPortStatus port_type = 12;
+        DpdkPortTypeValue port_type = 12;
         // The new device to be used.
-        SWBackendDeviceStatus device_type = 13;
+        DpdkDeviceTypeValue device_type = 13;
         // The hostname to be used by backend.
-        HostConfigName host_config = 14;
+        HostNameValue host_config = 14;
         // The no of queues to be used by backend.
         QueuesConfigured queue_count = 15;
         // The socket path to be used by backend.
@@ -1517,7 +1517,7 @@ message SetRequest {
         // Per Qemu VM hotplug config
         HotplugConfig hotplug_config = 22;
         // The packet direction to be used for port association.
-        SWBackendPktDirStatus packet_dir = 23;
+        PacketDirValue packet_dir = 23;
       }
     }
     // Data required to set info for a specific node.

--- a/stratum/hal/lib/common/gnmi_events.h
+++ b/stratum/hal/lib/common/gnmi_events.h
@@ -26,20 +26,20 @@ namespace hal {
 
 // Introduction to the contents of this file.
 //
-// There is a number of gNMI events defined below. The gNMI YANG model tree has
-// a lot of leafs and there is no way to guess which type of event should be
-// passed to a particular one. A brute-force approach of sending each received
-// event to every handler and let it decide if it should do something about it
-// works but is very time and CPU resources intensive. The hierarchy of
-// EventHandlerList<> templates solves this problem by keeping separate list of
-// handlers grouped by the type of event the handler is interested in. This
-// way the number of handlers an event is sent to is minimized to those that
+// There are a number of gNMI events defined below. The gNMI YANG model tree has
+// a lot of leaves and there is no way to guess which type of event should be
+// passed to a particular leaf. A brute-force approach of sending each received
+// event to every handler and letting it decide if it should do something about
+// it works, but is very time and CPU resource intensive. The hierarchy of
+// EventHandlerList<> templates solves this problem by keeping separate lists
+// of handlers grouped by the type of event the handler is interested in. This
+// way, the number of handlers an event is sent to is limited to those that
 // might want to learn about it.
 // The idea is simple:
-// - an handler knows what events it would like to receive, so, it can register
-//   itself with as many per-event lists as there is event types by calling
-//   Register() on correct lists.
-// - an event knows its type, so, it can call Process() method of correct event
+// - a handler knows what events it would like to receive, so it can register
+//   itself with as many per-event lists as there are event types by calling
+//   Register() on the correct lists.
+// - an event knows its type, so it can call Process() method of correct event
 //   handler list, which in turn will call all handlers that are registered.
 // C++ template and inheritence magic is used to make the whole process as
 // automatic (i.e. without explicit code) as possible.
@@ -58,9 +58,9 @@ class GnmiEvent {
 };
 using GnmiEventPtr = std::shared_ptr<GnmiEvent>;
 
-// A helper class that provides implementation of the GnmiEvent::Process()
+// A helper class that provides an implementation of the GnmiEvent::Process()
 // method that finds an instance of the EventHandlerList<> class that holds
-// references to all handlers interested in this type of events and passes the
+// references to all handlers interested in this type of event and passes the
 // event to this instance for processing.
 // This approach shortens the list of handlers that are bothered to check if
 // they should do something due to reception of this event.
@@ -70,14 +70,14 @@ class GnmiEventProcess : public GnmiEvent {
   ::util::Status Process() const override;
 };
 
-// A Timer event. Only certain type of subscriptions, like interface statistics,
-// handle this type of events.
+// A Timer event. Only certain types of subscriptions, such as interface
+// statistics, handle this type of event.
 class TimerEvent : public GnmiEventProcess<TimerEvent> {};
 
 // A Poll event.
 class PollEvent : public GnmiEventProcess<PollEvent> {};
 
-// An alarm has been triggered event.
+// An event signaling that an alarm has been triggered.
 class AlarmEvent : public GnmiEventProcess<AlarmEvent> {
  public:
   AlarmEvent(uint64 time_created, const std::string& info)

--- a/stratum/hal/lib/tdi/dpdk/dpdk_add_subtree_interface.cc
+++ b/stratum/hal/lib/tdi/dpdk/dpdk_add_subtree_interface.cc
@@ -115,22 +115,21 @@ TreeNode* YangParseTreePaths::AddSubtreeInterface(
 
   node = tree->AddNode(GetPath("interfaces")(
       "virtual-interface", name)("config")("counters")("in-fcs-errors")());
-  SetUpInterfacesInterfaceStateCountersInFcsErrors(
-      node_id, port_id, node, tree);
+  SetUpInterfacesInterfaceStateCountersInFcsErrors(node_id, port_id, node, tree);
 
   node = tree->AddNode(GetPath("interfaces")(
-      "virtual-interface", name)("config")("host")());
+      "virtual-interface", name)("config")("host-name")());
   SetUpInterfacesInterfaceConfigHost("", node_id, port_id, node, tree);
 
   node = tree->AddNode(GetPath("interfaces")(
       "virtual-interface", name)("config")("port-type")());
   SetUpInterfacesInterfaceConfigPortType(
-      SWBackendPortType::PORT_TYPE_NONE, node_id, port_id, node, tree);
+      DpdkPortType::PORT_TYPE_NONE, node_id, port_id, node, tree);
 
   node = tree->AddNode(GetPath("interfaces")(
       "virtual-interface", name)("config")("device-type")());
   SetUpInterfacesInterfaceConfigDeviceType(
-      SWBackendPortType::PORT_TYPE_NONE, node_id, port_id, node, tree);
+      DpdkPortType::PORT_TYPE_NONE, node_id, port_id, node, tree);
 
   node = tree->AddNode(GetPath("interfaces")(
       "virtual-interface", name)("config")("pipeline-name")());
@@ -163,7 +162,7 @@ TreeNode* YangParseTreePaths::AddSubtreeInterface(
   node = tree->AddNode(GetPath("interfaces")(
       "virtual-interface", name)("config")("packet-dir")());
   SetUpInterfacesInterfaceConfigPacketDir(
-      SWBackendPktDirType::DIRECTION_NONE, node_id, port_id, node, tree);
+      PacketDirection::DIRECTION_NONE, node_id, port_id, node, tree);
 
   node = tree->AddNode(GetPath("interfaces")("virtual-interface", name)
                        ("config")("qemu-socket-ip")());
@@ -174,12 +173,12 @@ TreeNode* YangParseTreePaths::AddSubtreeInterface(
   SetUpInterfacesInterfaceConfigQemuSocketPort(0, node_id, port_id, node, tree);
 
   node = tree->AddNode(GetPath("interfaces")(
-      "virtual-interface", name)("config")("hotplug")());
-  SetUpInterfacesInterfaceConfigHotplug(
-      SWBackendQemuHotplugStatus::NO_HOTPLUG, node_id, port_id, node, tree);
+      "virtual-interface", name)("config")("qemu-hotplug-mode")());
+  SetUpInterfacesInterfaceConfigQemuHotplugMode(
+      QemuHotplugMode::HOTPLUG_MODE_NONE, node_id, port_id, node, tree);
 
   node = tree->AddNode(GetPath("interfaces")(
-      "virtual-interface", name)("config")("qemu-vm-mac")());
+      "virtual-interface", name)("config")("qemu-vm-mac-address")());
   SetUpInterfacesInterfaceConfigQemuVmMacAddress(node_id, port_id, mac_address, node, tree);
 
   node = tree->AddNode(GetPath("interfaces")(

--- a/stratum/hal/lib/tdi/dpdk/dpdk_chassis_manager.h
+++ b/stratum/hal/lib/tdi/dpdk/dpdk_chassis_manager.h
@@ -84,7 +84,7 @@ class DpdkChassisManager {
   // Sets the value of a hotplug configuration parameter.
   ::util::Status SetHotplugParam(
       uint64 node_id, uint32 port_id, const SingletonPort& singleton_port,
-      SWBackendHotplugParams param_type);
+      DpdkHotplugParam param_type);
 
   // DpdkChassisManager is neither copyable nor movable.
   DpdkChassisManager(const DpdkChassisManager&) = delete;
@@ -112,11 +112,11 @@ class DpdkChassisManager {
     std::string qemu_vm_chardev_id;
     std::string qemu_vm_device_id;
     std::string native_socket_path;
-    SWBackendQemuHotplugStatus qemu_hotplug;
+    QemuHotplugMode qemu_hotplug_mode;
 
     HotplugConfig() : qemu_socket_port(0),
                       qemu_vm_mac_address(0),
-                      qemu_hotplug(NO_HOTPLUG) {}
+                      qemu_hotplug_mode(HOTPLUG_MODE_NONE) {}
   };
 
   struct PortConfig {
@@ -130,9 +130,9 @@ class DpdkChassisManager {
     // empty if loopback mode configuration failed
     absl::optional<LoopbackState> loopback_mode;
 
-    SWBackendPortType port_type;
-    SWBackendDeviceType device_type;
-    SWBackendPktDirType packet_dir;
+    DpdkPortType port_type;
+    DpdkDeviceType device_type;
+    PacketDirection packet_dir;
     int32 queues;
     std::string socket_path;
     std::string host_name;

--- a/stratum/hal/lib/tdi/dpdk/dpdk_chassis_manager_test.cc
+++ b/stratum/hal/lib/tdi/dpdk/dpdk_chassis_manager_test.cc
@@ -305,7 +305,7 @@ TEST_F(DpdkChassisManagerTest, RemovePort) {
 
 TEST_F(DpdkChassisManagerTest, IsPortParamSet) {
   SingletonPort sport;
-  sport.mutable_config_params()->set_type(PORT_TYPE_VHOST);
+  sport.mutable_config_params()->set_port_type(PORT_TYPE_VHOST);
   ASSERT_FALSE(m_chassis_manager_->IsPortParamSet(
       kUnit, kPort, ValueCase::kPortType));
   ASSERT_TRUE(m_chassis_manager_->SetPortParam(
@@ -328,10 +328,10 @@ TEST_F(DpdkChassisManagerTest, SetPortParam) {
 
   PortConfigParams* config_params = sport->mutable_config_params();
   config_params->set_admin_state(ADMIN_STATE_ENABLED);
-  config_params->set_type(PORT_TYPE_VHOST);
+  config_params->set_port_type(PORT_TYPE_VHOST);
   config_params->set_device_type(DEVICE_TYPE_VIRTIO_NET);
   config_params->set_queues(2);
-  config_params->set_socket("/socket/to/me");
+  config_params->set_socket_path("/socket/to/me");
   config_params->set_host_name("Fawlty");
 
   ASSERT_TRUE(m_chassis_manager_->SetPortParam(

--- a/stratum/hal/lib/tdi/dpdk/dpdk_hal_test.cc
+++ b/stratum/hal/lib/tdi/dpdk/dpdk_hal_test.cc
@@ -312,7 +312,10 @@ TEST_F(DpdkHalTest, ColdbootSetupFailureWhenChassisConfigPushFails) {
   EXPECT_THAT(errors[0].error_message(), HasSubstr("saved chassis config"));
 }
 
-TEST_F(DpdkHalTest, ColdbootSetupFailureWhenPipelineConfigPushFailsForSomeNodes) {
+// Test fails for DPDK because the the forwarding pipeline config is missing
+// or empty and PushSavedForwardingPipelineConfigs() returns OkStatus without
+// invoking switch_mock.
+TEST_F(DpdkHalTest, DISABLED_ColdbootSetupFailureWhenPipelineConfigPushFailsForSomeNodes) {
   // Setup and save the test config(s).
   ChassisConfig chassis_config;
   ForwardingPipelineConfigs forwarding_pipeline_configs;

--- a/stratum/hal/lib/tdi/dpdk/dpdk_parse_tree_interface.h
+++ b/stratum/hal/lib/tdi/dpdk/dpdk_parse_tree_interface.h
@@ -70,7 +70,7 @@ void SetUpInterfacesInterfaceConfigQemuSocketPort(
     uint64 default_socket_port, uint64 node_id, uint64 port_id,
     TreeNode* node, YangParseTree* tree);
 
-void SetUpInterfacesInterfaceConfigHotplug(
+void SetUpInterfacesInterfaceConfigQemuHotplugMode(
     uint64 status, uint64 node_id, uint64 port_id,
     TreeNode* node, YangParseTree* tree);
 

--- a/stratum/hal/lib/tdi/dpdk/dpdk_sde_wrapper.cc
+++ b/stratum/hal/lib/tdi/dpdk/dpdk_sde_wrapper.cc
@@ -143,7 +143,7 @@ dpdk_port_type_t get_target_port_type(DpdkPortType type) {
             << " qemu_vm_chardev_id=" << hotplug_attrs->qemu_vm_chardev_id
             << " qemu_vm_device_id=" << hotplug_attrs->qemu_vm_device_id
             << " native_socket_path=" << hotplug_attrs->native_socket_path
-            << " qemu_hotplug_mode = " << hotplug_attrs->qemu_hotplug;
+            << " qemu_hotplug=" << hotplug_attrs->qemu_hotplug;
 
   if (hotplug_config.qemu_hotplug_mode == HOTPLUG_MODE_ADD) {
        RETURN_IF_TDI_ERROR(bf_pal_hotplug_add(static_cast<bf_dev_id_t>(device),

--- a/stratum/hal/lib/tdi/dpdk/dpdk_sde_wrapper.cc
+++ b/stratum/hal/lib/tdi/dpdk/dpdk_sde_wrapper.cc
@@ -78,7 +78,7 @@ using namespace stratum::hal::tdi::helpers;
 }
 
 namespace {
-dpdk_port_type_t get_target_port_type(SWBackendPortType type) {
+dpdk_port_type_t get_target_port_type(DpdkPortType type) {
   switch(type) {
     case PORT_TYPE_VHOST: return BF_DPDK_LINK;
     case PORT_TYPE_TAP: return BF_DPDK_TAP;
@@ -121,7 +121,8 @@ dpdk_port_type_t get_target_port_type(SWBackendPortType type) {
   strncpy(hotplug_attrs->native_socket_path,
           hotplug_config.native_socket_path.c_str(),
           sizeof(hotplug_attrs->native_socket_path));
-  hotplug_attrs->qemu_hotplug = hotplug_config.qemu_hotplug;
+  // Convert enum to Boolean (NONE == false, ADD or DEL == true)
+  hotplug_attrs->qemu_hotplug = (hotplug_config.qemu_hotplug_mode != 0);
   hotplug_attrs->qemu_socket_port = hotplug_config.qemu_socket_port;
   uint64 mac_address = hotplug_config.qemu_vm_mac_address;
 
@@ -142,13 +143,13 @@ dpdk_port_type_t get_target_port_type(SWBackendPortType type) {
             << " qemu_vm_chardev_id=" << hotplug_attrs->qemu_vm_chardev_id
             << " qemu_vm_device_id=" << hotplug_attrs->qemu_vm_device_id
             << " native_socket_path=" << hotplug_attrs->native_socket_path
-            << " qemu_hotplug = " << hotplug_attrs->qemu_hotplug;
+            << " qemu_hotplug_mode = " << hotplug_attrs->qemu_hotplug;
 
-  if (hotplug_config.qemu_hotplug == HOTPLUG_ADD) {
+  if (hotplug_config.qemu_hotplug_mode == HOTPLUG_MODE_ADD) {
        RETURN_IF_TDI_ERROR(bf_pal_hotplug_add(static_cast<bf_dev_id_t>(device),
                                               static_cast<bf_dev_port_t>(port),
                                               hotplug_attrs.get()));
-  } else if (hotplug_config.qemu_hotplug == HOTPLUG_DEL) {
+  } else if (hotplug_config.qemu_hotplug_mode == HOTPLUG_MODE_DEL) {
        RETURN_IF_TDI_ERROR(bf_pal_hotplug_del(static_cast<bf_dev_id_t>(device),
                                               static_cast<bf_dev_port_t>(port),
                                               hotplug_attrs.get()));

--- a/stratum/hal/lib/tdi/dpdk/dpdk_switch.cc
+++ b/stratum/hal/lib/tdi/dpdk/dpdk_switch.cc
@@ -168,18 +168,10 @@ DpdkSwitch::~DpdkSwitch() {}
     ::util::Status status = ::util::OkStatus();
     switch (req.request_case()) {
       // Port data request
-      case DataRequest::Request::kOperStatus:
       case DataRequest::Request::kAdminStatus:
       case DataRequest::Request::kMacAddress:
-      case DataRequest::Request::kPortSpeed:
-      case DataRequest::Request::kNegotiatedPortSpeed:
       case DataRequest::Request::kLacpRouterMac:
       case DataRequest::Request::kPortCounters:
-      case DataRequest::Request::kForwardingViability:
-      case DataRequest::Request::kHealthIndicator:
-      case DataRequest::Request::kAutonegStatus:
-      case DataRequest::Request::kFrontPanelPortInfo:
-      case DataRequest::Request::kLoopbackStatus:
       case DataRequest::Request::kSdnPortId: {
         auto port_data = chassis_manager_->GetPortData(req);
         if (!port_data.ok()) {
@@ -204,6 +196,14 @@ DpdkSwitch::~DpdkSwitch() {}
         }
         break;
       }
+      case DataRequest::Request::kOperStatus:
+      case DataRequest::Request::kPortSpeed:
+      case DataRequest::Request::kNegotiatedPortSpeed:
+      case DataRequest::Request::kForwardingViability:
+      case DataRequest::Request::kHealthIndicator:
+      case DataRequest::Request::kAutonegStatus:
+      case DataRequest::Request::kFrontPanelPortInfo:
+      case DataRequest::Request::kLoopbackStatus:
       default:
         status =
             MAKE_ERROR(ERR_UNIMPLEMENTED)
@@ -253,7 +253,7 @@ bool DpdkSwitch::IsPortParamSet(
 
 ::util::Status DpdkSwitch::SetHotplugParam(
     uint64 node_id, uint32 port_id, const SingletonPort& singleton_port,
-    SWBackendHotplugParams param_type) {
+    DpdkHotplugParam param_type) {
   return chassis_manager_->SetHotplugParam(
       node_id, port_id, singleton_port, param_type);
 }

--- a/stratum/hal/lib/tdi/dpdk/dpdk_switch.h
+++ b/stratum/hal/lib/tdi/dpdk/dpdk_switch.h
@@ -37,7 +37,7 @@ public:
 
     virtual ::util::Status SetHotplugParam(
         uint64 node_id, uint32 port_id, const SingletonPort& singleton_port,
-        SWBackendHotplugParams param_type) = 0;
+        DpdkHotplugParam param_type) = 0;
 };
 
 class DpdkSwitch : virtual public SwitchInterface,
@@ -109,7 +109,7 @@ class DpdkSwitch : virtual public SwitchInterface,
   // Sets the value of a hotplug configuration parameter.
   ::util::Status SetHotplugParam(
       uint64 node_id, uint32 port_id, const SingletonPort& singleton_port,
-      SWBackendHotplugParams param_type) override;
+      DpdkHotplugParam param_type) override;
 
   // Factory function for creating the instance of the class.
   static std::unique_ptr<DpdkSwitch> CreateInstance(

--- a/stratum/hal/lib/tdi/dpdk/test_main.cc
+++ b/stratum/hal/lib/tdi/dpdk/test_main.cc
@@ -19,7 +19,7 @@ int main(int argc, char** argv) {
 
   bool tmpdir_created = false;
   if (FLAGS_test_tmpdir.empty()) {
-    char tmpdir[] = "/tmp/stratum_hal_ipdk_test.XXXXXX";
+    char tmpdir[] = "/tmp/stratum_dpdk_hal_test.XXXXXX";
     CHECK(mkdtemp(tmpdir));
     FLAGS_test_tmpdir = tmpdir;
     tmpdir_created = true;

--- a/stratum/hal/lib/tdi/tdi_sde_interface.h
+++ b/stratum/hal/lib/tdi/tdi_sde_interface.h
@@ -46,13 +46,13 @@ class TdiSdeInterface {
     std::string qemu_vm_chardev_id;
     std::string qemu_vm_device_id;
     std::string native_socket_path;
-    SWBackendQemuHotplugStatus qemu_hotplug;
+    QemuHotplugMode qemu_hotplug_mode;
   };
 
   struct PortConfigParams {
-    SWBackendPortType port_type;
-    SWBackendDeviceType device_type;
-    SWBackendPktDirType packet_dir;
+    DpdkPortType port_type;
+    DpdkDeviceType device_type;
+    PacketDirection packet_dir;
     int queues;
     int mtu;
     std::string socket_path;

--- a/stratum/hal/lib/tdi/tofino/test_main.cc
+++ b/stratum/hal/lib/tdi/tofino/test_main.cc
@@ -19,7 +19,7 @@ int main(int argc, char** argv) {
 
   bool tmpdir_created = false;
   if (FLAGS_test_tmpdir.empty()) {
-    char tmpdir[] = "/tmp/stratum_hal_tdi_test.XXXXXX";
+    char tmpdir[] = "/tmp/stratum_hal_tdi_tofino_test.XXXXXX";
     CHECK(mkdtemp(tmpdir));
     FLAGS_test_tmpdir = tmpdir;
     tmpdir_created = true;

--- a/stratum/hal/lib/yang/yang_parse_tree_test.cc
+++ b/stratum/hal/lib/yang/yang_parse_tree_test.cc
@@ -179,11 +179,11 @@ class YangParseTreeTest : public ::testing::Test {
     parse_tree_.AddSubtreeSystem();
   }
 
-  // A method helping testing if the OnXxx method of a leaf specified by 'path'.
-  // It takes care of all the boiler plate code:
+  // A method to help test the OnXxx method of a leaf specified by 'path'.
+  // It takes care of all the boilerplate code:
   // - adds an interface named "interface-1"
   // - adds a node named "node-1"
-  // - creates a stream that will write the response proto-buf into 'resp'
+  // - creates a stream that will write the response protobuf into 'resp'
   // - finds the node in the parse three
   // - gets the requested handler
   // - calls the handler with 'event'
@@ -192,7 +192,7 @@ class YangParseTreeTest : public ::testing::Test {
                                  const OnEventAction& action,
                                  const GnmiEvent& event,
                                  ::gnmi::SubscribeResponse* resp) {
-    // After tree creation only two leafs are defined:
+    // After tree creation only two leaves are defined:
     // /interfaces/interface[name=*]/state/ifindex
     // /interfaces/interface[name=*]/state/name
 
@@ -206,7 +206,7 @@ class YangParseTreeTest : public ::testing::Test {
     AddSubtreeSystem();
 
     // Mock gRPC stream that copies parameter of Write() to 'resp'. The contents
-    // of the 'resp' variable is then checked.
+    // of the 'resp' variable are than checked.
     SubscribeReaderWriterMock stream;
     EXPECT_CALL(stream, Write(_, _))
         .WillOnce(DoAll(
@@ -225,11 +225,11 @@ class YangParseTreeTest : public ::testing::Test {
     return handler(event, &stream);
   }
 
-  // A method helping testing if the OnPoll method of a leaf specified by
-  // 'path'. It calls ExecuteOnAction() that takes care of all the boiler plate
+  // A method to help test the OnPoll method of a leaf specified by
+  // 'path'. It calls ExecuteOnAction() that takes care of all the boilerplate
   // code:
   // - adds an interface named "interface-1"
-  // - creates a stream that will write the response proto-buf into 'resp'
+  // - creates a stream that will write the response protobuf into 'resp'
   // - finds the node in the parse three
   // - gets the OnPoll event handler
   // - calls the handler with PollEvent event
@@ -242,11 +242,11 @@ class YangParseTreeTest : public ::testing::Test {
                            resp);
   }
 
-  // A method helping testing if the OnTimer method of a leaf specified by
-  // 'path'. It calls ExecuteOnAction() that takes care of all the boiler plate
+  // A method to help test the OnTimer method of a leaf specified by
+  // 'path'. It calls ExecuteOnAction() that takes care of all the boilerplate
   // code:
   // - adds an interface named "interface-1"
-  // - creates a stream that will write the response proto-buf into 'resp'
+  // - creates a stream that will write the response protobuf into 'resp'
   // - finds the node in the parse three
   // - gets the OmTimer event handler
   // - calls the handler with TimerEvent event
@@ -259,11 +259,11 @@ class YangParseTreeTest : public ::testing::Test {
                            resp);
   }
 
-  // A method helping testing if the OnChange method of a leaf specified by
-  // 'path'. It calls ExecuteOnAction() that takes care of all the boiler plate
+  // A method to help test the OnChange method of a leaf specified by
+  // 'path'. It calls ExecuteOnAction() that takes care of all the boilerplate
   // code:
   // - adds an interface named "interface-1"
-  // - creates a stream that will write the response proto-buf into 'resp'
+  // - creates a stream that will write the response protobuf into 'resp'
   // - finds the node in the parse three
   // - gets the OnChange event handler
   // - calls the handler with 'event' event
@@ -276,11 +276,11 @@ class YangParseTreeTest : public ::testing::Test {
     return ExecuteOnAction(path, &TreeNode::GetOnChangeHandler, event, resp);
   }
 
-  // A method helping testing if the OnChange method of
+  // A method to help test the OnChange method of
   // /components/component/chassis/alarms sub-tree leaf specified by 'path'.
-  // It takes care of all the boiler plate code:
+  // It takes care of all the boilerplate code:
   // - adds a chassis named "chassis-1"
-  // - creates a stream that will write the response proto-buf into 'resp'
+  // - creates a stream that will write the response protobuf into 'resp'
   // - finds the node in the parse three
   // - gets the OnChange event handler
   // - calls the handler with event of type 'A'
@@ -305,11 +305,11 @@ class YangParseTreeTest : public ::testing::Test {
     EXPECT_EQ((resp.update().update(0).val().*get_value)(), expected_value);
   }
 
-  // A method helping testing if the OnPoll method of
+  // A method to help test the OnPoll method of
   // /components/component/chassis/alarms sub-tree leaf specified by 'path'.
-  // It takes care of all the boiler plate code:
+  // It takes care of all the boilerplate code:
   // - adds a chassis named "chassis-1"
-  // - creates a stream that will write the response proto-buf into 'resp' with
+  // - creates a stream that will write the response protobuf into 'resp' with
   //   value 'conf_value' of type 'W'
   // - finds the node in the parse three
   // - gets the OnPoll event handler
@@ -362,11 +362,11 @@ class YangParseTreeTest : public ::testing::Test {
                         expected_value, expected_value);
   }
 
-  // A method helping testing if the OnXxx method of a leaf specified by 'path'.
-  // It takes care of all the boiler plate code:
+  // A method to help test the OnXxx method of a leaf specified by 'path'.
+  // It takes care of all the boilerplate code:
   // - adds an interface named "interface-1"
   // - adds a node named "node-1"
-  // - creates a mock method that will write the set request proto-buf into
+  // - creates a mock method that will write the set request protobuf into
   //   'req'
   // - finds the node in the parse three
   // - gets the requested handler
@@ -376,7 +376,7 @@ class YangParseTreeTest : public ::testing::Test {
                               const OnSetAction& action,
                               const ::google::protobuf::Message& val,
                               SetRequest* req, GnmiEventPtr* notification) {
-    // After tree creation only two leafs are defined:
+    // After tree creation only two leaves are defined:
     // /interfaces/interface[name=*]/state/ifindex
     // /interfaces/interface[name=*]/state/name
 
@@ -422,12 +422,12 @@ class YangParseTreeTest : public ::testing::Test {
     return status;
   }
 
-  // A method helping testing if the OnUpdate method of a leaf specified by
-  // 'path'. It calls ExecuteOnSet() that takes care of all the boiler plate
+  // A method to help test the OnUpdate method of a leaf specified by
+  // 'path'. It calls ExecuteOnSet() that takes care of all the boilerplate
   // code:
   // - adds an interface named "interface-1"
   // - adds a node named "node-1"
-  // - creates a mock method that will write the set request proto-buf into
+  // - creates a mock method that will write the set request protobuf into
   //   'req'
   // - finds the node in the parse three
   // - gets the requested OnUpdate handler
@@ -442,12 +442,12 @@ class YangParseTreeTest : public ::testing::Test {
                         notification);
   }
 
-  // A method helping testing if the OnReplace method of a leaf specified by
-  // 'path'. It calls ExecuteOnSet() that takes care of all the boiler plate
+  // A method to help test the OnReplace method of a leaf specified by
+  // 'path'. It calls ExecuteOnSet() that takes care of all the boilerplate
   // code:
   // - adds an interface named "interface-1"
   // - adds a node named "node-1"
-  // - creates a mock method that will write the set request proto-buf into
+  // - creates a mock method that will write the set request protobuf into
   //   'req'
   // - finds the node in the parse three
   // - gets the requested OnReplace handler
@@ -649,7 +649,7 @@ TEST_F(YangParseTreeTest, FindRoot) {
 }
 
 TEST_F(YangParseTreeTest, PerformActionForAllNodesNonePresent) {
-  // After tree creation only two leafs are defined:
+  // After tree creation only two leaves are defined:
   // /interfaces/interface[name=*]/state/ifindex
   // /interfaces/interface[name=*]/state/name
 
@@ -670,9 +670,9 @@ TEST_F(YangParseTreeTest, PerformActionForAllNodesNonePresent) {
   EXPECT_EQ(0, counter);
 }
 
-// Check if the action is executed for all qualified leafs.
+// Check if the action is executed for all qualified leaves.
 TEST_F(YangParseTreeTest, PerformActionForAllNodesOnePresent) {
-  // After tree creation only two leafs are defined:
+  // After tree creation only two leaves are defined:
   // /interfaces/interface[name=*]/state/ifindex
   // /interfaces/interface[name=*]/state/name
 
@@ -802,9 +802,9 @@ TEST_F(YangParseTreeTest, SendNotificationPass) {
       /*node_id*/ 0, /*port_id*/ 0, HealthState::HEALTH_STATE_BAD)));
 }
 
-// Check if the action is executed for all qualified leafs.
+// Check if the action is executed for all qualified leaves.
 TEST_F(YangParseTreeTest, GetDataFromSwitchInterfaceDataConvertedCorrectly) {
-  // After tree creation only two leafs are defined:
+  // After tree creation only two leaves are defined:
   // /interfaces/interface[name=*]/state/ifindex
   // /interfaces/interface[name=*]/state/name
 
@@ -824,7 +824,7 @@ TEST_F(YangParseTreeTest, GetDataFromSwitchInterfaceDataConvertedCorrectly) {
                       Return(::util::OkStatus())));
 
   // Mock gRPC stream that copies parameter of Write() to 'resp'. The contents
-  // of the 'resp' variable is then checked.
+  // of the 'resp' variable are than checked.
   SubscribeReaderWriterMock stream;
   ::gnmi::SubscribeResponse resp;
   EXPECT_CALL(stream, Write(_, _))
@@ -974,7 +974,7 @@ TEST_F(YangParseTreeTest, InterfacesInterfaceStateAdminStatusOnChangeSuccess) {
 
 // Check if the action is executed correctly.
 TEST_F(YangParseTreeTest, InterfacesInterfaceStateNameOnPollSuccess) {
-  // After tree creation only two leafs are defined:
+  // After tree creation only two leaves are defined:
   // /interfaces/interface[name=*]/state/ifindex
   // /interfaces/interface[name=*]/state/name
 
@@ -982,7 +982,7 @@ TEST_F(YangParseTreeTest, InterfacesInterfaceStateNameOnPollSuccess) {
   AddSubtreeInterface("interface-1");
 
   // Mock gRPC stream that copies parameter of Write() to 'resp'. The contents
-  // of the 'resp' variable is then checked.
+  // of the 'resp' variable are than checked.
   SubscribeReaderWriterMock stream;
   ::gnmi::SubscribeResponse resp;
   EXPECT_CALL(stream, Write(_, _))
@@ -1005,7 +1005,7 @@ TEST_F(YangParseTreeTest, InterfacesInterfaceStateNameOnPollSuccess) {
   EXPECT_EQ(resp.update().update(0).val().string_val(), "interface-1");
 }
 
-// Check if the 'state/ifindex' OnPoll action is works correctly.
+// Check if the 'state/ifindex' OnPoll action works correctly.
 TEST_F(YangParseTreeTest, InterfacesInterfaceStateIfIndexOnPollSuccess) {
   const uint32 kInterface1SdnPortId = 33;
   auto path =
@@ -1144,20 +1144,20 @@ TEST_F(YangParseTreeTest,
 
   static constexpr char kMacAddressAsString[] = "11:22:33:44:55:66";
   static constexpr char kMacStrings[][21] = {
-      "11:22:33:44:55",        // Too short string
-      "11:22:33:44:55:66:77",  // Too long string
+      "11:22:33:44:55",        // String too short
+      "11:22:33:44:55:66:77",  // String too long
       "11;22;33;44;55;66",     // Incorrect delimiter
       "11-22-33-44-55-66",     // Unsupported delimiter
-      "11::22:33:44:55:66",    // Too many delimiter in between
-      ":11:22:33:44:55:66",    // Too many delimiter in the beginning
-      "11:22:33:44:55:66:",    // Too many delimiter in the end
+      "11::22:33:44:55:66",    // Too many delimiters in between
+      ":11:22:33:44:55:66",    // Too many delimiters at the beginning
+      "11:22:33:44:55:66:",    // Too many delimiters at the end
       "1122:3344:5566",        // Unsupported format
       "0",                     // No colon
       "00112233445566",        // No colon
       "11:22:333:44:55:66",    // Too many hex digits
       "11:22:3:44:55:66",      // Too few hex digits
-      "",                      // empty mac string
-      "st:ra:tu:mr:oc:ks"      // None hex digits
+      "",                      // Empty string
+      "st:ra:tu:mr:oc:ks"      // Non-hex digits
   };
 
   // Set new value.
@@ -2523,7 +2523,7 @@ TEST_F(YangParseTreeTest,
   AddSubtreeChassis("chassis-1");
 
   // Mock implementation of RetrieveValue() that sends a response with contents
-  // of whole sub-tree (all leafs).
+  // of whole sub-tree (all leaves).
   EXPECT_CALL(switch_, RetrieveValue(_, _, _, _))
       .WillOnce(DoAll(WithArg<2>(Invoke([](WriterInterface<DataResponse>* w) {
                         DataResponse resp;
@@ -2757,7 +2757,7 @@ TEST_F(YangParseTreeTest,
   AddSubtreeChassis("chassis-1");
 
   // Mock implementation of RetrieveValue() that sends a response with contents
-  // of whole sub-tree (all leafs).
+  // of whole sub-tree (all leaves).
   EXPECT_CALL(switch_, RetrieveValue(_, _, _, _))
       .WillOnce(DoAll(
           WithArg<2>(Invoke([](WriterInterface<DataResponse>* w) {
@@ -2995,7 +2995,7 @@ TEST_F(YangParseTreeTest,
 // Check if all expected handlers are registered
 TEST_F(YangParseTreeTest,
        ExpectedRegistrationsTakePlaceInterfacesInterfaceElipsis) {
-  // After tree creation only two leafs are defined:
+  // After tree creation only two leaves are defined:
   // /interfaces/interface[name=*]/state/ifindex
   // /interfaces/interface[name=*]/state/name
 
@@ -3057,7 +3057,7 @@ TEST_F(YangParseTreeTest,
 // Check if all expected handlers are registered
 TEST_F(YangParseTreeTest,
        ExpectedRegistrationsTakePlaceComponentsComponetChassisAlarms) {
-  // After tree creation only two leafs are defined:
+  // After tree creation only two leaves are defined:
   // /interfaces/interface[name=*]/state/ifindex
   // /interfaces/interface[name=*]/state/name
 


### PR DESCRIPTION
User interface changes:

- Renamed `host` leaf to `host-name`. `host` is ambiguous; the value we are setting is the host *name*.

- Renamed `hotplug` leaf to `qemu-hotplug-mode`. `hotplug` is ambiguous; the value we are setting is the QEMU hotplug *mode*.

- Renamed `qemu-vm-mac` leaf to `qemu-vm-mac-address`. The singleton port mac address leaf is named `mac-address`. Leaf names should be consistent.

Internal changes:

- Renamed `SWBackend` protobuf definitions, changing the prefix to `Dpdk` in some cases and removing it entirely in others.

- Renamed protobuf fields to match the leaf name: `mempool_name` instead of `mempool`, `port_type` instead of `type`, etc.

Other changes:

- Disabled the `ColdbootSetupFailureWhenPipelineConfigPushFailsForSomeNodes` test case in dpdk_hal_test. This test will always fail for DPDK because we require that the forwarding pipeline configuration file be empty on startup, which causes DpdkSwitch::PushChassisConfig to return OK instead of an error.

- Modified DpdkSwitch::RetrieveValue to return ERR_UNIMPLEMENTED instead of passing port parameters that DPDK does not support (kPortSpeed, etc.) to the chassis manager.

- Corrected the temporary directory name used by DPDK unit tests from `ipdk` to `dpdk`.

- Corrected grammar errors in a number of comments.

Outstanding issues:

- The Teardown tests in dpdk_hal_test are currently failing for reasons that are not immediately clear.

Signed-off-by: Derek G Foster <derek.foster@intel.com>