### PR TITLE
Define a TdiPortManager

### DIFF
--- a/stratum/hal/bin/tdi/tofino/tofino_main.cc
+++ b/stratum/hal/bin/tdi/tofino/tofino_main.cc
@@ -16,6 +16,7 @@
 #include "stratum/hal/lib/tdi/tdi_sde_wrapper.h"
 #include "stratum/hal/lib/tdi/tdi_table_manager.h"
 #include "stratum/hal/lib/tdi/tofino/tofino_chassis_manager.h"
+#include "stratum/hal/lib/tdi/tofino/tofino_port_manager.h"
 #include "stratum/hal/lib/tdi/tofino/tofino_hal.h"
 #include "stratum/hal/lib/tdi/tofino/tofino_switch.h"
 #include "stratum/lib/security/auth_policy_checker.h"
@@ -41,6 +42,8 @@ namespace tdi {
   const int device_id = 0;
 
   auto sde_wrapper = TdiSdeWrapper::CreateSingleton();
+
+  auto tofino_port_manager = TofinoPortManager::CreateSingleton();
 
   RETURN_IF_ERROR(sde_wrapper->InitializeSde(
       FLAGS_tdi_sde_install, FLAGS_tdi_switchd_cfg, FLAGS_tdi_switchd_background));
@@ -80,8 +83,8 @@ namespace tdi {
       {device_id, tdi_node.get()},
   };
 
-  auto chassis_manager =
-      TofinoChassisManager::CreateInstance(mode, phal, sde_wrapper);
+  auto chassis_manager = TofinoChassisManager::CreateInstance(
+      mode, phal, sde_wrapper, tofino_port_manager);
 
   auto tdi_switch = TofinoSwitch::CreateInstance(
       chassis_manager.get(), device_id_to_tdi_node);

--- a/stratum/hal/lib/tdi/dpdk/dpdk_sde_target.cc
+++ b/stratum/hal/lib/tdi/dpdk/dpdk_sde_target.cc
@@ -77,6 +77,12 @@ using namespace stratum::hal::tdi::helpers;
   return ::util::OkStatus();
 }
 
