### PR TITLE
Initialize tdi_sde_wrapper member variable

### DIFF
--- a/stratum/hal/lib/tdi/tdi_sde_wrapper.cc
+++ b/stratum/hal/lib/tdi/tdi_sde_wrapper.cc
@@ -44,7 +44,8 @@ using namespace stratum::hal::tdi::helpers;
 TdiSdeWrapper* TdiSdeWrapper::singleton_ = nullptr;
 ABSL_CONST_INIT absl::Mutex TdiSdeWrapper::init_lock_(absl::kConstInit);
 
-TdiSdeWrapper::TdiSdeWrapper() : port_status_event_writer_(nullptr) {}
+TdiSdeWrapper::TdiSdeWrapper() : port_status_event_writer_(nullptr),
+                                 tdi_info_(nullptr) {}
 
 // Create and start an new session.
 ::util::StatusOr<std::shared_ptr<TdiSdeInterface::SessionInterface>>


### PR DESCRIPTION
- Initialized tdi_info_ member variable to nullptr.

Signed-off-by: Derek G Foster <derek.foster@intel.com>