### PR TITLE
Refactor dpdk chassis manager

### DIFF
--- a/stratum/hal/lib/tdi/dpdk/BUILD
+++ b/stratum/hal/lib/tdi/dpdk/BUILD
@@ -27,17 +27,12 @@ target_defines = [
 
 stratum_cc_library(
     name = "dpdk_chassis_manager",
-    srcs = [
-        "dpdk_chassis_manager.cc",
-        "dpdk_port_config.cc"
-    ],
-    hdrs = [
-        "dpdk_chassis_manager.h",
-        "dpdk_port_config.h",
-        "dpdk_port_constants.h"
-    ],
+    srcs = ["dpdk_chassis_manager.cc"],
+    hdrs = ["dpdk_chassis_manager.h"],
     defines = target_defines,
     deps = [
+	":dpdk_port_config",
+	":dpdk_port_constants",
         "//stratum/glue/gtl:map_util",
         "//stratum/glue/status",
         "//stratum/glue/status:statusor",
@@ -63,14 +58,25 @@ stratum_cc_library(
 )
 
 stratum_cc_library(
-    name = "dpdk_sde_utils",
-    srcs = ["dpdk_sde_utils.cc"],
-    hdrs = [
-        "//stratum/hal/lib/tdi:tdi_sde_utils.h",
-    ],
+    name = "dpdk_port_config",
+    srcs = ["dpdk_port_config.cc"],
+    hdrs = ["dpdk_port_config.h"],
     deps = [
-        "@local_dpdk_bin//:dpdk_sde",
+	":dpdk_port_constants",
+        "//stratum/glue/status",
+        "//stratum/glue:integral_types",
+        "//stratum/hal/lib/common:common_cc_proto",
+        "//stratum/hal/lib/tdi:tdi_sde_interface",
+        "//stratum/public/lib:error",
+        "@com_github_google_glog//:glog",
+        "@com_google_absl//absl/types:optional",
+        "@com_google_protobuf//:protobuf",
     ],
+)
+
+stratum_cc_library(
+    name = "dpdk_port_constants",
+    hdrs = ["dpdk_port_constants.h"],
 )
 
 stratum_cc_library(
@@ -89,6 +95,13 @@ stratum_cc_library(
         "@com_google_absl//absl/container:flat_hash_map",
         "@local_dpdk_bin//:dpdk_sde",
     ],
+)
+
+stratum_cc_library(
+    name = "dpdk_sde_utils",
+    srcs = ["dpdk_sde_utils.cc"],
+    hdrs = ["//stratum/hal/lib/tdi:tdi_sde_utils.h"],
+    deps = ["@local_dpdk_bin//:dpdk_sde"],
 )
 
 stratum_cc_library(
@@ -213,6 +226,19 @@ stratum_cc_test(
         "//stratum/public/lib:error",
         "@com_github_google_glog//:glog",
         "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest",
+    ],
+)
+
+stratum_cc_test(
+    name = "dpdk_port_config_test",
+    srcs = [
+        "dpdk_port_config_test.cc",
+    ],
+    deps = [
+	":dpdk_port_config",
+	"//stratum/hal/lib/tdi:tdi_sde_interface",
+        ":test_main",
         "@com_google_googletest//:gtest",
     ],
 )

--- a/stratum/hal/lib/tdi/dpdk/BUILD
+++ b/stratum/hal/lib/tdi/dpdk/BUILD
@@ -27,8 +27,15 @@ target_defines = [
 
 stratum_cc_library(
     name = "dpdk_chassis_manager",
-    srcs = ["dpdk_chassis_manager.cc"],
-    hdrs = ["dpdk_chassis_manager.h"],
+    srcs = [
+        "dpdk_chassis_manager.cc",
+        "dpdk_port_config.cc"
+    ],
+    hdrs = [
+        "dpdk_chassis_manager.h",
+        "dpdk_port_config.h",
+        "dpdk_port_constants.h"
+    ],
     defines = target_defines,
     deps = [
         "//stratum/glue/gtl:map_util",

--- a/stratum/hal/lib/tdi/dpdk/dpdk_chassis_manager.cc
+++ b/stratum/hal/lib/tdi/dpdk/dpdk_chassis_manager.cc
@@ -181,7 +181,7 @@ bool DpdkChassisManager::IsPortParamSet(
   RETURN_IF_ERROR(config.SetHotplugParam(param_type, singleton_port));
 
   auto hotplug_params = static_cast<TdiSdeInterface::HotplugConfigParams*>(
-      &config.cfg.hotplug_config);
+      &config.hotplug);
   auto unit = node_id_to_unit_[node_id];
   auto sdk_port_id = node_id_to_port_id_to_sdk_port_id_[node_id][port_id];
 
@@ -326,7 +326,7 @@ bool DpdkChassisManager::IsPortParamSet(
       << " (SDK Port " << sdk_port_id << ").";
 
   RETURN_IF_ERROR(sde_interface_->HotplugPort(unit, sdk_port_id,
-                                              config->cfg.hotplug_config));
+                                              config->hotplug));
 
   return ::util::OkStatus();
 }

--- a/stratum/hal/lib/tdi/dpdk/dpdk_chassis_manager.cc
+++ b/stratum/hal/lib/tdi/dpdk/dpdk_chassis_manager.cc
@@ -259,9 +259,7 @@ bool DpdkChassisManager::IsPortParamSet(
   LOG(INFO) << "Adding port " << port_id << " in node " << node_id
             << " (SDK Port " << sdk_port_id << ").";
 
-  RETURN_IF_ERROR(sde_interface_->AddPort(
-      unit, sdk_port_id, singleton_port.speed_bps(), sde_params,
-      config_params.fec_mode()));
+  RETURN_IF_ERROR(sde_interface_->AddPort(unit, sdk_port_id, sde_params));
 
   // Check if Control Port Creation is opted.
   if (config->control_port.length()) {
@@ -274,9 +272,7 @@ bool DpdkChassisManager::IsPortParamSet(
      * and maps 1:1 to parent port's sdk_port_id.
      */
     uint32 sdk_ctl_port_id = SDK_PORT_CONTROL_BASE + sdk_port_id;
-    RETURN_IF_ERROR(sde_interface_->AddPort(
-        unit, sdk_ctl_port_id, singleton_port.speed_bps(), sde_params,
-        config_params.fec_mode()));
+    RETURN_IF_ERROR(sde_interface_->AddPort(unit, sdk_ctl_port_id, sde_params));
   }
 
   if (config->mtu) {

--- a/stratum/hal/lib/tdi/dpdk/dpdk_chassis_manager.h
+++ b/stratum/hal/lib/tdi/dpdk/dpdk_chassis_manager.h
@@ -24,6 +24,8 @@ namespace stratum {
 namespace hal {
 namespace tdi {
 
+class DpdkPortConfig;
+
 // Lock which protects chassis state across the entire switch.
 extern absl::Mutex chassis_lock;
 
@@ -104,52 +106,6 @@ class DpdkChassisManager {
     std::unique_ptr<ChannelReader<T>> reader;
   };
 
-  struct HotplugConfig {
-    uint32 qemu_socket_port;
-    uint64 qemu_vm_mac_address;
-    std::string qemu_socket_ip;
-    std::string qemu_vm_netdev_id;
-    std::string qemu_vm_chardev_id;
-    std::string qemu_vm_device_id;
-    std::string native_socket_path;
-    QemuHotplugMode qemu_hotplug_mode;
-
-    HotplugConfig() : qemu_socket_port(0),
-                      qemu_vm_mac_address(0),
-                      qemu_hotplug_mode(HOTPLUG_MODE_NONE) {}
-  };
-
-  struct PortConfig {
-    // ADMIN_STATE_UNKNOWN indicates that something went wrong during port
-    // configuration, and the port add failed or was not attempted.
-    AdminState admin_state;
-    absl::optional<uint64> speed_bps;  // empty if port add failed
-    absl::optional<int32> mtu;         // empty if MTU configuration failed
-    absl::optional<TriState> autoneg;  // empty if Autoneg configuration failed
-    absl::optional<FecMode> fec_mode;  // empty if port add failed
-    // empty if loopback mode configuration failed
-    absl::optional<LoopbackState> loopback_mode;
-
-    DpdkPortType port_type;
-    DpdkDeviceType device_type;
-    PacketDirection packet_dir;
-    int32 queues;
-    std::string socket_path;
-    std::string host_name;
-    std::string pipeline_name;
-    std::string mempool_name;
-    std::string control_port;
-    std::string pci_bdf;
-    HotplugConfig hotplug_config;
-
-    PortConfig() : admin_state(ADMIN_STATE_UNKNOWN),
-                   port_type(PORT_TYPE_NONE),
-                   device_type(DEVICE_TYPE_NONE),
-                   packet_dir (DIRECTION_HOST),
-                   queues(0) {
-    }
-  };
-
   // Maximum depth of port status change event channel.
   static constexpr int kMaxPortStatusEventDepth = 1024;
   static constexpr int kMaxXcvrEventDepth = 1024;
@@ -158,8 +114,8 @@ class DpdkChassisManager {
   // class.
   DpdkChassisManager(OperationMode mode, TdiSdeInterface* sde_interface);
 
-  ::util::StatusOr<const PortConfig*> GetPortConfig(uint64 node_id,
-                                                    uint32 port_id) const
+  ::util::StatusOr<const DpdkPortConfig*> GetPortConfig(
+      uint64 node_id, uint32 port_id) const
       SHARED_LOCKS_REQUIRED(chassis_lock);
 
   // Returns the state of a port given its ID and the ID of its node.
@@ -183,18 +139,18 @@ class DpdkChassisManager {
   // helper to add / configure / enable a port with TdiSdeInterface
   ::util::Status AddPortHelper(uint64 node_id, int unit, uint32 port_id,
                                const SingletonPort& singleton_port,
-                               PortConfig* config);
+                               DpdkPortConfig* config);
 
   // helper to hotplug add / delete a port with TdiSdeInterface
   ::util::Status HotplugPortHelper(uint64 node_id, int unit, uint32 port_id,
                                    const SingletonPort& singleton_port,
-                                   PortConfig* config);
+                                   DpdkPortConfig* config);
 
   // helper to update port configuration with TdiSdeInterface
   ::util::Status UpdatePortHelper(uint64 node_id, int unit, uint32 port_id,
                                   const SingletonPort& singleton_port,
-                                  const PortConfig& config_old,
-                                  PortConfig* config);
+                                  const DpdkPortConfig& config_old,
+                                  DpdkPortConfig* config);
 
   // Determines the mode of operation:
   // - OPERATION_MODE_STANDALONE: when Stratum stack runs independently and
@@ -233,7 +189,7 @@ class DpdkChassisManager {
   // We may change this once missing "get" methods get added to TdiSdeInterface,
   // as we would be able to rely on TdiSdeInterface to query config parameters,
   // instead of maintaining a "consistent" view in this map.
-  std::map<uint64, std::map<uint32, PortConfig>>
+  std::map<uint64, std::map<uint32, DpdkPortConfig>>
       node_id_to_port_id_to_port_config_ GUARDED_BY(chassis_lock);
 
   // Map from node ID to another map from port ID to PortKey corresponding
@@ -253,10 +209,6 @@ class DpdkChassisManager {
   // This contains the inverse mapping of: node_id_to_port_id_to_sdk_port_id_
   // This map is updated as part of each config push.
   std::map<uint64, std::map<uint32, uint32>> node_id_to_sdk_port_id_to_port_id_
-      GUARDED_BY(chassis_lock);
-
-  // Bitmask indicating which attributes have been configured.
-  std::map<uint64, std::map<uint32, uint32>> node_id_port_id_to_backend_
       GUARDED_BY(chassis_lock);
 
   // Pointer to a TdiSdeInterface implementation that wraps all the SDE calls.

--- a/stratum/hal/lib/tdi/dpdk/dpdk_chassis_manager_test.cc
+++ b/stratum/hal/lib/tdi/dpdk/dpdk_chassis_manager_test.cc
@@ -190,8 +190,6 @@ class DpdkChassisManagerTest : public ::testing::Test {
         m_chassis_manager_->node_id_to_port_id_to_sdk_port_id_.empty());
     CHECK_RETURN_IF_FALSE(
         m_chassis_manager_->node_id_to_sdk_port_id_to_port_id_.empty());
-    CHECK_RETURN_IF_FALSE(
-        m_chassis_manager_->node_id_port_id_to_backend_.empty());
     return ::util::OkStatus();
   }
 

--- a/stratum/hal/lib/tdi/dpdk/dpdk_port_config.cc
+++ b/stratum/hal/lib/tdi/dpdk/dpdk_port_config.cc
@@ -1,0 +1,202 @@
+// Copyright 2021-2022 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#include "stratum/hal/lib/tdi/dpdk/dpdk_port_config.h"
+
+#include <cstdint>
+#include <ostream>
+
+#include "glog/logging.h"
+#include "stratum/glue/status/status.h"
+#include "stratum/hal/lib/common/common.pb.h"
+#include "stratum/hal/lib/tdi/dpdk/dpdk_port_constants.h"
+
+namespace stratum {
+namespace hal {
+namespace tdi {
+
+// Returns the parameter mask for a ValueCase, or zero if the
+// ValueCase is not known.
+uint32_t DpdkPortConfig::ParamMaskForCase(ValueCase value_case) {
+  switch (value_case) {
+  case ValueCase::kPortType:
+    return GNMI_CONFIG_PORT_TYPE;
+  case ValueCase::kDeviceType:
+    return GNMI_CONFIG_DEVICE_TYPE;
+  case ValueCase::kQueueCount:
+    return GNMI_CONFIG_QUEUE_COUNT;
+  case ValueCase::kSockPath:
+    return GNMI_CONFIG_SOCKET_PATH;
+
+  case ValueCase::kHostConfig:
+    return GNMI_CONFIG_HOST_NAME;
+  case ValueCase::kPipelineName:
+    return GNMI_CONFIG_PIPELINE_NAME;
+  case ValueCase::kMempoolName:
+    return GNMI_CONFIG_MEMPOOL_NAME;
+  case ValueCase::kMtuValue:
+    return GNMI_CONFIG_MTU_VALUE;
+
+  case ValueCase::kPciBdf:
+    return GNMI_CONFIG_PCI_BDF_VALUE;
+  case ValueCase::kPacketDir:
+    return GNMI_CONFIG_PACKET_DIR;
+  default:
+    return 0;
+  }
+}
+
+::util::Status DpdkPortConfig::SetParam(
+    ValueCase value_case,
+    const SingletonPort& singleton_port) {
+
+  const auto& config_params = singleton_port.config_params();
+
+  switch (value_case) {
+    case ValueCase::kPortType:
+      params_set |= GNMI_CONFIG_PORT_TYPE;
+      cfg.port_type = config_params.port_type();
+      LOG(INFO) << "PortParam::kPortType = " << cfg.port_type;
+      break;
+
+    case ValueCase::kDeviceType:
+      params_set |= GNMI_CONFIG_DEVICE_TYPE;
+      cfg.device_type = config_params.device_type();
+      LOG(INFO) << "PortParam::kDeviceType = " << cfg.device_type;
+      break;
+
+    case ValueCase::kQueueCount:
+      params_set |= GNMI_CONFIG_QUEUE_COUNT;
+      cfg.queues = config_params.queues();
+      LOG(INFO) << "PortParam::kQueueCount = " << cfg.queues;
+      break;
+
+    case ValueCase::kSockPath:
+      params_set |= GNMI_CONFIG_SOCKET_PATH;
+      cfg.socket_path = config_params.socket_path();
+      LOG(INFO) << "PortParam::kSockPath = " << cfg.socket_path;
+      break;
+
+    case ValueCase::kHostConfig:
+      params_set |= GNMI_CONFIG_HOST_NAME;
+      cfg.host_name = config_params.host_name();
+      LOG(INFO) << "PortParam::kHostConfig = " << cfg.host_name;
+      break;
+
+    case ValueCase::kPipelineName:
+      cfg.pipeline_name = config_params.pipeline_name();
+      params_set |= GNMI_CONFIG_PIPELINE_NAME;
+      LOG(INFO) << "PortParam::kPipelineName = " << cfg.pipeline_name;
+      break;
+
+    case ValueCase::kMempoolName:
+      cfg.mempool_name = config_params.mempool_name();
+      params_set |= GNMI_CONFIG_MEMPOOL_NAME;
+      LOG(INFO) << "PortParam::kMempoolName = " << cfg.mempool_name;
+      break;
+
+    case ValueCase::kControlPort:
+      control_port = config_params.control_port();
+      LOG(INFO) << "PortParam::kControlPort = " << control_port;
+      break;
+
+    case ValueCase::kPciBdf:
+      params_set |= GNMI_CONFIG_PCI_BDF_VALUE;
+      cfg.pci_bdf = config_params.pci_bdf();
+      LOG(INFO) << "PortParam::kPciBdf = " << cfg.pci_bdf;
+      break;
+
+    case ValueCase::kMtuValue:
+      if (config_params.mtu() > MAX_MTU) {
+        return MAKE_ERROR(ERR_INVALID_PARAM)
+             << "Unsupported MTU = " << config_params.mtu()
+             << ". MTU should be less than " << MAX_MTU;
+      }
+      mtu = config_params.mtu();
+      params_set |= GNMI_CONFIG_MTU_VALUE;
+      LOG(INFO) << "PortParam::kMtuValue = " << mtu.value();
+      break;
+
+    case ValueCase::kPacketDir:
+      params_set |= GNMI_CONFIG_PACKET_DIR;
+      cfg.packet_dir = config_params.packet_dir();
+      LOG(INFO) << "PortParam::kPacketDir = " << cfg.packet_dir;
+      break;
+
+    default:
+      break;
+  }
+  return ::util::OkStatus();
+}
+
+::util::Status DpdkPortConfig::SetHotplugParam(
+  DpdkHotplugParam param_type, const SingletonPort& singleton_port) {
+
+  const auto& params = singleton_port.config_params().hotplug_config();
+  auto& hotplug = cfg.hotplug_config;
+
+  switch (param_type) {
+    case PARAM_SOCK_IP:
+      params_set |= GNMI_CONFIG_HOTPLUG_SOCKET_IP;
+      hotplug.qemu_socket_ip = params.qemu_socket_ip();
+      LOG(INFO) << "HotplugParam::qemu_socket_ip = " << hotplug.qemu_socket_ip;
+      break;
+
+    case PARAM_SOCK_PORT:
+      params_set |= GNMI_CONFIG_HOTPLUG_SOCKET_PORT;
+      hotplug.qemu_socket_port = params.qemu_socket_port();
+      LOG(INFO) << "HotplugParam::qemu_socket_port = "
+                << hotplug.qemu_socket_port;
+      break;
+
+    case PARAM_HOTPLUG_MODE:
+      params_set |= GNMI_CONFIG_HOTPLUG_MODE;
+      hotplug.qemu_hotplug_mode = params.qemu_hotplug_mode();
+      LOG(INFO) << "HotplugParam::qemu_hotplug_mode = "
+                << hotplug.qemu_hotplug_mode;
+      break;
+
+    case PARAM_VM_MAC:
+      params_set |= GNMI_CONFIG_HOTPLUG_VM_MAC_ADDRESS;
+      hotplug.qemu_vm_mac_address = params.qemu_vm_mac_address();
+      LOG(INFO) << "HotplugParam::qemu_vm_mac_address = "
+                << hotplug.qemu_vm_mac_address;
+      break;
+
+    case PARAM_NETDEV_ID:
+      params_set |= GNMI_CONFIG_HOTPLUG_VM_NETDEV_ID;
+      hotplug.qemu_vm_netdev_id = params.qemu_vm_netdev_id();
+      LOG(INFO) << "HotplugParam::qemu_vm_netdev_id = "
+                << hotplug.qemu_vm_netdev_id;
+      break;
+
+    case PARAM_CHARDEV_ID:
+      params_set |= GNMI_CONFIG_HOTPLUG_VM_CHARDEV_ID;
+      hotplug.qemu_vm_chardev_id = params.qemu_vm_chardev_id();
+      LOG(INFO) << "HotplugParam::qemu_vm_chardev_id = "
+                << hotplug.qemu_vm_chardev_id;
+      break;
+
+    case PARAM_NATIVE_SOCK_PATH:
+      params_set |= GNMI_CONFIG_NATIVE_SOCKET_PATH;
+      hotplug.native_socket_path = params.native_socket_path();
+      LOG(INFO) << "HotplugParam::qemu_native_socket_path = "
+                << hotplug.native_socket_path;
+      break;
+
+    case PARAM_DEVICE_ID:
+      params_set |= GNMI_CONFIG_HOTPLUG_VM_DEVICE_ID;
+      hotplug.qemu_vm_device_id = params.qemu_vm_device_id();
+      LOG(INFO) << "HotplugParam::qemu_vm_device_id = "
+                << hotplug.qemu_vm_device_id;
+      break;
+
+    default:
+      break;
+  }
+  return ::util::OkStatus();
+}
+
+}  // namespace tdi
+}  // namespace hal
+}  // namespace stratum

--- a/stratum/hal/lib/tdi/dpdk/dpdk_port_config.cc
+++ b/stratum/hal/lib/tdi/dpdk/dpdk_port_config.cc
@@ -110,7 +110,7 @@ uint32_t DpdkPortConfig::ParamMaskForCase(ValueCase value_case) {
       if (config_params.mtu() > MAX_MTU) {
         return MAKE_ERROR(ERR_INVALID_PARAM)
              << "Unsupported MTU = " << config_params.mtu()
-             << ". MTU should be less than " << MAX_MTU;
+             << ". MTU should be less than " << MAX_MTU << ".";
       }
       mtu = config_params.mtu();
       params_set |= GNMI_CONFIG_MTU_VALUE;

--- a/stratum/hal/lib/tdi/dpdk/dpdk_port_config.cc
+++ b/stratum/hal/lib/tdi/dpdk/dpdk_port_config.cc
@@ -133,7 +133,6 @@ uint32_t DpdkPortConfig::ParamMaskForCase(ValueCase value_case) {
   DpdkHotplugParam param_type, const SingletonPort& singleton_port) {
 
   const auto& params = singleton_port.config_params().hotplug_config();
-  auto& hotplug = cfg.hotplug_config;
 
   switch (param_type) {
     case PARAM_SOCK_IP:

--- a/stratum/hal/lib/tdi/dpdk/dpdk_port_config.h
+++ b/stratum/hal/lib/tdi/dpdk/dpdk_port_config.h
@@ -32,9 +32,11 @@ public:
   absl::optional<FecMode> fec_mode;  // empty if port add failed
   absl::optional<LoopbackState> loopback_mode; // empty if config failed
 
-  // The configuration object we pass to the SDE.
+  // The configuration objects we pass to the SDE.
   TdiSdeInterface::PortConfigParams cfg;
+  TdiSdeInterface::HotplugConfigParams hotplug;
 
+  // TAP control port.
   std::string control_port;
 
   // Whether the port has been added.

--- a/stratum/hal/lib/tdi/dpdk/dpdk_port_config.h
+++ b/stratum/hal/lib/tdi/dpdk/dpdk_port_config.h
@@ -1,0 +1,104 @@
+// Copyright 2021-2022 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef STRATUM_HAL_LIB_TDI_DPDK_DPDK_PORT_CONFIG_H_
+#define STRATUM_HAL_LIB_TDI_DPDK_DPDK_PORT_CONFIG_H_
+
+#include <cstdint>
+#include <string>
+
+#include "absl/types/optional.h"
+
+#include "stratum/glue/integral_types.h"
+#include "stratum/glue/status/status.h"
+#include "stratum/hal/lib/common/common.pb.h"
+#include "stratum/hal/lib/tdi/tdi_sde_interface.h"
+
+namespace stratum {
+namespace hal {
+namespace tdi {
+
+using ValueCase = SetRequest::Request::Port::ValueCase;
+
+class DpdkPortConfig {
+public:
+  // ADMIN_STATE_UNKNOWN indicates that something went wrong during port
+  // configuration, and the port add failed or was not attempted.
+  AdminState admin_state;
+
+  absl::optional<uint64> speed_bps;  // empty if port add failed
+  absl::optional<int32> mtu;         // empty if MTU configuration failed
+  absl::optional<TriState> autoneg;  // empty if Autoneg configuration failed
+  absl::optional<FecMode> fec_mode;  // empty if port add failed
+  absl::optional<LoopbackState> loopback_mode; // empty if config failed
+
+  // The configuration object we pass to the SDE.
+  TdiSdeInterface::PortConfigParams cfg;
+
+  std::string control_port;
+
+  // Whether the port has been added.
+  bool port_done;
+
+  // Whether the HOTPLUG port has been added.
+  bool hotplug_done;
+
+  DpdkPortConfig() {
+    Reset();
+  }
+
+  // Determines whether the specified parameter has been configured.
+  bool IsParamSet(ValueCase value_case) const {
+    auto param_mask = ParamMaskForCase(value_case);
+    return (params_set & param_mask) != 0;
+  }
+
+  // Stores the specified parameter.
+  ::util::Status SetParam(ValueCase value_case,
+                          const SingletonPort& singleton_port);
+
+  // Stores the specified hotplug parameter.
+  ::util::Status SetHotplugParam(DpdkHotplugParam param_type,
+                                 const SingletonPort& singleton_port);
+
+  // Checks whether any the specified parameters have been configured.
+  bool HasAnyOf(uint32_t param_mask) const {
+    return (params_set & param_mask) != 0;
+  }
+
+  // Checks whether all the specified parameters have been configured.
+  bool HasAllOf(uint32_t param_mask) const {
+    return (params_set & param_mask) == param_mask;
+  }
+
+  // Adds the specified parameters to the configuration set.
+  void Add(uint32 param_mask) {
+    params_set |= param_mask;
+  }
+
+  // Removes the specified parameters from the configuration set.
+  void Remove(uint32_t param_mask) {
+    params_set &= ~param_mask;
+  }
+
+  // Resets parameters to initial state.
+  void Reset() {
+    admin_state = ADMIN_STATE_UNKNOWN;
+    params_set = 0;
+    port_done = false;
+    hotplug_done = false;
+  }
+
+private:
+  // Returns the parameter mask for a SetRequest::Request::Port::ValueCase.
+  static uint32_t ParamMaskForCase(ValueCase value_case);
+
+  // Bitmask indicating which parameters have been configured.
+  uint32_t params_set;
+};
+
+}  // namespace tdi
+}  // namespace hal
+}  // namespace stratum
+
+#endif  // STRATUM_HAL_LIB_TDI_DPDK_DPDK_PORT_CONFIG_H_

--- a/stratum/hal/lib/tdi/dpdk/dpdk_port_config_test.cc
+++ b/stratum/hal/lib/tdi/dpdk/dpdk_port_config_test.cc
@@ -1,0 +1,166 @@
+// Copyright 2022 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#include "gtest/gtest.h"
+#include "stratum/hal/lib/tdi/dpdk/dpdk_port_config.h"
+#include "stratum/hal/lib/tdi/dpdk/dpdk_port_constants.h"
+#include "stratum/hal/lib/tdi/tdi_sde_interface.h"
+
+namespace stratum {
+namespace hal {
+namespace tdi {
+
+namespace {
+
+TEST(DpdkConfigParamTest, Create) {
+  DpdkPortConfig config;
+  ASSERT_EQ(config.HasAnyOf(0xFFFFFFFF), false);
+}
+
+TEST(DpdkConfigParamTest, AddOne) {
+  DpdkPortConfig config;
+  config.Add(GNMI_CONFIG_PIPELINE_NAME);
+  // Verify that bit was set
+  ASSERT_EQ(config.HasAllOf(GNMI_CONFIG_PIPELINE_NAME), true);
+  // Verify that no other bit was set
+  ASSERT_EQ(config.HasAnyOf(~GNMI_CONFIG_PIPELINE_NAME), false);
+}
+
+TEST(DpdkConfigParamTest, HasAnyOf) {
+  DpdkPortConfig config;
+  config.Add(GNMI_CONFIG_VHOST_REQUIRED);
+  ASSERT_EQ(config.HasAnyOf(GNMI_CONFIG_VHOST_REQUIRED), true);
+}
+
+TEST(DpdkConfigParamTest, HasAllOf) {
+  DpdkPortConfig config;
+  config.Add(GNMI_CONFIG_VHOST_REQUIRED);
+  ASSERT_EQ(config.HasAllOf(GNMI_CONFIG_VHOST_REQUIRED), true);
+}
+
+TEST(DpdkConfigParamTest, Remove) {
+  DpdkPortConfig config;
+  config.Add(GNMI_CONFIG_VHOST_REQUIRED);
+  config.Remove(GNMI_CONFIG_QUEUE_COUNT);
+  EXPECT_EQ(config.HasAnyOf(GNMI_CONFIG_VHOST_REQUIRED), true);
+  ASSERT_EQ(config.HasAnyOf(GNMI_CONFIG_QUEUE_COUNT), false);
+}
+
+TEST(DpdkConfigParamTest, Reset) {
+  DpdkPortConfig config;
+  config.Add(GNMI_CONFIG_VHOST_REQUIRED);
+  EXPECT_EQ(config.HasAnyOf(GNMI_CONFIG_VHOST_REQUIRED), true);
+  config.Reset();
+  ASSERT_EQ(config.HasAnyOf(0xFFFFFFFF), false);
+}
+
+TEST(DpdkConfigParamTest, IsParamSet) {
+  DpdkPortConfig config;
+  config.Add(GNMI_CONFIG_MTU_VALUE);
+  ASSERT_TRUE(config.IsParamSet(ValueCase::kMtuValue));
+  ASSERT_FALSE(config.IsParamSet(ValueCase::kMempoolName));
+}
+
+TEST(DpdkConfigParamTest, SetPortParam) {
+  DpdkPortConfig config;
+  SingletonPort sport;
+  PortConfigParams* port_params = sport.mutable_config_params();
+  port_params->set_port_type(PORT_TYPE_VHOST);
+  auto status = config.SetParam(ValueCase::kPortType, sport);
+  EXPECT_TRUE(status.ok());
+  ASSERT_EQ(config.HasAnyOf(GNMI_CONFIG_PORT_TYPE), true);
+  ASSERT_EQ(config.cfg.port_type, PORT_TYPE_VHOST);
+}
+
+TEST(DpdkConfigParamTest, VhostConfig) {
+  DpdkPortConfig config;
+  SingletonPort sport;
+  PortConfigParams* port_params = sport.mutable_config_params();
+  // Set parameter values
+  port_params->set_port_type(PORT_TYPE_VHOST);
+  port_params->set_device_type(DEVICE_TYPE_VIRTIO_BLK);
+  port_params->set_queues(4);
+  port_params->set_socket_path("Wrench");
+  port_params->set_host_name("Gaston");
+  // Verify that no parameters are defined
+  ASSERT_FALSE(config.HasAnyOf(GNMI_CONFIG_VHOST_REQUIRED));
+  // Set four of the parameters
+  ASSERT_TRUE(config.SetParam(ValueCase::kQueueCount, sport).ok());
+  ASSERT_TRUE(config.SetParam(ValueCase::kSockPath, sport).ok());
+  ASSERT_TRUE(config.SetParam(ValueCase::kPortType, sport).ok());
+  ASSERT_TRUE(config.SetParam(ValueCase::kDeviceType, sport).ok());
+  // Verify that the set is incomplete
+  ASSERT_FALSE(config.HasAllOf(GNMI_CONFIG_VHOST_REQUIRED));
+  // Set the fifth parameter
+  ASSERT_TRUE(config.SetParam(ValueCase::kHostConfig, sport).ok());
+  // Verify that the set is complete
+  ASSERT_TRUE(config.HasAllOf(GNMI_CONFIG_VHOST_REQUIRED));
+}
+
+TEST(DpdkConfigParamTest, MtuValue) {
+  DpdkPortConfig config;
+  SingletonPort sport;
+  sport.mutable_config_params()->set_mtu(1500);
+  ASSERT_TRUE(config.SetParam(ValueCase::kMtuValue, sport).ok());
+  ASSERT_TRUE(config.HasAnyOf(GNMI_CONFIG_MTU_VALUE));
+  ASSERT_EQ(config.mtu, 1500);
+}
+
+TEST(DpskConfigParamTest, BadMtuValue) {
+  DpdkPortConfig config;
+  SingletonPort sport;
+  PortConfigParams* port_params = sport.mutable_config_params();
+  port_params->set_mtu(0x10001);
+  config.mtu.reset();
+  auto status = config.SetParam(ValueCase::kMtuValue, sport);
+  ASSERT_FALSE(config.mtu.has_value());
+}
+
+TEST(DpdkConfigParamTest, HotplugSocketPort) {
+  DpdkPortConfig config;
+  SingletonPort sport;
+  sport.mutable_config_params()
+       ->mutable_hotplug_config()
+       ->set_qemu_socket_port(1984);
+  ASSERT_TRUE(config.SetHotplugParam(PARAM_SOCK_PORT, sport).ok());
+  ASSERT_TRUE(config.HasAllOf(GNMI_CONFIG_HOTPLUG_SOCKET_PORT));
+  ASSERT_EQ(config.cfg.hotplug_config.qemu_socket_port, 1984);
+}
+
+TEST(DpdkConfigParamTest, HotplugConfig) {
+  DpdkPortConfig config;
+  SingletonPort sport;
+  // Set parameter values
+  PortConfigParams* port_params = sport.mutable_config_params();
+  HotplugConfig* hotplug_config = port_params->mutable_hotplug_config();
+  hotplug_config->set_qemu_socket_ip("192.168.17.5");
+  hotplug_config->set_qemu_socket_port(1776);
+  hotplug_config->set_qemu_hotplug_mode(HOTPLUG_MODE_ADD);
+  hotplug_config->set_qemu_vm_mac_address(0x112233445566ULL);
+  hotplug_config->set_qemu_vm_netdev_id("netdev");
+  hotplug_config->set_qemu_vm_chardev_id("chardev");
+  hotplug_config->set_native_socket_path("/into/the/woods");
+  hotplug_config->set_qemu_vm_device_id("infernal");
+  // Verify that set is empty
+  ASSERT_FALSE(config.HasAnyOf(GNMI_CONFIG_HOTPLUG_REQUIRED));
+  // Set all but one parameter
+  ASSERT_TRUE(config.SetHotplugParam(PARAM_CHARDEV_ID, sport).ok());
+  ASSERT_TRUE(config.SetHotplugParam(PARAM_DEVICE_ID, sport).ok());
+  ASSERT_TRUE(config.SetHotplugParam(PARAM_HOTPLUG_MODE, sport).ok());
+  ASSERT_TRUE(config.SetHotplugParam(PARAM_NATIVE_SOCK_PATH, sport).ok());
+  ASSERT_TRUE(config.SetHotplugParam(PARAM_NETDEV_ID, sport).ok());
+  ASSERT_TRUE(config.SetHotplugParam(PARAM_SOCK_IP, sport).ok());
+  ASSERT_TRUE(config.SetHotplugParam(PARAM_SOCK_PORT, sport).ok());
+  // Verify that set is incomplete
+  ASSERT_FALSE(config.HasAllOf(GNMI_CONFIG_HOTPLUG_REQUIRED));
+  // Set final parameter
+  ASSERT_TRUE(config.SetHotplugParam(PARAM_VM_MAC, sport).ok());
+  // Verify that set is complete
+  ASSERT_TRUE(config.HasAllOf(GNMI_CONFIG_HOTPLUG_REQUIRED));
+}
+
+}  // namespace
+
+}  // namespace tdi
+}  // namespace hal
+}  // namespace stratum

--- a/stratum/hal/lib/tdi/dpdk/dpdk_port_config_test.cc
+++ b/stratum/hal/lib/tdi/dpdk/dpdk_port_config_test.cc
@@ -124,7 +124,7 @@ TEST(DpdkConfigParamTest, HotplugSocketPort) {
        ->set_qemu_socket_port(1984);
   ASSERT_TRUE(config.SetHotplugParam(PARAM_SOCK_PORT, sport).ok());
   ASSERT_TRUE(config.HasAllOf(GNMI_CONFIG_HOTPLUG_SOCKET_PORT));
-  ASSERT_EQ(config.cfg.hotplug_config.qemu_socket_port, 1984);
+  ASSERT_EQ(config.hotplug.qemu_socket_port, 1984);
 }
 
 TEST(DpdkConfigParamTest, HotplugConfig) {

--- a/stratum/hal/lib/tdi/dpdk/dpdk_port_constants.h
+++ b/stratum/hal/lib/tdi/dpdk/dpdk_port_constants.h
@@ -4,6 +4,8 @@
 #ifndef STRATUM_HAL_LIB_TDI_DPDK_DPDK_PORT_CONSTANTS_H_
 #define STRATUM_HAL_LIB_TDI_DPDK_DPDK_PORT_CONSTANTS_H_
 
+#include <stdint.h>
+
 namespace stratum {
 namespace hal {
 namespace tdi {
@@ -76,7 +78,7 @@ constexpr int32 MAX_MTU = 65535;
 
 // SDK_PORT_CONTROL_BASE is used as an offset to define a reserved
 // port range for the control ports.
-#define SDK_PORT_CONTROL_BASE 256
+constexpr uint32_t SDK_PORT_CONTROL_BASE = 256;
 
 enum qemu_cmd_type {
    CHARDEV_ADD,

--- a/stratum/hal/lib/tdi/dpdk/dpdk_port_constants.h
+++ b/stratum/hal/lib/tdi/dpdk/dpdk_port_constants.h
@@ -1,0 +1,94 @@
+// Copyright 2021-2022 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef STRATUM_HAL_LIB_TDI_DPDK_DPDK_PORT_CONSTANTS_H_
+#define STRATUM_HAL_LIB_TDI_DPDK_DPDK_PORT_CONSTANTS_H_
+
+namespace stratum {
+namespace hal {
+namespace tdi {
+
+static inline constexpr uint32_t CONFIG_BIT(int n) {
+    return 1U << n;
+}
+
+constexpr uint32_t GNMI_CONFIG_PORT_TYPE = CONFIG_BIT(0);
+constexpr uint32_t GNMI_CONFIG_DEVICE_TYPE = CONFIG_BIT(1);
+constexpr uint32_t GNMI_CONFIG_QUEUE_COUNT = CONFIG_BIT(2);
+constexpr uint32_t GNMI_CONFIG_SOCKET_PATH = CONFIG_BIT(3);
+constexpr uint32_t GNMI_CONFIG_HOST_NAME = CONFIG_BIT(4);
+constexpr uint32_t GNMI_CONFIG_PIPELINE_NAME = CONFIG_BIT(5);
+constexpr uint32_t GNMI_CONFIG_MEMPOOL_NAME = CONFIG_BIT(6);
+constexpr uint32_t GNMI_CONFIG_MTU_VALUE = CONFIG_BIT(7);
+
+constexpr uint32_t GNMI_CONFIG_PCI_BDF_VALUE = CONFIG_BIT(8);
+constexpr uint32_t GNMI_CONFIG_HOTPLUG_SOCKET_IP = CONFIG_BIT(9);
+constexpr uint32_t GNMI_CONFIG_HOTPLUG_SOCKET_PORT = CONFIG_BIT(10);
+constexpr uint32_t GNMI_CONFIG_HOTPLUG_MODE = CONFIG_BIT(11);
+constexpr uint32_t GNMI_CONFIG_HOTPLUG_VM_MAC_ADDRESS = CONFIG_BIT(12);
+constexpr uint32_t GNMI_CONFIG_HOTPLUG_VM_NETDEV_ID = CONFIG_BIT(13);
+constexpr uint32_t GNMI_CONFIG_HOTPLUG_VM_CHARDEV_ID = CONFIG_BIT(14);
+constexpr uint32_t GNMI_CONFIG_NATIVE_SOCKET_PATH = CONFIG_BIT(15);
+
+constexpr uint32_t GNMI_CONFIG_HOTPLUG_VM_DEVICE_ID = CONFIG_BIT(16);
+constexpr uint32_t GNMI_CONFIG_PACKET_DIR = CONFIG_BIT(17);
+
+// Parameters that must be set for a VHOST port.
+constexpr uint32_t GNMI_CONFIG_VHOST_REQUIRED =
+    GNMI_CONFIG_PORT_TYPE | GNMI_CONFIG_DEVICE_TYPE |
+    GNMI_CONFIG_QUEUE_COUNT | GNMI_CONFIG_SOCKET_PATH |
+    GNMI_CONFIG_HOST_NAME;
+
+// Parameters that must not be set for a VHOST port.
+constexpr uint32_t GNMI_CONFIG_VHOST_UNSUPPORTED =
+    GNMI_CONFIG_PCI_BDF_VALUE;
+
+// Parameters that must be set for a LINK port.
+constexpr uint32_t GNMI_CONFIG_LINK_REQUIRED =
+    GNMI_CONFIG_PORT_TYPE | GNMI_CONFIG_PCI_BDF_VALUE;
+
+// Parameters that must not be set for a LINK port.
+constexpr uint32_t GNMI_CONFIG_LINK_UNSUPPORTED =
+    GNMI_CONFIG_DEVICE_TYPE | GNMI_CONFIG_QUEUE_COUNT |
+    GNMI_CONFIG_SOCKET_PATH | GNMI_CONFIG_HOST_NAME;
+
+// Parameters that must be set for a TAP port.
+constexpr uint32_t GNMI_CONFIG_TAP_REQUIRED = GNMI_CONFIG_PORT_TYPE;
+
+// Parameters that must not be set for a TAP port.
+constexpr uint32_t GNMI_CONFIG_TAP_UNSUPPORTED =
+    GNMI_CONFIG_DEVICE_TYPE | GNMI_CONFIG_QUEUE_COUNT |
+    GNMI_CONFIG_SOCKET_PATH | GNMI_CONFIG_HOST_NAME |
+    GNMI_CONFIG_PCI_BDF_VALUE;
+
+// Parameters that must be set for a HOTPLUG port.
+constexpr uint32_t GNMI_CONFIG_HOTPLUG_REQUIRED =
+    GNMI_CONFIG_HOTPLUG_SOCKET_IP | GNMI_CONFIG_HOTPLUG_SOCKET_PORT |
+    GNMI_CONFIG_HOTPLUG_MODE | GNMI_CONFIG_HOTPLUG_VM_MAC_ADDRESS |
+    GNMI_CONFIG_HOTPLUG_VM_NETDEV_ID | GNMI_CONFIG_HOTPLUG_VM_CHARDEV_ID |
+    GNMI_CONFIG_NATIVE_SOCKET_PATH | GNMI_CONFIG_HOTPLUG_VM_DEVICE_ID;
+
+constexpr char DEFAULT_PIPELINE[] = "pipe";
+constexpr char DEFAULT_MEMPOOL[] = "MEMPOOL0";
+constexpr int32 DEFAULT_MTU = 1500;
+constexpr auto DEFAULT_PACKET_DIR = DIRECTION_HOST;
+constexpr int32 MAX_MTU = 65535;
+
+// SDK_PORT_CONTROL_BASE is used as an offset to define a reserved
+// port range for the control ports.
+#define SDK_PORT_CONTROL_BASE 256
+
+enum qemu_cmd_type {
+   CHARDEV_ADD,
+   NETDEV_ADD,
+   DEVICE_ADD,
+   CHARDEV_DEL,
+   NETDEV_DEL,
+   DEVICE_DEL
+};
+
+}  // namespace tdi
+}  // namespace hal
+}  // namespace stratum
+
+#endif  // STRATUM_HAL_LIB_TDI_DPDK_DPDK_PORT_CONSTANTS_H_

--- a/stratum/hal/lib/tdi/dpdk/dpdk_sde_wrapper.cc
+++ b/stratum/hal/lib/tdi/dpdk/dpdk_sde_wrapper.cc
@@ -160,16 +160,12 @@ dpdk_port_type_t get_target_port_type(DpdkPortType type) {
 
 ::util::Status TdiSdeWrapper::AddPort(
     int device, int port, uint64 speed_bps, FecMode fec_mode) {
-  auto port_attrs = absl::make_unique<port_attributes_t>();
-  RETURN_IF_TDI_ERROR(bf_pal_port_add(static_cast<bf_dev_id_t>(device),
-                                      static_cast<bf_dev_port_t>(port),
-                                      port_attrs.get()));
-  return ::util::OkStatus();
+  return MAKE_ERROR(ERR_UNIMPLEMENTED)
+      << "AddPort(device, port, speed, fec_mode) not implemented";
 }
 
 ::util::Status TdiSdeWrapper::AddPort(
-    int device, int port, uint64 speed_bps, const PortConfigParams& config,
-    FecMode fec_mode) {
+    int device, int port, const PortConfigParams& config) {
   static int port_in;
   static int port_out;
 
@@ -188,7 +184,7 @@ dpdk_port_type_t get_target_port_type(DpdkPortType type) {
   port_attrs->port_out_id = port_out++;
   port_attrs->net_port = config.packet_dir;
 
-  LOG(INFO) << "Parameters for backend are:"
+  LOG(INFO) << "Parameters for DPDK are:"
             << " port_name=" << port_attrs->port_name
             << " port_type=" << port_attrs->port_type
             << " port_in_id=" << port_attrs->port_in_id
@@ -197,7 +193,7 @@ dpdk_port_type_t get_target_port_type(DpdkPortType type) {
             << " pipeline_out_name=" << port_attrs->pipe_out
             << " mempool_name=" << port_attrs->mempool_name
             << " net_port=" << port_attrs->net_port
-            << " sdk_port_id = " << port;
+            << " sdk_port_id= " << port;
 
   if (port_attrs->port_type == BF_DPDK_LINK) {
     // Update LINK parameters

--- a/stratum/hal/lib/tdi/tdi_sde_interface.h
+++ b/stratum/hal/lib/tdi/tdi_sde_interface.h
@@ -61,7 +61,6 @@ class TdiSdeInterface {
     std::string pipeline_name;
     std::string mempool_name;
     std::string pci_bdf;
-    struct HotplugConfigParams hotplug_config;
   };
 
   // SessionInterface is a proxy class for TDI sessions. Most API calls require

--- a/stratum/hal/lib/tdi/tdi_sde_interface.h
+++ b/stratum/hal/lib/tdi/tdi_sde_interface.h
@@ -201,9 +201,8 @@ class TdiSdeInterface {
                                  FecMode fec_mode = FEC_MODE_UNKNOWN) = 0;
 
   // Add a new port with the given parameters.
-  virtual ::util::Status AddPort(int device, int port, uint64 speed_bps,
-                                 const PortConfigParams& config,
-                                 FecMode fec_mode = FEC_MODE_UNKNOWN) = 0 ;
+  virtual ::util::Status AddPort(
+      int device, int port, const PortConfigParams& config) = 0 ;
 
   // Hotplug add/delete the port
   virtual ::util::Status HotplugPort(int device, int port,

--- a/stratum/hal/lib/tdi/tdi_sde_mock.h
+++ b/stratum/hal/lib/tdi/tdi_sde_mock.h
@@ -87,8 +87,7 @@ class TdiSdeMock : public TdiSdeInterface {
   MOCK_METHOD4(AddPort, ::util::Status(int device, int port, uint64 speed_bps,
                                        FecMode fec_mode));
   MOCK_METHOD(::util::Status, AddPort,
-              (int device, int port, uint64 speed_bps,
-               const PortConfigParams& config, FecMode fec_mode));
+              (int device, int port, const PortConfigParams& config));
   MOCK_METHOD(::util::Status, HotplugPort,
               (int device, int port, HotplugConfigParams& hotplug_config));
   MOCK_METHOD2(DeletePort, ::util::Status(int device, int port));

--- a/stratum/hal/lib/tdi/tdi_sde_wrapper.h
+++ b/stratum/hal/lib/tdi/tdi_sde_wrapper.h
@@ -164,8 +164,7 @@ class TdiSdeWrapper : public TdiSdeInterface {
   ::util::Status AddPort(int device, int port, uint64 speed_bps,
                          FecMode fec_mode) override;
   ::util::Status AddPort(
-      int device, int port, uint64 speed_bps,
-      const PortConfigParams& config, FecMode fec_mode) override;
+      int device, int port, const PortConfigParams& config) override;
   ::util::Status HotplugPort(int device, int port,
                             HotplugConfigParams& hotplug_config) override;
   ::util::Status DeletePort(int device, int port) override;

--- a/stratum/hal/lib/tdi/tofino/tofino_sde_wrapper.cc
+++ b/stratum/hal/lib/tdi/tofino/tofino_sde_wrapper.cc
@@ -205,7 +205,7 @@ bf_status_t sde_port_status_callback(
 
 ::util::Status TdiSdeWrapper::HotplugPort(
     int device, int port, HotplugConfigParams& hotplug_config) {
-  return ::util::OkStatus();
+  return MAKE_ERROR(ERR_UNIMPLEMENTED) << "HotplugPort not implemented";
 }
 
 ::util::Status TdiSdeWrapper::AddPort(
@@ -220,9 +220,9 @@ bf_status_t sde_port_status_callback(
 }
 
 ::util::Status TdiSdeWrapper::AddPort(
-    int device, int port, uint64 speed_bps, const PortConfigParams& config,
-    FecMode fec_mode) {
-  return ::util::OkStatus();
+    int device, int port, const PortConfigParams& config) {
+  return MAKE_ERROR(ERR_UNIMPLEMENTED)
+      << "AddPort(device, port, config) not implemented";
 }
 
 ::util::Status TdiSdeWrapper::DeletePort(int device, int port) {


### PR DESCRIPTION
Refactor dpdk_chassis_manager:

- Moved constant definitions to dpdk_port_constants.h.

- Factored out PortConfig class, renamed it to DpdkPortConfig,
  and moved the definition and implementation to separate files.

- Implemented SetParam, SetHotplugParam, and IsParamSet methods
  in DpdkPortConfig.

- Made the configuration bitmask a part of DpdkPortConfig.
  Implemented access methods to replace direct operations on
  the configuration mask.

- Removed PORT_DONE and HOTPLUG_DONE bits from the configuration
  mask and replaced them with port_done and hotplug_done member
  variables.

- Normalized the log messages issued when port parameters are set.

- Implemented a dpdk_port_config unit test.

Remove HotplugConfigParams member from PortConfigParams class:

- The PortConfigParams and HotplugConfigParams structures are
  orthogonal. Embedding one within the other complicates things
  unnecessarily.

Remove unused parameters from DPDK-specific AddPort method:

- Removed the unused speed_bps and fec_mode parameters from the
  DPDK-specific AddPort SDE method. The method now requires only
  device, port, and configuration structure.

- Modified dpdk_sde_wrapper to return ERR_UNIMPLEMENTED if the
  legacy AddPort method is called.

- Modified tofino_sde_wrapper to return ERR_UNIMPLEMENTED if the
  DPDK-specific AddPort method is called.

- Also modified tofino_sde_wrapper to return ERR_UNIMPLEMENTED
  if the HotplugPort method is called.

Signed-off-by: Derek G Foster <derek.foster@intel.com>