### PR TITLE
Rename tdi_info_ params to conform to naming practices

### DIFF
--- a/stratum/hal/lib/tdi/tdi_sde_table_data.cc
+++ b/stratum/hal/lib/tdi/tdi_sde_table_data.cc
@@ -169,10 +169,10 @@ using namespace stratum::hal::tdi::helpers;
 }
 
 ::util::StatusOr<std::unique_ptr<TdiSdeInterface::TableDataInterface>>
-TableData::CreateTableData(const ::tdi::TdiInfo* tdi_info_, int table_id,
+TableData::CreateTableData(const ::tdi::TdiInfo* tdi_info, int table_id,
                            int action_id) {
   const ::tdi::Table* table;
-  RETURN_IF_TDI_ERROR(tdi_info_->tableFromIdGet(table_id, &table));
+  RETURN_IF_TDI_ERROR(tdi_info->tableFromIdGet(table_id, &table));
   std::unique_ptr<::tdi::TableData> table_data;
   if (action_id) {
     RETURN_IF_TDI_ERROR(table->dataAllocate(action_id, &table_data));

--- a/stratum/hal/lib/tdi/tdi_sde_table_key.cc
+++ b/stratum/hal/lib/tdi/tdi_sde_table_key.cc
@@ -257,9 +257,9 @@ using namespace stratum::hal::tdi::helpers;
 }
 
 ::util::StatusOr<std::unique_ptr<TdiSdeInterface::TableKeyInterface>>
-TableKey::CreateTableKey(const ::tdi::TdiInfo* tdi_info_, int table_id) {
+TableKey::CreateTableKey(const ::tdi::TdiInfo* tdi_info, int table_id) {
   const ::tdi::Table* table;
-  RETURN_IF_TDI_ERROR(tdi_info_->tableFromIdGet(table_id, &table));
+  RETURN_IF_TDI_ERROR(tdi_info->tableFromIdGet(table_id, &table));
   std::unique_ptr<::tdi::TableKey> table_key;
   RETURN_IF_TDI_ERROR(table->keyAllocate(&table_key));
   auto key = std::unique_ptr<TdiSdeInterface::TableKeyInterface>(

--- a/stratum/hal/lib/tdi/tdi_sde_wrapper.h
+++ b/stratum/hal/lib/tdi/tdi_sde_wrapper.h
@@ -56,7 +56,7 @@ class TableKey : public TdiSdeInterface::TableKeyInterface {
 
   // Allocates a new table key object.
   static ::util::StatusOr<std::unique_ptr<TdiSdeInterface::TableKeyInterface>>
-  CreateTableKey(const ::tdi::TdiInfo* tdi_info_, int table_id);
+  CreateTableKey(const ::tdi::TdiInfo* tdi_info, int table_id);
 
   // Stores the underlying SDE object.
   std::unique_ptr<::tdi::TableKey> table_key_;
@@ -84,7 +84,7 @@ class TableData : public TdiSdeInterface::TableDataInterface {
 
   // Allocates a new table data object.
   static ::util::StatusOr<std::unique_ptr<TdiSdeInterface::TableDataInterface>>
-  CreateTableData(const ::tdi::TdiInfo* tdi_info_, int table_id,
+  CreateTableData(const ::tdi::TdiInfo* tdi_info, int table_id,
                   int action_id);
 
   // Stores the underlying SDE object.


### PR DESCRIPTION
- Renamed tdi_info_ parameters to tdi_info. Stratum uses the '_' suffix for class member variables, to distinguish them from parameters and local variables.

Signed-off-by: Derek G Foster <derek.foster@intel.com>