### PR TITLE
Port tdi_table_manager change from P4-OVS

### DIFF
--- a/stratum/hal/lib/tdi/tdi_table_manager.cc
+++ b/stratum/hal/lib/tdi/tdi_table_manager.cc
@@ -473,18 +473,18 @@ std::unique_ptr<TdiTableManager> TdiTableManager::CreateInstance(
       param->set_param_id(expected_param.id());
       param->set_value(value);
     }
-  }
+  } else {
+    // Action profile member id
+    uint64 action_member_id;
+    if (table_data->GetActionMemberId(&action_member_id).ok()) {
+      result.mutable_action()->set_action_profile_member_id(action_member_id);
+    }
 
-  // Action profile member id
-  uint64 action_member_id;
-  if (table_data->GetActionMemberId(&action_member_id).ok()) {
-    result.mutable_action()->set_action_profile_member_id(action_member_id);
-  }
-
-  // Action profile group id
-  uint64 selector_group_id;
-  if (table_data->GetSelectorGroupId(&selector_group_id).ok()) {
-    result.mutable_action()->set_action_profile_group_id(selector_group_id);
+    // Action profile group id
+    uint64 selector_group_id;
+    if (table_data->GetSelectorGroupId(&selector_group_id).ok()) {
+      result.mutable_action()->set_action_profile_group_id(selector_group_id);
+    }
   }
 
   // Counter data, if applicable.


### PR DESCRIPTION
- In BuildP4TableEntry, only set the action profile member and group IDs if the action ID is zero, instead of setting them unconditionally.

Signed-off-by: Derek G Foster <derek.foster@intel.com>