### PR TITLE
cmake support part-1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,12 @@
+# CMake build file for Stratum code.
+#
+# Copyright 2022 Intel Corporation
+# SPDX-License-Identifier: Apache 2.0
+
+cmake_minimum_required(VERSION 3.5)
+project(stratum)
+
+# Suppress "warning: attribute ignored" on ABSL_MUST_USE_RESULT [[nodiscard]]
+add_compile_options(-Wno-attributes)
+
+add_subdirectory(stratum)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 # Copyright 2022 Intel Corporation
 # SPDX-License-Identifier: Apache 2.0
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.15)
 project(stratum)
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,27 @@
 cmake_minimum_required(VERSION 3.5)
 project(stratum)
 
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_INSTALL_PREFIX}/lib")
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_INSTALL_PREFIX}/lib")
+
+find_package(absl REQUIRED)
+
+option(BUILD_SHARED_LIBS "Build shared library" OFF)
+
 # Suppress "warning: attribute ignored" on ABSL_MUST_USE_RESULT [[nodiscard]]
 add_compile_options(-Wno-attributes)
+
+set(STRATUM_SOURCE_DIR
+    "${CMAKE_CURRENT_SOURCE_DIR}" CACHE PATH
+    "Path to Stratum source directory")
+
+set(STRATUM_INCLUDES
+    ${STRATUM_SOURCE_DIR}
+    # Protobuf C++ header files.
+    # TODO(comes from net-rec for now
+    ${PROTO_OUT_DIR}
+)
 
 add_subdirectory(stratum)

--- a/stratum/CMakeLists.txt
+++ b/stratum/CMakeLists.txt
@@ -1,5 +1,3 @@
-# CMake build file for Stratum code.
-#
 # Copyright 2022 Intel Corporation
 # SPDX-License-Identifier: Apache 2.0
 

--- a/stratum/CMakeLists.txt
+++ b/stratum/CMakeLists.txt
@@ -1,0 +1,11 @@
+# CMake build file for Stratum code.
+#
+# Copyright 2022 Intel Corporation
+# SPDX-License-Identifier: Apache 2.0
+
+add_subdirectory(glue)
+add_subdirectory(lib)
+add_subdirectory(public)
+add_subdirectory(tools/gnmi)
+
+add_subdirectory(hal)

--- a/stratum/glue/CMakeLists.txt
+++ b/stratum/glue/CMakeLists.txt
@@ -1,0 +1,21 @@
+# CMake build file for Stratum code.
+#
+# Copyright 2022 Intel Corporation
+# SPDX-License-Identifier: Apache 2.0
+
+add_library(stratum_glue_o OBJECT
+    gtl/cleanup.h
+    integral_types.h
+    logging.cc
+    logging.h
+    status/posix_error_space.cc
+    status/posix_error_space.h
+    status/status.cc
+    status/status.h
+    status/status_macros.cc
+    status/status_macros.h
+    status/statusor.cc
+    status/statusor.h
+)
+
+target_include_directories(stratum_glue_o PRIVATE ${STRATUM_INCLUDES})

--- a/stratum/glue/CMakeLists.txt
+++ b/stratum/glue/CMakeLists.txt
@@ -1,4 +1,4 @@
-# CMake build file for Stratum code.
+# CMake build file for Stratum glue code.
 #
 # Copyright 2022 Intel Corporation
 # SPDX-License-Identifier: Apache 2.0

--- a/stratum/hal/CMakeLists.txt
+++ b/stratum/hal/CMakeLists.txt
@@ -1,4 +1,4 @@
-# CMake build file for Stratum code.
+# CMake build file for Stratum hal code.
 #
 # Copyright 2022 Intel Corporation
 # SPDX-License-Identifier: Apache 2.0

--- a/stratum/hal/CMakeLists.txt
+++ b/stratum/hal/CMakeLists.txt
@@ -1,0 +1,7 @@
+# CMake build file for Stratum code.
+#
+# Copyright 2022 Intel Corporation
+# SPDX-License-Identifier: Apache 2.0
+
+add_subdirectory(lib)
+add_subdirectory(bin/tdi)

--- a/stratum/hal/bin/tdi/CMakeLists.txt
+++ b/stratum/hal/bin/tdi/CMakeLists.txt
@@ -20,9 +20,6 @@ add_executable(tdi_pipeline_builder
     $<TARGET_OBJECTS:stratum_public_o>
 )
 
