### PR TITLE
Fix the issue observed during control port creation

### DIFF
--- a/stratum/hal/lib/tdi/dpdk/dpdk_chassis_manager.cc
+++ b/stratum/hal/lib/tdi/dpdk/dpdk_chassis_manager.cc
@@ -264,6 +264,7 @@ bool DpdkChassisManager::IsPortParamSet(
     // Packet direction for control port will always be host type
     sde_params.port_type = PORT_TYPE_TAP;
     sde_params.packet_dir = DEFAULT_PACKET_DIR;
+    sde_params.port_name = config->control_port;
 
     /* sdk_ctl_port_id is uniquely derived from the SDK_PORT_CONTROL_BASE range
      * and maps 1:1 to parent port's sdk_port_id.


### PR DESCRIPTION
Copy the port name when creation of control port is requested. If not, this will result in hash collision maintained by SDE backend as control port will be created with same name as physical port and resulting in failure when adding the port.

Signed-off-by: Nupur Uttarwar <nupur.uttarwar@intel.com>