+::util::Status TdiSdeWrapper::UnregisterPortStatusEventWriter() {
+  absl::WriterMutexLock l(&port_status_event_writer_lock_);
+  port_status_event_writer_ = nullptr;
+  return ::util::OkStatus();
+}
+
 namespace {
 dpdk_port_type_t get_target_port_type(DpdkPortType type) {
   switch(type) {
@@ -244,29 +250,6 @@ dpdk_port_type_t get_target_port_type(DpdkPortType type) {
   return MAKE_ERROR(ERR_UNIMPLEMENTED) << "DisablePort not implemented";
 }
 
-::util::Status TdiSdeWrapper::SetPortShapingRate(
-    int device, int port, bool is_in_pps, uint32 burst_size,
-    uint64 rate_per_second) {
-  return MAKE_ERROR(ERR_OPER_NOT_SUPPORTED)
-      << "SetPortShapingRate not supported";
-}
-
-::util::Status TdiSdeWrapper::EnablePortShaping(
-    int device, int port, TriState enable) {
-  return MAKE_ERROR(ERR_OPER_NOT_SUPPORTED)
-      << "EnablePortShaping not supported";
-}
-
-::util::Status TdiSdeWrapper::SetPortAutonegPolicy(
-    int device, int port, TriState autoneg) {
-  return MAKE_ERROR(ERR_OPER_NOT_SUPPORTED)
-      << "SetPortAutonegPolicy not supported";
-}
-
-::util::Status TdiSdeWrapper::SetPortMtu(int device, int port, int32 mtu) {
-  return MAKE_ERROR(ERR_UNIMPLEMENTED) << "SetPortMtu not implemented";
-}
-
 // Should this return ::util::StatusOr<bool>?
 bool TdiSdeWrapper::IsValidPort(int device, int port) {
   // NOTE: Method returns bool. What is BF_SUCCESS (an enum) doing here?
@@ -274,12 +257,6 @@ bool TdiSdeWrapper::IsValidPort(int device, int port) {
   // that it is supposed to succeed, but BF_SUCCESS == 0, which when
   // converted to a Boolean is FALSE, so it is actually failure.
   return BF_SUCCESS;
-}
-
-::util::Status TdiSdeWrapper::SetPortLoopbackMode(
-    int device, int port, LoopbackState loopback_mode) {
-  return MAKE_ERROR(ERR_OPER_NOT_SUPPORTED)
-      << "SetPortLoopbackMode not supported";
 }
 
 ::util::StatusOr<bool> TdiSdeWrapper::IsSoftwareModel(int device) {
@@ -324,20 +301,6 @@ std::string TdiSdeWrapper::GetSdeVersion() const {
   RETURN_IF_TDI_ERROR(bf_pal_port_str_to_dev_port_map(
       static_cast<bf_dev_id_t>(device), port_string, &dev_port));
   return static_cast<uint32>(dev_port);
-}
-
-::util::StatusOr<int> TdiSdeWrapper::GetPcieCpuPort(int device) {
-  return MAKE_ERROR(ERR_OPER_NOT_SUPPORTED) << "GetPcieCpuPort not supported";
-}
-
-::util::Status TdiSdeWrapper::SetTmCpuPort(int device, int port) {
-  return MAKE_ERROR(ERR_OPER_NOT_SUPPORTED) << "SetTmCpuPort not supported";
-}
-
-::util::Status TdiSdeWrapper::SetDeflectOnDropDestination(
-    int device, int port, int queue) {
-  return MAKE_ERROR(ERR_UNIMPLEMENTED)
-      << "SetDeflectOnDropDestination not implemented";
 }
 
 ::util::Status TdiSdeWrapper::InitializeSde(

--- a/stratum/hal/lib/tdi/tdi_sde_wrapper.cc
+++ b/stratum/hal/lib/tdi/tdi_sde_wrapper.cc
@@ -41,34 +41,10 @@ namespace tdi {
 
 using namespace stratum::hal::tdi::helpers;
 
-constexpr absl::Duration TdiSdeWrapper::kWriteTimeout;
-constexpr int32 TdiSdeWrapper::kBfDefaultMtu;
-
 TdiSdeWrapper* TdiSdeWrapper::singleton_ = nullptr;
 ABSL_CONST_INIT absl::Mutex TdiSdeWrapper::init_lock_(absl::kConstInit);
 
 TdiSdeWrapper::TdiSdeWrapper() : port_status_event_writer_(nullptr) {}
-
-::util::Status TdiSdeWrapper::OnPortStatusEvent(
-    int device, int port, bool up, absl::Time timestamp) {
-  // Create PortStatusEvent message.
-  PortState state = up ? PORT_STATE_UP : PORT_STATE_DOWN;
-  PortStatusEvent event = {device, port, state, timestamp};
-
-  {
-    absl::ReaderMutexLock l(&port_status_event_writer_lock_);
-    if (!port_status_event_writer_) {
-      return ::util::OkStatus();
-    }
-    return port_status_event_writer_->Write(event, kWriteTimeout);
-  }
-}
-
-::util::Status TdiSdeWrapper::UnregisterPortStatusEventWriter() {
-  absl::WriterMutexLock l(&port_status_event_writer_lock_);
-  port_status_event_writer_ = nullptr;
-  return ::util::OkStatus();
-}
 
 // Create and start an new session.
 ::util::StatusOr<std::shared_ptr<TdiSdeInterface::SessionInterface>>

--- a/stratum/hal/lib/tdi/tofino/tofino_chassis_manager.h
+++ b/stratum/hal/lib/tdi/tofino/tofino_chassis_manager.h
@@ -15,6 +15,7 @@
 #include "absl/types/optional.h"
 #include "stratum/glue/integral_types.h"
 #include "stratum/hal/lib/tdi/tdi_sde_interface.h"
+#include "stratum/hal/lib/tdi/tofino/tofino_port_manager.h"
 #include "stratum/hal/lib/common/gnmi_events.h"
 #include "stratum/hal/lib/common/phal_interface.h"
 #include "stratum/hal/lib/common/utils.h"
@@ -76,7 +77,8 @@ class TofinoChassisManager {
   // Factory function for creating the instance of the class.
   static std::unique_ptr<TofinoChassisManager> CreateInstance(
       OperationMode mode, PhalInterface* phal_interface,
-      TdiSdeInterface* tdi_sde_interface);
+      TdiSdeInterface* tdi_sde_interface,
+      TofinoPortManager* tofino_port_manager);
 
   // TofinoChassisManager is neither copyable nor movable.
   TofinoChassisManager(const TofinoChassisManager&) = delete;
@@ -120,7 +122,7 @@ class TofinoChassisManager {
   // Private constructor. Use CreateInstance() to create an instance of this
   // class.
   TofinoChassisManager(OperationMode mode, PhalInterface* phal_interface,
-		       TdiSdeInterface* tdi_sde_interface);
+      TdiSdeInterface* tdi_sde_interface, TofinoPortManager* tofino_port_manager);
 
   ::util::StatusOr<const PortConfig*> GetPortConfig(uint64 node_id,
                                                     uint32 port_id) const
@@ -293,6 +295,9 @@ class TofinoChassisManager {
 
   // Pointer to a TdiSdeInterface implementation that wraps all the SDE calls.
   TdiSdeInterface* tdi_sde_interface_;  // not owned by this class.
+
+  // Pointer to a TofinoPortManager implementation that wraps the SDE calls.
+  TofinoPortManager* tofino_port_manager_;  // not owned by this class.
 
   friend class TofinoChassisManagerTest;
 };

--- a/stratum/hal/lib/tdi/tofino/tofino_port_manager.h
+++ b/stratum/hal/lib/tdi/tofino/tofino_port_manager.h
@@ -1,0 +1,111 @@
+// Copyright 2020-present Open Networking Foundation
+// Copyright 2022 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef STRATUM_HAL_LIB_TDI_TOFINO_TOFINO_PORT_MANAGER_H_
+#define STRATUM_HAL_LIB_TDI_TOFINO_TOFINO_PORT_MANAGER_H_
+
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "absl/synchronization/mutex.h"
+#include "stratum/hal/lib/tdi/tdi_sde_wrapper.h"
+
+// Suppress clang errors
+#undef LOCKS_EXCLUDED
+#define LOCKS_EXCLUDED(...)
+
+namespace stratum {
+namespace hal {
+namespace tdi {
+
+class TofinoPortManager : public TdiSdeInterface::TdiPortManager {
+ public:
+  TofinoPortManager();
+
+  // Required methods from public interface
+  ::util::Status RegisterPortStatusEventWriter(
+      std::unique_ptr<ChannelWriter<TdiSdeInterface::PortStatusEvent>> writer)
+      LOCKS_EXCLUDED(port_status_event_writer_lock_);
+  ::util::Status UnregisterPortStatusEventWriter()
+      LOCKS_EXCLUDED(port_status_event_writer_lock_);
+  ::util::Status GetPortInfo(int device, int port,
+                             TargetDatapathId *target_dp_id);
+  ::util::StatusOr<PortState> GetPortState(int device, int port);
+  ::util::Status GetPortCounters(int device, int port,
+                                 PortCounters* counters);
+  ::util::StatusOr<uint32> GetPortIdFromPortKey(
+      int device, const PortKey& port_key);
+  bool IsValidPort(int device, int port);
+  ::util::Status AddPort(int device, int port);
+  ::util::Status DeletePort(int device, int port);
+  ::util::Status EnablePort(int device, int port);
+  ::util::Status DisablePort(int device, int port);
+
+  // Tofino specific methods
+  ::util::Status AddPort(int device, int port, uint64 speed_bps,
+                         FecMode fec_mode);
+  ::util::Status SetPortShapingRate(
+      int device, int port, bool is_in_pps, uint32 burst_size,
+      uint64 rate_per_second);
+  ::util::Status EnablePortShaping(int device, int port,
+                                           TriState enable);
+  ::util::Status SetPortAutonegPolicy(int device, int port,
+                                              TriState autoneg);
+  ::util::Status SetPortMtu(int device, int port, int32 mtu);
+  ::util::Status SetPortLoopbackMode(int uint, int port,
+                                             LoopbackState loopback_mode);
+  ::util::StatusOr<int> GetPcieCpuPort(int device);
+  ::util::Status SetTmCpuPort(int device, int port);
+  ::util::Status SetDeflectOnDropDestination(int device, int port,
+                                                     int queue);
+
+  // Creates the singleton instance. Expected to be called once to initialize
+  // the instance.
+  static TofinoPortManager* CreateSingleton() LOCKS_EXCLUDED(init_lock_);
+
+  // The following public functions are specific to this class. They are to be
+  // called by SDE callbacks only.
+
+  // Return the singleton instance to be used in the SDE callbacks.
+  static TofinoPortManager* GetSingleton() LOCKS_EXCLUDED(init_lock_);
+
+  // Called whenever a port status event is received from SDK. It forwards the
+  // port status event to the module who registered a callback by calling
+  // RegisterPortStatusEventWriter().
+  ::util::Status OnPortStatusEvent(int device, int dev_port, bool up,
+                                   absl::Time timestamp)
+      LOCKS_EXCLUDED(port_status_event_writer_lock_);
+
+ protected:
+  // RW mutex lock for protecting the singleton instance initialization and
+  // reading it back from other threads. Unlike other singleton classes, we
+  // use RW lock as we need the pointer to class to be returned.
+  static absl::Mutex init_lock_;
+
+  // The singleton instance.
+  static TofinoPortManager* singleton_ GUARDED_BY(init_lock_);
+
+ private:
+  // Timeout for Write() operations on port status events.
+  static constexpr absl::Duration kWriteTimeout = absl::InfiniteDuration();
+
+  // Default MTU for ports on Tofino.
+  static constexpr int32 kBfDefaultMtu = 10 * 1024;  // 10K
+
+  // RM Mutex to protect the port status writer.
+  mutable absl::Mutex port_status_event_writer_lock_;
+
+  // Writer to forward the port status change message to. It is registered
+  // by chassis manager to receive SDE port status change events.
+  std::unique_ptr<ChannelWriter<TdiSdeInterface::PortStatusEvent>> port_status_event_writer_
+      GUARDED_BY(port_status_event_writer_lock_);
+};
+
+}  // namespace tdi
+}  // namespace hal
+}  // namespace stratum
+
+#endif  // STRATUM_HAL_LIB_TDI_TOFINO_TOFINO_PORT_MANAGER_H_


### PR DESCRIPTION
Signed-off-by: Ravi Vantipalli <ravi.vantipalli@intel.com>

Group port related methods in TdiSdiInterface into a TdiPortManager.

TdiPortManager defines a base set of methods which are mandatory for each target to implement. All target specific methods are defined in a per target port manager class. TofinoPortManager is an example.
Which methods are mandatory is up for discussion too.

After this, each target does not have to implement dummies for unsupported methods.

Tofino chassis manager will completely stop relying on tofino_sde_wrapper with this change.