-# Suppress "warning: attribute ignored" on ABSL_MUST_USE_RESULT [[nodiscard]]
-target_compile_options(tdi_pipeline_builder PRIVATE -Wno-attributes)
-
 target_include_directories(tdi_pipeline_builder PRIVATE
     ${STRATUM_SOURCE_DIR}
     ${PROTO_OUT_DIR}
@@ -32,7 +29,7 @@ target_link_libraries(tdi_pipeline_builder PUBLIC stratum_proto p4runtime_proto)
 
 target_link_libraries(tdi_pipeline_builder PUBLIC
     protobuf gflags glog grpc grpc++
-    absl_raw_hash_set
+    absl::raw_hash_set
 )
 
 install(TARGETS tdi_pipeline_builder RUNTIME)

--- a/stratum/hal/bin/tdi/CMakeLists.txt
+++ b/stratum/hal/bin/tdi/CMakeLists.txt
@@ -1,0 +1,38 @@
+# CMake build file for Stratum code.
+#
+# Copyright 2022 Intel Corporation
+# SPDX-License-Identifier: Apache 2.0
+
+if(TOFINO_TARGET)
+    add_subdirectory(tofino)
+elseif(DPDK_TARGET)
+    add_subdirectory(dpdk)
+endif()
+
+##############################
+# Build tdi_pipeline_builder #
+##############################
+
+add_executable(tdi_pipeline_builder
+    tdi_pipeline_builder.cc
+    $<TARGET_OBJECTS:stratum_glue_o>
+    $<TARGET_OBJECTS:stratum_lib_o>
+    $<TARGET_OBJECTS:stratum_public_o>
+)
+
+# Suppress "warning: attribute ignored" on ABSL_MUST_USE_RESULT [[nodiscard]]
+target_compile_options(tdi_pipeline_builder PRIVATE -Wno-attributes)
+
+target_include_directories(tdi_pipeline_builder PRIVATE
+    ${STRATUM_SOURCE_DIR}
+    ${PROTO_OUT_DIR}
+)
+
+target_link_libraries(tdi_pipeline_builder PUBLIC stratum_proto p4runtime_proto)
+
+target_link_libraries(tdi_pipeline_builder PUBLIC
+    protobuf gflags glog grpc grpc++
+    absl_raw_hash_set
+)
+
+install(TARGETS tdi_pipeline_builder RUNTIME)

--- a/stratum/hal/bin/tdi/dpdk/CMakeLists.txt
+++ b/stratum/hal/bin/tdi/dpdk/CMakeLists.txt
@@ -6,7 +6,6 @@
 add_library(stratum_dpdk_o OBJECT
     dpdk_main.cc
     dpdk_main.h
-    main.cc
 )
 
 target_include_directories(stratum_dpdk_o PRIVATE
@@ -16,13 +15,17 @@ target_include_directories(stratum_dpdk_o PRIVATE
 
 add_dependencies(stratum_dpdk_o stratum_proto)
 
-add_executable(stratum_dpdk $<TARGET_OBJECTS:stratum_dpdk_o>)
-
-target_link_libraries(stratum_dpdk PRIVATE
-    -Wl,--whole-archive
-    stratum_hal_lib_tdi
-    -Wl,--no-whole-archive
+add_executable(stratum_dpdk 
+    main.cc
+    $<TARGET_OBJECTS:stratum_dpdk_o>
 )
+
+target_include_directories(stratum_dpdk PRIVATE
+    ${STRATUM_SOURCE_DIR}
+    ${PROTO_OUT_DIR}
+    ${SDE_INSTALL_DIR}/include)
+
+target_link_libraries(stratum_dpdk PRIVATE stratum_tdi)
 
 install(TARGETS stratum_dpdk RUNTIME)
 

--- a/stratum/hal/bin/tdi/dpdk/CMakeLists.txt
+++ b/stratum/hal/bin/tdi/dpdk/CMakeLists.txt
@@ -1,0 +1,35 @@
+# CMake build file for Stratum code.
+#
+# Copyright 2022 Intel Corporation
+# SPDX-License-Identifier: Apache 2.0
+
+add_library(stratum_dpdk_o OBJECT
+    dpdk_main.cc
+    dpdk_main.h
+    main.cc
+)
+
+target_include_directories(stratum_dpdk_o PRIVATE
+    ${STRATUM_SOURCE_DIR}
+    ${PROTO_OUT_DIR}
+    ${SDE_INSTALL_DIR}/include)
+
+add_dependencies(stratum_dpdk_o stratum_proto)
+
+add_executable(stratum_dpdk $<TARGET_OBJECTS:stratum_dpdk_o>)
+
+target_link_libraries(stratum_dpdk PRIVATE
+    -Wl,--whole-archive
+    stratum_hal_lib_tdi
+    -Wl,--no-whole-archive
+)
+
+install(TARGETS stratum_dpdk RUNTIME)
+
+install(
+    FILES
+        dpdk_port_config.pb.txt
+        dpdk_skip_p4.conf
+    DESTINATION
+        ${CMAKE_INSTALL_PREFIX}/share/stratum/dpdk
+)

--- a/stratum/hal/bin/tdi/tofino/CMakeLists.txt
+++ b/stratum/hal/bin/tdi/tofino/CMakeLists.txt
@@ -1,0 +1,35 @@
+# CMake build file for Stratum code.
+#
+# Copyright 2022 Intel Corporation
+# SPDX-License-Identifier: Apache 2.0
+
+add_library(stratum_tofino_o OBJECT
+    tofino_main.cc
+    tofino_main.h
+    main.cc
+)
+
+target_include_directories(stratum_tofino_o PRIVATE
+    ${STRATUM_SOURCE_DIR}
+    ${PROTO_OUT_DIR}
+    ${SDE_INSTALL_DIR}/include)
+
+add_dependencies(stratum_tofino_o stratum_proto)
+
+add_executable(stratum_tofino $<TARGET_OBJECTS:stratum_tofino_o>)
+
+target_link_libraries(stratum_tofino PRIVATE
+    -Wl,--whole-archive
+    stratum_hal_lib_tdi
+    -Wl,--no-whole-archive
+)
+
+install(TARGETS stratum_tofino RUNTIME)
+
+install(
+    FILES
+        tofino_skip_p4_no_bsp.conf
+        tofino_skip_p4.conf
+    DESTINATION
+        ${CMAKE_INSTALL_PREFIX}/share/stratum/tofino
+)

--- a/stratum/hal/bin/tdi/tofino/CMakeLists.txt
+++ b/stratum/hal/bin/tdi/tofino/CMakeLists.txt
@@ -6,7 +6,6 @@
 add_library(stratum_tofino_o OBJECT
     tofino_main.cc
     tofino_main.h
-    main.cc
 )
 
 target_include_directories(stratum_tofino_o PRIVATE
@@ -16,13 +15,17 @@ target_include_directories(stratum_tofino_o PRIVATE
 
 add_dependencies(stratum_tofino_o stratum_proto)
 
-add_executable(stratum_tofino $<TARGET_OBJECTS:stratum_tofino_o>)
-
-target_link_libraries(stratum_tofino PRIVATE
-    -Wl,--whole-archive
-    stratum_hal_lib_tdi
-    -Wl,--no-whole-archive
+add_executable(stratum_tofino
+    main.cc
+    $<TARGET_OBJECTS:stratum_tofino_o>
 )
+
+target_include_directories(stratum_tofino PRIVATE
+    ${STRATUM_SOURCE_DIR}
+    ${PROTO_OUT_DIR}
+    ${SDE_INSTALL_DIR}/include)
+
+target_link_libraries(stratum_tofino PRIVATE stratum_tdi)
 
 install(TARGETS stratum_tofino RUNTIME)
 

--- a/stratum/hal/bin/tdi/tofino/tofino_skip_p4.conf
+++ b/stratum/hal/bin/tdi/tofino/tofino_skip_p4.conf
@@ -1,0 +1,31 @@
+{
+    "instance": 0,
+    "chip_list": [
+        {
+            "chip_family": "Tofino",
+            "pcie_sysfs_prefix": "/sys/devices/pci0000:00/0000:00:03.0/0000:05:00.0",
+            "pcie_bus": 5,
+            "pcie_dev": 0,
+            "pcie_int_mode": 1,
+            "pcie_domain": 0,
+            "instance": 0,
+            "sds_fw_path": "share/tofino_sds_fw/avago/firmware",
+            "pcie_fn": 0,
+            "id": "asic-0"
+        }
+    ],
+    "id": "dummy.csv",
+    "p4_program_list": [
+        {
+            "pd-thrift": "",
+            "program-name": "dummy",
+            "tofino-bin": "",
+            "instance": 0,
+            "pd": "",
+            "agent0": "lib/libpltfm_mgr.so",
+            "path": "dummy",
+            "id": "pgm-0",
+            "table-config": ""
+        }
+    ]
+}

--- a/stratum/hal/bin/tdi/tofino/tofino_skip_p4_no_bsp.conf
+++ b/stratum/hal/bin/tdi/tofino/tofino_skip_p4_no_bsp.conf
@@ -1,0 +1,31 @@
+{
+    "instance": 0,
+    "chip_list": [
+        {
+            "chip_family": "Tofino",
+            "pcie_sysfs_prefix": "/sys/devices/pci0000:00/0000:00:03.0/0000:05:00.0",
+            "pcie_bus": 5,
+            "pcie_dev": 0,
+            "pcie_int_mode": 1,
+            "pcie_domain": 0,
+            "instance": 0,
+            "sds_fw_path": "share/tofino_sds_fw/avago/firmware",
+            "pcie_fn": 0,
+            "id": "asic-0"
+        }
+    ],
+    "id": "dummy.csv",
+    "p4_program_list": [
+        {
+            "pd-thrift": "",
+            "program-name": "dummy",
+            "tofino-bin": "",
+            "instance": 0,
+            "pd": "",
+            "board-port-map": "share/port_map.json",
+            "path": "dummy",
+            "id": "pgm-0",
+            "table-config": ""
+        }
+    ]
+}

--- a/stratum/hal/lib/CMakeLists.txt
+++ b/stratum/hal/lib/CMakeLists.txt
@@ -1,5 +1,3 @@
-# CMake build file for Stratum code.
-#
 # Copyright 2022 Intel Corporation
 # SPDX-License-Identifier: Apache 2.0
 

--- a/stratum/hal/lib/CMakeLists.txt
+++ b/stratum/hal/lib/CMakeLists.txt
@@ -1,0 +1,11 @@
+# CMake build file for Stratum code.
+#
+# Copyright 2022 Intel Corporation
+# SPDX-License-Identifier: Apache 2.0
+
+add_subdirectory(common)
+add_subdirectory(phal)
+add_subdirectory(p4)
+add_subdirectory(yang)
+
+add_subdirectory(tdi)

--- a/stratum/hal/lib/common/CMakeLists.txt
+++ b/stratum/hal/lib/common/CMakeLists.txt
@@ -1,4 +1,4 @@
-# CMake build file for Stratum code.
+# CMake build file for Stratum hal common code.
 #
 # Copyright 2022 Intel Corporation
 # SPDX-License-Identifier: Apache 2.0

--- a/stratum/hal/lib/common/CMakeLists.txt
+++ b/stratum/hal/lib/common/CMakeLists.txt
@@ -1,0 +1,32 @@
+# CMake build file for Stratum code.
+#
+# Copyright 2022 Intel Corporation
+# SPDX-License-Identifier: Apache 2.0
+
+add_library(stratum_hal_lib_common_o OBJECT
+    channel_writer_wrapper.h
+    config_monitoring_service.cc
+    config_monitoring_service.h
+    error_buffer.cc
+    error_buffer.h
+    gnmi_publisher.cc
+    gnmi_publisher.h
+    openconfig_converter.cc
+    openconfig_converter.h
+    p4_service.cc
+    p4_service.h
+    server_writer_wrapper.h
+    utils.cc
+    utils.h
+    writer_interface.h
+)
+
+target_include_directories(stratum_hal_lib_common_o PRIVATE
+    ${STRATUM_INCLUDES}
+    ${SDE_INSTALL_DIR}/include
+)
+
+add_dependencies(stratum_hal_lib_common_o
+    gnmi_proto
+    stratum_proto
+)

--- a/stratum/hal/lib/p4/CMakeLists.txt
+++ b/stratum/hal/lib/p4/CMakeLists.txt
@@ -1,0 +1,18 @@
+# CMake build file for Stratum code.
+#
+# Copyright 2022 Intel Corporation
+# SPDX-License-Identifier: Apache 2.0
+
+add_library(stratum_hal_lib_p4_o OBJECT
+    p4_info_manager.cc
+    p4_info_manager.h
+    utils.cc
+    utils.h
+)
+
+target_include_directories(stratum_hal_lib_p4_o PRIVATE ${STRATUM_INCLUDES})
+
+add_dependencies(stratum_hal_lib_p4_o
+    stratum_proto
+    p4runtime_proto
+)

--- a/stratum/hal/lib/p4/CMakeLists.txt
+++ b/stratum/hal/lib/p4/CMakeLists.txt
@@ -1,4 +1,4 @@
-# CMake build file for Stratum code.
+# CMake build file for Stratum p4 service code.
 #
 # Copyright 2022 Intel Corporation
 # SPDX-License-Identifier: Apache 2.0

--- a/stratum/hal/lib/phal/CMakeLists.txt
+++ b/stratum/hal/lib/phal/CMakeLists.txt
@@ -1,4 +1,4 @@
-# CMake build file for Stratum code.
+# CMake build file for Stratum phal code.
 #
 # Copyright 2022 Intel Corporation
 # SPDX-License-Identifier: Apache 2.0

--- a/stratum/hal/lib/phal/CMakeLists.txt
+++ b/stratum/hal/lib/phal/CMakeLists.txt
@@ -1,0 +1,13 @@
+# CMake build file for Stratum code.
+#
+# Copyright 2022 Intel Corporation
+# SPDX-License-Identifier: Apache 2.0
+
+add_library(stratum_hal_lib_phal_o OBJECT
+    phal_sim.cc
+    phal_sim.h
+)
+
+target_include_directories(stratum_hal_lib_phal_o PRIVATE ${STRATUM_INCLUDES})
+
+add_dependencies(stratum_hal_lib_phal_o stratum_proto)

--- a/stratum/hal/lib/tdi/CMakeLists.txt
+++ b/stratum/hal/lib/tdi/CMakeLists.txt
@@ -1,0 +1,123 @@
+# CMake build file for Stratum code.
+#
+# Copyright 2022 Intel Corporation
+# SPDX-License-Identifier: Apache 2.0
+
+add_library(stratum_hal_lib_tdi_o OBJECT
+    tdi_action_profile_manager.cc
+    tdi_action_profile_manager.h
+    tdi_counter_manager.cc
+    tdi_counter_manager.h
+    tdi_id_mapper.cc
+    tdi_id_mapper.h
+    tdi_node.cc
+    tdi_node.h
+    tdi_packetio_manager.cc
+    tdi_packetio_manager.h
+    tdi_pipeline_utils.cc
+    tdi_pipeline_utils.h
+    tdi_pre_manager.cc
+    tdi_pre_manager.h
+    tdi_sde_action_profile.cc
+    tdi_sde_clone_session.cc
+    tdi_sde_common.h
+    tdi_sde_counter.cc
+    tdi_sde_helpers.cc
+    tdi_sde_helpers.h
+    tdi_sde_interface.h
+    tdi_sde_meter.cc
+    tdi_sde_multicast.cc
+    tdi_sde_register.cc
+    tdi_sde_table_data.cc
+    tdi_sde_table_entry.cc
+    tdi_sde_table_key.cc
+    tdi_sde_utils.h
+    tdi_sde_wrapper.cc
+    tdi_sde_wrapper.h
+    tdi_table_manager.cc
+    tdi_table_manager.h
+    utils.cc
+    utils.h
+)
+
+target_include_directories(stratum_hal_lib_tdi_o PRIVATE
+    ${STRATUM_INCLUDES}
+    ${SDE_INSTALL_DIR}/include
+)
+
+add_dependencies(stratum_hal_lib_tdi_o stratum_proto)
+
+if(TOFINO_TARGET)
+  add_subdirectory(tofino)
+elseif(DPDK_TARGET)
+  add_subdirectory(dpdk)
+endif()
+
+add_library(stratum_hal_lib_tdi SHARED
+    $<TARGET_OBJECTS:stratum_glue_o>
+    $<TARGET_OBJECTS:stratum_lib_o>
+    $<TARGET_OBJECTS:stratum_public_o>
+    $<TARGET_OBJECTS:stratum_hal_lib_common_o>
+    $<TARGET_OBJECTS:stratum_hal_lib_phal_o>
+    $<TARGET_OBJECTS:stratum_hal_lib_p4_o>
+    $<TARGET_OBJECTS:stratum_hal_lib_yang_o>
+    $<TARGET_OBJECTS:stratum_hal_lib_tdi_o>
+
+    $<$<BOOL:${TOFINO_TARGET}>:$<TARGET_OBJECTS:stratum_hal_lib_yang_subtree_interface_o>>
+    $<$<BOOL:${TOFINO_TARGET}>:$<TARGET_OBJECTS:stratum_hal_lib_tdi_tofino_o>>
+
+    $<$<BOOL:${DPDK_TARGET}>:$<TARGET_OBJECTS:stratum_hal_lib_tdi_dpdk_o>>
+)
+
+target_link_libraries(stratum_hal_lib_tdi PUBLIC
+    absl::strings absl::synchronization absl::graphcycles_internal
+    absl::stacktrace absl::symbolize absl::malloc_internal
+    absl::debugging_internal absl::demangle_internal absl::time
+    absl::strings_internal absl::throw_delegate
+    absl::base absl::spinlock_wait absl::int128 absl::raw_logging_internal
+    absl::log_severity absl::civil_time absl::civil_time absl::time_zone
+    absl::status absl::cord absl::cord_internal absl::cordz_info
+    absl::cordz_handle absl::cordz_sample_token absl::cordz_functions
+    absl::exponential_biased absl::str_format_internal absl::hash
+    absl::raw_hash_set absl::city absl::bad_optional_access
+    absl::bad_variant_access absl::low_level_hash
+)
+
+target_link_libraries(stratum_hal_lib_tdi PUBLIC glog gflags grpc protobuf grpc++)
+target_link_libraries(stratum_hal_lib_tdi PUBLIC pthread)
+
+target_link_libraries(stratum_hal_lib_tdi PUBLIC
+    openconfig_proto
+    stratum_proto
+    gnmi_proto
+    grpc_proto
+    p4runtime_proto
+)
+
+if(TOFINO_TARGET)
+    target_link_libraries(stratum_hal_lib_tdi PUBLIC
+        driver
+        target_sys
+    )
+elseif(DPDK_TARGET)
+    target_link_libraries(stratum_hal_lib_tdi PUBLIC
+        driver
+        bf_switchd_lib
+        tdi
+        tdi_json_parser
+        target_utils
+        target_sys
+    )
+
+    target_link_directories(stratum_hal_lib_tdi PUBLIC 
+        ${SDE_INSTALL_DIR}/lib
+        ${DPDK_LIBRARY_DIRS}
+    )
+
+    target_link_options(stratum_hal_lib_tdi PUBLIC
+        ${DPDK_LD_FLAGS}
+        ${DPDK_LDFLAGS_OTHER}
+    )
+endif()
+
+install(TARGETS stratum_hal_lib_tdi RUNTIME)

--- a/stratum/hal/lib/tdi/CMakeLists.txt
+++ b/stratum/hal/lib/tdi/CMakeLists.txt
@@ -1,9 +1,9 @@
-# CMake build file for Stratum code.
+# CMake build file for Stratum hal tdi library.
 #
 # Copyright 2022 Intel Corporation
 # SPDX-License-Identifier: Apache 2.0
 
-add_library(stratum_hal_lib_tdi_o OBJECT
+add_library(stratum_tdi_o OBJECT
     tdi_action_profile_manager.cc
     tdi_action_profile_manager.h
     tdi_counter_manager.cc
@@ -40,12 +40,12 @@ add_library(stratum_hal_lib_tdi_o OBJECT
     utils.h
 )
 
-target_include_directories(stratum_hal_lib_tdi_o PRIVATE
+target_include_directories(stratum_tdi_o PRIVATE
     ${STRATUM_INCLUDES}
     ${SDE_INSTALL_DIR}/include
 )
 
-add_dependencies(stratum_hal_lib_tdi_o stratum_proto)
+add_dependencies(stratum_tdi_o stratum_proto)
 
 if(TOFINO_TARGET)
   add_subdirectory(tofino)
@@ -53,7 +53,7 @@ elseif(DPDK_TARGET)
   add_subdirectory(dpdk)
 endif()
 
-add_library(stratum_hal_lib_tdi SHARED
+add_library(stratum_tdi
     $<TARGET_OBJECTS:stratum_glue_o>
     $<TARGET_OBJECTS:stratum_lib_o>
     $<TARGET_OBJECTS:stratum_public_o>
@@ -61,7 +61,7 @@ add_library(stratum_hal_lib_tdi SHARED
     $<TARGET_OBJECTS:stratum_hal_lib_phal_o>
     $<TARGET_OBJECTS:stratum_hal_lib_p4_o>
     $<TARGET_OBJECTS:stratum_hal_lib_yang_o>
-    $<TARGET_OBJECTS:stratum_hal_lib_tdi_o>
+    $<TARGET_OBJECTS:stratum_tdi_o>
 
     $<$<BOOL:${TOFINO_TARGET}>:$<TARGET_OBJECTS:stratum_hal_lib_yang_subtree_interface_o>>
     $<$<BOOL:${TOFINO_TARGET}>:$<TARGET_OBJECTS:stratum_hal_lib_tdi_tofino_o>>
@@ -69,7 +69,7 @@ add_library(stratum_hal_lib_tdi SHARED
     $<$<BOOL:${DPDK_TARGET}>:$<TARGET_OBJECTS:stratum_hal_lib_tdi_dpdk_o>>
 )
 
-target_link_libraries(stratum_hal_lib_tdi PUBLIC
+target_link_libraries(stratum_tdi PUBLIC
     absl::strings absl::synchronization absl::graphcycles_internal
     absl::stacktrace absl::symbolize absl::malloc_internal
     absl::debugging_internal absl::demangle_internal absl::time
@@ -83,10 +83,10 @@ target_link_libraries(stratum_hal_lib_tdi PUBLIC
     absl::bad_variant_access absl::low_level_hash
 )
 
-target_link_libraries(stratum_hal_lib_tdi PUBLIC glog gflags grpc protobuf grpc++)
-target_link_libraries(stratum_hal_lib_tdi PUBLIC pthread)
+target_link_libraries(stratum_tdi PUBLIC glog gflags grpc protobuf grpc++)
+target_link_libraries(stratum_tdi PUBLIC pthread)
 
-target_link_libraries(stratum_hal_lib_tdi PUBLIC
+target_link_libraries(stratum_tdi PUBLIC
     openconfig_proto
     stratum_proto
     gnmi_proto
@@ -95,12 +95,12 @@ target_link_libraries(stratum_hal_lib_tdi PUBLIC
 )
 
 if(TOFINO_TARGET)
-    target_link_libraries(stratum_hal_lib_tdi PUBLIC
+    target_link_libraries(stratum_tdi PUBLIC
         driver
         target_sys
     )
 elseif(DPDK_TARGET)
-    target_link_libraries(stratum_hal_lib_tdi PUBLIC
+    target_link_libraries(stratum_tdi PUBLIC
         driver
         bf_switchd_lib
         tdi
@@ -109,15 +109,13 @@ elseif(DPDK_TARGET)
         target_sys
     )
 
-    target_link_directories(stratum_hal_lib_tdi PUBLIC 
+    target_link_directories(stratum_tdi PUBLIC 
         ${SDE_INSTALL_DIR}/lib
         ${DPDK_LIBRARY_DIRS}
     )
 
-    target_link_options(stratum_hal_lib_tdi PUBLIC
+    target_link_options(stratum_tdi PUBLIC
         ${DPDK_LD_FLAGS}
         ${DPDK_LDFLAGS_OTHER}
     )
 endif()
-
-install(TARGETS stratum_hal_lib_tdi RUNTIME)

--- a/stratum/hal/lib/tdi/dpdk/CMakeLists.txt
+++ b/stratum/hal/lib/tdi/dpdk/CMakeLists.txt
@@ -1,0 +1,29 @@
+# CMake build file for Stratum code.
+#
+# Copyright 2022 Intel Corporation
+# SPDX-License-Identifier: Apache 2.0
+
+add_library(stratum_hal_lib_tdi_dpdk_o OBJECT
+    dpdk_chassis_manager.cc
+    dpdk_chassis_manager.h
+    dpdk_hal.cc
+    dpdk_hal.h
+    dpdk_port_config.cc
+    dpdk_port_config.h
+    dpdk_sde_target.cc
+    dpdk_sde_utils.cc
+    dpdk_switch.cc
+    dpdk_switch.h
+    dpdk_add_subtree_interface.cc
+    dpdk_parse_tree_interface.cc
+    dpdk_parse_tree_interface.h
+)
+
+target_compile_definitions(stratum_hal_lib_tdi_dpdk_o PRIVATE SDE_9_5_0)
+
+target_include_directories(stratum_hal_lib_tdi_dpdk_o PRIVATE
+    ${STRATUM_INCLUDES}
+    ${SDE_INSTALL_DIR}/include
+)
+
+add_dependencies(stratum_hal_lib_tdi_dpdk_o stratum_proto)

--- a/stratum/hal/lib/tdi/dpdk/CMakeLists.txt
+++ b/stratum/hal/lib/tdi/dpdk/CMakeLists.txt
@@ -1,4 +1,4 @@
-# CMake build file for Stratum code.
+# CMake build file for Stratum dpdk lib code.
 #
 # Copyright 2022 Intel Corporation
 # SPDX-License-Identifier: Apache 2.0
@@ -18,8 +18,6 @@ add_library(stratum_hal_lib_tdi_dpdk_o OBJECT
     dpdk_parse_tree_interface.cc
     dpdk_parse_tree_interface.h
 )
-
-target_compile_definitions(stratum_hal_lib_tdi_dpdk_o PRIVATE SDE_9_5_0)
 
 target_include_directories(stratum_hal_lib_tdi_dpdk_o PRIVATE
     ${STRATUM_INCLUDES}

--- a/stratum/hal/lib/tdi/tofino/CMakeLists.txt
+++ b/stratum/hal/lib/tdi/tofino/CMakeLists.txt
@@ -1,4 +1,4 @@
-# CMake build file for Stratum code.
+# CMake build file for Stratum tofino lib code.
 #
 # Copyright 2022 Intel Corporation
 # SPDX-License-Identifier: Apache 2.0

--- a/stratum/hal/lib/tdi/tofino/CMakeLists.txt
+++ b/stratum/hal/lib/tdi/tofino/CMakeLists.txt
@@ -1,0 +1,24 @@
+# CMake build file for Stratum code.
+#
+# Copyright 2022 Intel Corporation
+# SPDX-License-Identifier: Apache 2.0
+
+add_library(stratum_hal_lib_tdi_tofino_o OBJECT
+  tofino_chassis_manager.cc
+  tofino_chassis_manager.h
+  tofino_hal.cc
+  tofino_hal.h
+  tofino_sde_target.cc
+  tofino_sde_utils.cc
+  tofino_switch.cc
+  tofino_switch.h
+)
+
+target_compile_definitions(stratum_hal_lib_tdi_tofino_o PRIVATE SDE_9_11_0)
+
+target_include_directories(stratum_hal_lib_tdi_tofino_o PRIVATE
+    ${STRATUM_INCLUDES}
+    ${SDE_INSTALL_DIR}/include
+)
+
+add_dependencies(stratum_hal_lib_tdi_tofino_o stratum_proto)

--- a/stratum/hal/lib/yang/CMakeLists.txt
+++ b/stratum/hal/lib/yang/CMakeLists.txt
@@ -1,0 +1,45 @@
+# CMake build file for Stratum code.
+#
+# Copyright 2022 Intel Corporation
+# SPDX-License-Identifier: Apache 2.0
+
+add_library(stratum_hal_lib_yang_o OBJECT
+    yang_parse_tree.cc
+    yang_parse_tree.h
+    yang_parse_tree_chassis.cc
+    yang_parse_tree_component.cc
+    yang_parse_tree_component.h
+    yang_parse_tree_helpers.cc
+    yang_parse_tree_helpers.h
+    yang_parse_tree_interface.cc
+    yang_parse_tree_interface.h
+    yang_parse_tree_node.cc
+    yang_parse_tree_optical.cc
+    yang_parse_tree_paths.cc
+    yang_parse_tree_paths.h
+    yang_parse_tree_singleton.cc
+    yang_parse_tree_system.cc
+)
+
+target_include_directories(stratum_hal_lib_yang_o PRIVATE
+    ${STRATUM_INCLUDES}
+)
+
+add_dependencies(stratum_hal_lib_yang_o
+    gnmi_proto
+    stratum_proto
+)
+
+# generic subtree interface for most targets
+add_library(stratum_hal_lib_yang_subtree_interface_o OBJECT
+    yang_add_subtree_interface.cc
+)
+
+target_include_directories(stratum_hal_lib_yang_subtree_interface_o PRIVATE
+    ${STRATUM_INCLUDES}
+)
+
+add_dependencies(stratum_hal_lib_yang_subtree_interface_o
+    gnmi_proto
+    stratum_proto
+)

--- a/stratum/hal/lib/yang/CMakeLists.txt
+++ b/stratum/hal/lib/yang/CMakeLists.txt
@@ -1,4 +1,4 @@
-# CMake build file for Stratum code.
+# CMake build file for Stratum yang code.
 #
 # Copyright 2022 Intel Corporation
 # SPDX-License-Identifier: Apache 2.0

--- a/stratum/lib/CMakeLists.txt
+++ b/stratum/lib/CMakeLists.txt
@@ -1,0 +1,20 @@
+# CMake build file for Stratum code.
+#
+# Copyright 2022 Intel Corporation
+# SPDX-License-Identifier: Apache 2.0
+
+add_library(stratum_lib_o OBJECT
+    timer_daemon.cc
+    timer_daemon.h
+    channel/channel.h
+    channel/channel_internal.h
+    macros.h
+    security/auth_policy_checker.cc
+    security/auth_policy_checker.h
+    utils.cc
+    utils.h
+)
+
+target_include_directories(stratum_lib_o PRIVATE ${STRATUM_INCLUDES})
+
+add_dependencies(stratum_lib_o stratum_proto)

--- a/stratum/lib/CMakeLists.txt
+++ b/stratum/lib/CMakeLists.txt
@@ -1,4 +1,4 @@
-# CMake build file for Stratum code.
+# CMake build file for Stratum lib code.
 #
 # Copyright 2022 Intel Corporation
 # SPDX-License-Identifier: Apache 2.0

--- a/stratum/public/CMakeLists.txt
+++ b/stratum/public/CMakeLists.txt
@@ -1,4 +1,4 @@
-# CMake build file for Stratum code.
+# CMake build file for Stratum public code.
 #
 # Copyright 2022 Intel Corporation
 # SPDX-License-Identifier: Apache 2.0

--- a/stratum/public/CMakeLists.txt
+++ b/stratum/public/CMakeLists.txt
@@ -1,0 +1,13 @@
+# CMake build file for Stratum code.
+#
+# Copyright 2022 Intel Corporation
+# SPDX-License-Identifier: Apache 2.0
+
+add_library(stratum_public_o OBJECT
+    lib/error.cc
+    lib/error.h
+)
+
+target_include_directories(stratum_public_o PRIVATE ${STRATUM_INCLUDES})
+
+add_dependencies(stratum_public_o stratum_proto)

--- a/stratum/tools/gnmi/CMakeLists.txt
+++ b/stratum/tools/gnmi/CMakeLists.txt
@@ -1,0 +1,38 @@
+# CMake build file for Stratum code.
+#
+# Copyright 2022 Intel Corporation
+# SPDX-License-Identifier: Apache 2.0
+
+add_executable(gnmi_cli
+    gnmi_cli.cc
+    $<TARGET_OBJECTS:stratum_glue_o>
+    $<TARGET_OBJECTS:stratum_lib_o>
+    $<TARGET_OBJECTS:stratum_public_o>
+)
+
+target_link_libraries(gnmi_cli
+    PUBLIC
+        gnmi_proto grpc_proto stratum_proto p4runtime_proto
+        grpc protobuf gflags grpc++ glog
+        pthread re2 absl::raw_hash_set
+)
+
+if(HAVE_POSIX_AIO)
+    target_link_libraries(gnmi_cli PUBLIC rt)
+endif()
+
+target_include_directories(gnmi_cli
+    PRIVATE
+        ${STRATUM_SOURCE_DIR}
+        ${PROTO_OUT_DIR}
+)
+
+add_dependencies(gnmi_cli
+    gnmi_proto
+    grpc_proto
+)
+
+# TODO
+if(NOT DPDK_TARGET)
+    install(TARGETS gnmi_cli RUNTIME)
+endif()

--- a/stratum/tools/gnmi/CMakeLists.txt
+++ b/stratum/tools/gnmi/CMakeLists.txt
@@ -1,4 +1,4 @@
-# CMake build file for Stratum code.
+# CMake build file for gnmi cli code.
 #
 # Copyright 2022 Intel Corporation
 # SPDX-License-Identifier: Apache 2.0


### PR DESCRIPTION
This is the first PR to be followed by more enhancements to the cmake build.

This PR is a dependent implementation. That means, it can be only built as part of a higher level build tree. This higher level build tree provides the require proto builds and any required dependencies.

There is no integration yet of the test cases.

Part 2 of this implementation will bring in support for building protos.