### PR TITLE
Fix pervasive memory leak

### DIFF
--- a/stratum/hal/lib/tdi/tdi_sde_action_profile.cc
+++ b/stratum/hal/lib/tdi/tdi_sde_action_profile.cc
@@ -67,15 +67,15 @@ using namespace stratum::hal::tdi::helpers;
   std::unique_ptr<::tdi::Target> dev_tgt;
   device->createTarget(&dev_tgt);
 
-  ::tdi::Flags *flags = new ::tdi::Flags(0);
+  const auto flags = ::tdi::Flags(0);
   if (insert) {
     RETURN_IF_TDI_ERROR(table->entryAdd(*real_session->tdi_session_,
-                                        *dev_tgt, *flags, *table_key,
+                                        *dev_tgt, flags, *table_key,
                                         *real_table_data->table_data_))
         << "Could not add action profile member with: " << dump_args();
   } else {
     RETURN_IF_TDI_ERROR(table->entryMod(*real_session->tdi_session_,
-                                             *dev_tgt, *flags, *table_key,
+                                             *dev_tgt, flags, *table_key,
                                              *real_table_data->table_data_))
         << "Could not modify action profile member with: " << dump_args();
   }
@@ -127,9 +127,9 @@ using namespace stratum::hal::tdi::helpers;
   std::unique_ptr<::tdi::Target> dev_tgt;
   device->createTarget(&dev_tgt);
 
-  ::tdi::Flags *flags = new ::tdi::Flags(0);
+  const auto flags = ::tdi::Flags(0);
   RETURN_IF_TDI_ERROR(table->entryDel(*real_session->tdi_session_,
-                                      *dev_tgt, *flags, *table_key))
+                                      *dev_tgt, flags, *table_key))
       << "Could not delete action profile member with: " << dump_args();
   return ::util::OkStatus();
 }
@@ -149,7 +149,7 @@ using namespace stratum::hal::tdi::helpers;
   std::unique_ptr<::tdi::Target> dev_tgt;
   device->createTarget(&dev_tgt);
 
-  ::tdi::Flags *flags = new ::tdi::Flags(0);
+  const auto flags = ::tdi::Flags(0);
   const ::tdi::Table* table;
   RETURN_IF_TDI_ERROR(tdi_info_->tableFromIdGet(table_id, &table));
   std::vector<std::unique_ptr<::tdi::TableKey>> keys;
@@ -163,7 +163,7 @@ using namespace stratum::hal::tdi::helpers;
     // Key: $ACTION_MEMBER_ID
     RETURN_IF_ERROR(SetFieldExact(keys[0].get(), kActionMemberId, member_id));
     RETURN_IF_TDI_ERROR(table->entryGet(
-        *real_session->tdi_session_, *dev_tgt, *flags, *keys[0],
+        *real_session->tdi_session_, *dev_tgt, flags, *keys[0],
         datums[0].get()));
   } else {
     RETURN_IF_ERROR(GetAllEntries(real_session->tdi_session_, *dev_tgt,
@@ -231,14 +231,14 @@ using namespace stratum::hal::tdi::helpers;
   std::unique_ptr<::tdi::Target> dev_tgt;
   device->createTarget(&dev_tgt);
 
-  ::tdi::Flags *flags = new ::tdi::Flags(0);
+  const auto flags = ::tdi::Flags(0);
   if (insert) {
     RETURN_IF_TDI_ERROR(table->entryAdd(
-        *real_session->tdi_session_, *dev_tgt, *flags, *table_key, *table_data))
+        *real_session->tdi_session_, *dev_tgt, flags, *table_key, *table_data))
         << "Could not add action profile group with: " << dump_args();
   } else {
     RETURN_IF_TDI_ERROR(table->entryMod(
-        *real_session->tdi_session_, *dev_tgt, *flags, *table_key, *table_data))
+        *real_session->tdi_session_, *dev_tgt, flags, *table_key, *table_data))
         << "Could not modify action profile group with: " << dump_args();
   }
 
@@ -294,9 +294,9 @@ using namespace stratum::hal::tdi::helpers;
   std::unique_ptr<::tdi::Target> dev_tgt;
   device->createTarget(&dev_tgt);
 
-  ::tdi::Flags *flags = new ::tdi::Flags(0);
+  const auto flags = ::tdi::Flags(0);
   RETURN_IF_TDI_ERROR(table->entryDel(*real_session->tdi_session_,
-                                            *dev_tgt, *flags, *table_key))
+                                            *dev_tgt, flags, *table_key))
       << "Could not delete action profile group with: " << dump_args();
 
   return ::util::OkStatus();
@@ -321,7 +321,7 @@ using namespace stratum::hal::tdi::helpers;
   std::unique_ptr<::tdi::Target> dev_tgt;
   device->createTarget(&dev_tgt);
 
-  ::tdi::Flags *flags = new ::tdi::Flags(0);
+  const auto flags = ::tdi::Flags(0);
   const ::tdi::Table* table;
   RETURN_IF_TDI_ERROR(tdi_info_->tableFromIdGet(table_id, &table));
   std::vector<std::unique_ptr<::tdi::TableKey>> keys;
@@ -335,7 +335,7 @@ using namespace stratum::hal::tdi::helpers;
     // Key: $SELECTOR_GROUP_ID
     RETURN_IF_ERROR(SetFieldExact(keys[0].get(), kSelectorGroupId, group_id));
     RETURN_IF_TDI_ERROR(table->entryGet(
-        *real_session->tdi_session_, *dev_tgt, *flags, *keys[0],
+        *real_session->tdi_session_, *dev_tgt, flags, *keys[0],
         datums[0].get()));
   } else {
     RETURN_IF_ERROR(GetAllEntries(real_session->tdi_session_, *dev_tgt,

--- a/stratum/hal/lib/tdi/tdi_sde_clone_session.cc
+++ b/stratum/hal/lib/tdi/tdi_sde_clone_session.cc
@@ -41,7 +41,7 @@ using namespace stratum::hal::tdi::helpers;
   std::unique_ptr<::tdi::Target> dev_tgt;
   device->createTarget(&dev_tgt);
 
-  ::tdi::Flags *flags = new ::tdi::Flags(0);
+  const auto flags = ::tdi::Flags(0);
   RETURN_IF_TDI_ERROR(
       tdi_info_->tableFromNameGet(kMirrorConfigTable, &table));
   std::unique_ptr<::tdi::TableKey> table_key;
@@ -72,10 +72,10 @@ using namespace stratum::hal::tdi::helpers;
 
   if (insert) {
     RETURN_IF_TDI_ERROR(table->entryAdd(
-        *real_session->tdi_session_, *dev_tgt, *flags, *table_key, *table_data));
+        *real_session->tdi_session_, *dev_tgt, flags, *table_key, *table_data));
   } else {
     RETURN_IF_TDI_ERROR(table->entryMod(
-        *real_session->tdi_session_, *dev_tgt, *flags, *table_key, *table_data));
+        *real_session->tdi_session_, *dev_tgt, flags, *table_key, *table_data));
   }
 
   return ::util::OkStatus();
@@ -128,9 +128,9 @@ using namespace stratum::hal::tdi::helpers;
   std::unique_ptr<::tdi::Target> dev_tgt;
   device->createTarget(&dev_tgt);
 
-  ::tdi::Flags *flags = new ::tdi::Flags(0);
+  const auto flags = ::tdi::Flags(0);
   RETURN_IF_TDI_ERROR(table->entryDel(*real_session->tdi_session_,
-                                      *dev_tgt, *flags, *table_key));
+                                      *dev_tgt, flags, *table_key));
 
   return ::util::OkStatus();
 }
@@ -154,7 +154,7 @@ using namespace stratum::hal::tdi::helpers;
   std::unique_ptr<::tdi::Target> dev_tgt;
   device->createTarget(&dev_tgt);
 
-  ::tdi::Flags *flags = new ::tdi::Flags(0);
+  const auto flags = ::tdi::Flags(0);
   const ::tdi::Table* table;
   RETURN_IF_TDI_ERROR(
       tdi_info_->tableFromNameGet(kMirrorConfigTable, &table));
@@ -173,7 +173,7 @@ using namespace stratum::hal::tdi::helpers;
     // Key: $sid
     RETURN_IF_ERROR(SetFieldExact(keys[0].get(), "$sid", session_id));
     RETURN_IF_TDI_ERROR(table->entryGet(
-        *real_session->tdi_session_, *dev_tgt, *flags, *keys[0],
+        *real_session->tdi_session_, *dev_tgt, flags, *keys[0],
         datums[0].get()));
   } else {
     RETURN_IF_ERROR(GetAllEntries(real_session->tdi_session_, *dev_tgt,

--- a/stratum/hal/lib/tdi/tdi_sde_counter.cc
+++ b/stratum/hal/lib/tdi/tdi_sde_counter.cc
@@ -75,14 +75,14 @@ using namespace stratum::hal::tdi::helpers;
   std::unique_ptr<::tdi::Target> dev_tgt;
   device->createTarget(&dev_tgt);
 
-  ::tdi::Flags *flags = new ::tdi::Flags(0);
+  const auto flags = ::tdi::Flags(0);
   if(byte_count.value() == 0 && packet_count.value() == 0) {
     LOG(INFO) << "Resetting counters";
     RETURN_IF_TDI_ERROR(table->clear(
-      *real_session->tdi_session_, *dev_tgt, *flags));
+      *real_session->tdi_session_, *dev_tgt, flags));
   } else {
     RETURN_IF_TDI_ERROR(table->entryMod(
-     *real_session->tdi_session_, *dev_tgt, *flags, *table_key, *table_data));
+     *real_session->tdi_session_, *dev_tgt, flags, *table_key, *table_data));
   }
 
   return ::util::OkStatus();
@@ -107,7 +107,7 @@ using namespace stratum::hal::tdi::helpers;
   std::unique_ptr<::tdi::Target> dev_tgt;
   device->createTarget(&dev_tgt);
 
-  ::tdi::Flags *flags = new ::tdi::Flags(0);
+  const auto flags = ::tdi::Flags(0);
   const ::tdi::Table* table;
   RETURN_IF_TDI_ERROR(tdi_info_->tableFromIdGet(counter_id, &table));
   std::vector<std::unique_ptr<::tdi::TableKey>> keys;
@@ -126,7 +126,7 @@ using namespace stratum::hal::tdi::helpers;
     RETURN_IF_ERROR(
         SetFieldExact(keys[0].get(), kCounterIndex, counter_index.value()));
     RETURN_IF_TDI_ERROR(table->entryGet(
-        *real_session->tdi_session_, *dev_tgt, *flags, *keys[0],
+        *real_session->tdi_session_, *dev_tgt, flags, *keys[0],
         datums[0].get()));
 
   } else {

--- a/stratum/hal/lib/tdi/tdi_sde_helpers.cc
+++ b/stratum/hal/lib/tdi/tdi_sde_helpers.cc
@@ -402,16 +402,16 @@ namespace helpers {
   // "full". The SDE does not support querying the usage on these.
   const ::tdi::Device *device = nullptr;
   ::tdi::DevMgr::getInstance().deviceGet(0, &device);
-  ::tdi::Flags *flags = new ::tdi::Flags(0);
+  const auto flags = ::tdi::Flags(0);
   uint32 entries = 0;
   if (IsPreallocatedTable(*table)) {
     size_t table_size;
     RETURN_IF_TDI_ERROR(
-        table->sizeGet(*tdi_session, tdi_dev_target, *flags, &table_size));
+        table->sizeGet(*tdi_session, tdi_dev_target, flags, &table_size));
     entries = table_size;
   } else {
     RETURN_IF_TDI_ERROR(
-	table->usageGet(*tdi_session, tdi_dev_target, *flags, &entries));
+	table->usageGet(*tdi_session, tdi_dev_target, flags, &entries));
   }
 
   table_keys->resize(0);
@@ -426,7 +426,7 @@ namespace helpers {
     RETURN_IF_TDI_ERROR(table->dataAllocate(&table_data));
     RETURN_IF_TDI_ERROR(table->entryGetFirst(
         *tdi_session, tdi_dev_target,
-        *flags, table_key.get(),
+        flags, table_key.get(),
         table_data.get()));
 
     table_keys->push_back(std::move(table_key));
@@ -446,7 +446,7 @@ namespace helpers {
     }
     uint32 actual = 0;
     RETURN_IF_TDI_ERROR(table->entryGetNextN(
-        *tdi_session, tdi_dev_target, *flags, *(*table_keys)[0], pairs.size(),
+        *tdi_session, tdi_dev_target, flags, *(*table_keys)[0], pairs.size(),
         &pairs, &actual));
 
     table_keys->insert(table_keys->end(), std::make_move_iterator(keys.begin()),

--- a/stratum/hal/lib/tdi/tdi_sde_meter.cc
+++ b/stratum/hal/lib/tdi/tdi_sde_meter.cc
@@ -71,24 +71,24 @@ using namespace stratum::hal::tdi::helpers;
   std::unique_ptr<::tdi::Target> dev_tgt;
   device->createTarget(&dev_tgt);
 
-  ::tdi::Flags *flags = new ::tdi::Flags(0);
+  const auto flags = ::tdi::Flags(0);
   if (meter_index) {
     // Single index target.
     // Meter key: $METER_INDEX
     RETURN_IF_ERROR(
         SetFieldExact(table_key.get(), kMeterIndex, meter_index.value()));
     RETURN_IF_TDI_ERROR(table->entryMod(
-        *real_session->tdi_session_, *dev_tgt, *flags, *table_key, *table_data));
+        *real_session->tdi_session_, *dev_tgt, flags, *table_key, *table_data));
   } else {
     // Wildcard write to all indices.
     size_t table_size;
     RETURN_IF_TDI_ERROR(table->sizeGet(*real_session->tdi_session_,
-                                       *dev_tgt, *flags, &table_size));
+                                       *dev_tgt, flags, &table_size));
     for (size_t i = 0; i < table_size; ++i) {
       // Meter key: $METER_INDEX
       RETURN_IF_ERROR(SetFieldExact(table_key.get(), kMeterIndex, i));
       RETURN_IF_TDI_ERROR(table->entryMod(
-          *real_session->tdi_session_, *dev_tgt, *flags, *table_key, *table_data));
+          *real_session->tdi_session_, *dev_tgt, flags, *table_key, *table_data));
     }
   }
 
@@ -115,7 +115,7 @@ using namespace stratum::hal::tdi::helpers;
   std::unique_ptr<::tdi::Target> dev_tgt;
   device->createTarget(&dev_tgt);
 
-  ::tdi::Flags *flags = new ::tdi::Flags(0);
+  const auto flags = ::tdi::Flags(0);
   const ::tdi::Table* table;
   RETURN_IF_TDI_ERROR(tdi_info_->tableFromIdGet(table_id, &table));
   std::vector<std::unique_ptr<::tdi::TableKey>> keys;
@@ -131,7 +131,7 @@ using namespace stratum::hal::tdi::helpers;
     RETURN_IF_ERROR(SetFieldExact(keys[0].get(), kMeterIndex,
                     meter_index.value()));
     RETURN_IF_TDI_ERROR(table->entryGet(
-        *real_session->tdi_session_, *dev_tgt, *flags, *keys[0],
+        *real_session->tdi_session_, *dev_tgt, flags, *keys[0],
         datums[0].get()));
   } else {
     RETURN_IF_ERROR(GetAllEntries(real_session->tdi_session_, *dev_tgt,

--- a/stratum/hal/lib/tdi/tdi_sde_multicast.cc
+++ b/stratum/hal/lib/tdi/tdi_sde_multicast.cc
@@ -142,17 +142,17 @@ namespace {
   std::unique_ptr<::tdi::Target> dev_tgt;
   device->createTarget(&dev_tgt);
 
-  ::tdi::Flags *flags = new ::tdi::Flags(0);
+  const auto flags = ::tdi::Flags(0);
   const ::tdi::Table* table;
   RETURN_IF_TDI_ERROR(tdi_info_->tableFromNameGet(kPreNodeTable, &table));
   size_t table_size;
 
   RETURN_IF_TDI_ERROR(table->sizeGet(*real_session->tdi_session_,
-                                      *dev_tgt, *flags, &table_size));
+                                      *dev_tgt, flags, &table_size));
   uint32 usage;
   RETURN_IF_TDI_ERROR(table->usageGet(
       *real_session->tdi_session_, *dev_tgt,
-      *flags, &usage));
+      flags, &usage));
   std::unique_ptr<::tdi::TableKey> table_key;
   std::unique_ptr<::tdi::TableData> table_data;
   RETURN_IF_TDI_ERROR(table->keyAllocate(&table_key));
@@ -163,7 +163,7 @@ namespace {
     RETURN_IF_ERROR(SetFieldExact(table_key.get(), kMcNodeId, id));
     bf_status_t status;
     status = table->entryGet(
-        *real_session->tdi_session_, *dev_tgt, *flags, *table_key,
+        *real_session->tdi_session_, *dev_tgt, flags, *table_key,
         table_data.get());
     if (status == BF_OBJECT_NOT_FOUND) {
       return id;
@@ -201,7 +201,7 @@ namespace {
   std::unique_ptr<::tdi::Target> dev_tgt;
   device->createTarget(&dev_tgt);
 
-  ::tdi::Flags *flags = new ::tdi::Flags(0);
+  const auto flags = ::tdi::Flags(0);
 
   ASSIGN_OR_RETURN(uint64 mc_node_id, GetFreeMulticastNodeId(dev_id, session));
 
@@ -215,7 +215,7 @@ namespace {
   // Data: $DEV_PORT
   RETURN_IF_ERROR(SetField(table_data.get(), kMcNodeDevPort, ports));
   RETURN_IF_TDI_ERROR(table->entryAdd(
-      *real_session->tdi_session_, *dev_tgt, *flags, *table_key, *table_data));
+      *real_session->tdi_session_, *dev_tgt, flags, *table_key, *table_data));
   return mc_node_id;
 }
 
@@ -232,7 +232,7 @@ namespace {
   std::unique_ptr<::tdi::Target> dev_tgt;
   device->createTarget(&dev_tgt);
 
-  ::tdi::Flags *flags = new ::tdi::Flags(0);
+  const auto flags = ::tdi::Flags(0);
   const ::tdi::Table* table;
   RETURN_IF_TDI_ERROR(tdi_info_->tableFromNameGet(kPreMgidTable, &table));
 
@@ -243,7 +243,7 @@ namespace {
   // Key: $MGID
   RETURN_IF_ERROR(SetFieldExact(table_key.get(), kMgid, group_id));
   RETURN_IF_TDI_ERROR(table->entryGet(
-      *real_session->tdi_session_,*dev_tgt, *flags, *table_key,
+      *real_session->tdi_session_,*dev_tgt, flags, *table_key,
       table_data.get()));
   // Data: $MULTICAST_NODE_ID
   std::vector<uint32> mc_node_list;
@@ -265,7 +265,7 @@ namespace {
   std::unique_ptr<::tdi::Target> dev_tgt;
   device->createTarget(&dev_tgt);
 
-  ::tdi::Flags *flags = new ::tdi::Flags(0);
+  const auto flags = ::tdi::Flags(0);
   const ::tdi::Table* table;
   RETURN_IF_TDI_ERROR(tdi_info_->tableFromNameGet(kPreNodeTable, &table));
   auto table_id = table->tableInfoGet()->idGet();
@@ -276,7 +276,7 @@ namespace {
     RETURN_IF_TDI_ERROR(table->keyAllocate(&table_key));
     RETURN_IF_ERROR(SetFieldExact(table_key.get(), kMcNodeId, mc_node_id));
     RETURN_IF_TDI_ERROR(table->entryDel(*real_session->tdi_session_,
-                                         *dev_tgt, *flags, *table_key));
+                                         *dev_tgt, flags, *table_key));
   }
 
   return ::util::OkStatus();
@@ -298,7 +298,7 @@ namespace {
   std::unique_ptr<::tdi::Target> dev_tgt;
   device->createTarget(&dev_tgt);
 
-  ::tdi::Flags *flags = new ::tdi::Flags(0);
+  const auto flags = ::tdi::Flags(0);
   const ::tdi::Table* table;  // PRE node table.
   RETURN_IF_TDI_ERROR(tdi_info_->tableFromNameGet(kPreNodeTable, &table));
   auto table_id = table->tableInfoGet()->idGet();
@@ -310,7 +310,7 @@ namespace {
   // Key: $MULTICAST_NODE_ID
   RETURN_IF_ERROR(SetFieldExact(table_key.get(), kMcNodeId, mc_node_id));
   RETURN_IF_TDI_ERROR(table->entryGet(
-      *real_session->tdi_session_, *dev_tgt, *flags, *table_key,
+      *real_session->tdi_session_, *dev_tgt, flags, *table_key,
       table_data.get()));
   // Data: $DEV_PORT
   std::vector<uint32> dev_ports;
@@ -340,7 +340,7 @@ namespace {
   device->createTarget(&dev_tgt);
 
 
-  ::tdi::Flags *flags = new ::tdi::Flags(0);
+  const auto flags = ::tdi::Flags(0);
   const ::tdi::Table* table = nullptr;  // PRE MGID table.
   RETURN_IF_TDI_ERROR(tdi_info_->tableFromNameGet(kPreMgidTable, &table));
   auto table_id = table->tableInfoGet()->idGet();
@@ -370,11 +370,11 @@ namespace {
 
   if (insert) {
     RETURN_IF_TDI_ERROR(table->entryAdd(
-        *real_session->tdi_session_, *dev_tgt, *flags, *table_key, *table_data));
+        *real_session->tdi_session_, *dev_tgt, flags, *table_key, *table_data));
 
   } else {
     RETURN_IF_TDI_ERROR(table->entryMod(
-        *real_session->tdi_session_, *dev_tgt, *flags, *table_key, *table_data));
+        *real_session->tdi_session_, *dev_tgt, flags, *table_key, *table_data));
   }
 
   return ::util::OkStatus();
@@ -409,7 +409,7 @@ namespace {
   std::unique_ptr<::tdi::Target> dev_tgt;
   device->createTarget(&dev_tgt);
 
-  ::tdi::Flags *flags = new ::tdi::Flags(0);
+  const auto flags = ::tdi::Flags(0);
   const ::tdi::Table* table;  // PRE MGID table.
   RETURN_IF_TDI_ERROR(tdi_info_->tableFromNameGet(kPreMgidTable, &table));
   std::unique_ptr<::tdi::TableKey> table_key;
@@ -417,7 +417,7 @@ namespace {
   // Key: $MGID
   RETURN_IF_ERROR(SetFieldExact(table_key.get(), kMgid, group_id));
   RETURN_IF_TDI_ERROR(table->entryDel(*real_session->tdi_session_,
-                                            *dev_tgt, *flags, *table_key));
+                                            *dev_tgt, flags, *table_key));
 
   return ::util::OkStatus();
 }
@@ -437,7 +437,7 @@ namespace {
   std::unique_ptr<::tdi::Target> dev_tgt;
   device->createTarget(&dev_tgt);
 
-  ::tdi::Flags *flags = new ::tdi::Flags(0);
+  const auto flags = ::tdi::Flags(0);
   const ::tdi::Table* table;  // PRE MGID table.
   RETURN_IF_TDI_ERROR(tdi_info_->tableFromNameGet(kPreMgidTable, &table));
   std::vector<std::unique_ptr<::tdi::TableKey>> keys;
@@ -451,7 +451,7 @@ namespace {
     // Key: $MGID
     RETURN_IF_ERROR(SetFieldExact(keys[0].get(), kMgid, group_id));
     RETURN_IF_TDI_ERROR(table->entryGet(
-        *real_session->tdi_session_, *dev_tgt, *flags, *keys[0],
+        *real_session->tdi_session_, *dev_tgt, flags, *keys[0],
         datums[0].get()));
   } else {
     RETURN_IF_ERROR(GetAllEntries(real_session->tdi_session_, *dev_tgt,

--- a/stratum/hal/lib/tdi/tdi_sde_register.cc
+++ b/stratum/hal/lib/tdi/tdi_sde_register.cc
@@ -105,25 +105,25 @@ namespace {
   std::unique_ptr<::tdi::Target> dev_tgt;
   device->createTarget(&dev_tgt);
 
-  ::tdi::Flags *flags = new ::tdi::Flags(0);
+  const auto flags = ::tdi::Flags(0);
   if (register_index) {
     // Single index target.
     // Register key: $REGISTER_INDEX
     RETURN_IF_ERROR(
         SetFieldExact(table_key.get(), kRegisterIndex, register_index.value()));
     RETURN_IF_TDI_ERROR(table->entryMod(
-        *real_session->tdi_session_, *dev_tgt, *flags,
+        *real_session->tdi_session_, *dev_tgt, flags,
         *table_key, *table_data));
   } else {
     // Wildcard write to all indices.
     size_t table_size;
     RETURN_IF_TDI_ERROR(table->sizeGet(*real_session->tdi_session_,
-                                       *dev_tgt, *flags, &table_size));
+                                       *dev_tgt, flags, &table_size));
     for (size_t i = 0; i < table_size; ++i) {
       // Register key: $REGISTER_INDEX
       RETURN_IF_ERROR(SetFieldExact(table_key.get(), kRegisterIndex, i));
       RETURN_IF_TDI_ERROR(table->entryMod(
-          *real_session->tdi_session_, *dev_tgt, *flags, *table_key, *table_data));
+          *real_session->tdi_session_, *dev_tgt, flags, *table_key, *table_data));
     }
   }
 
@@ -148,7 +148,7 @@ namespace {
   std::unique_ptr<::tdi::Target> dev_tgt;
   device->createTarget(&dev_tgt);
 
-  ::tdi::Flags *flags = new ::tdi::Flags(0);
+  const auto flags = ::tdi::Flags(0);
   const ::tdi::Table* table;
   RETURN_IF_TDI_ERROR(tdi_info_->tableFromIdGet(table_id, &table));
   std::vector<std::unique_ptr<::tdi::TableKey>> keys;
@@ -165,7 +165,7 @@ namespace {
     RETURN_IF_ERROR(
         SetFieldExact(keys[0].get(), kRegisterIndex, register_index.value()));
     RETURN_IF_TDI_ERROR(table->entryGet(
-        *real_session->tdi_session_, *dev_tgt, *flags, *keys[0],
+        *real_session->tdi_session_, *dev_tgt, flags, *keys[0],
         datums[0].get()));
   } else {
     RETURN_IF_ERROR(GetAllEntries(real_session->tdi_session_, *dev_tgt,

--- a/stratum/hal/lib/tdi/tdi_sde_table_entry.cc
+++ b/stratum/hal/lib/tdi/tdi_sde_table_entry.cc
@@ -64,9 +64,9 @@ using namespace stratum::hal::tdi::helpers;
    * pipeline id also should be set
    */
 
-  ::tdi::Flags *flags = new ::tdi::Flags(0);
+  const auto flags = ::tdi::Flags(0);
   RETURN_IF_TDI_ERROR(table->entryAdd(
-      *real_session->tdi_session_, *dev_tgt, *flags, *real_table_key->table_key_,
+      *real_session->tdi_session_, *dev_tgt, flags, *real_table_key->table_key_,
       *real_table_data->table_data_))
       << "Could not add table entry with: " << dump_args();
 
@@ -104,9 +104,9 @@ using namespace stratum::hal::tdi::helpers;
   std::unique_ptr<::tdi::Target> dev_tgt;
   device->createTarget(&dev_tgt);
 
-  ::tdi::Flags *flags = new ::tdi::Flags(0);
+  const auto flags = ::tdi::Flags(0);
   RETURN_IF_TDI_ERROR(table->entryMod(
-      *real_session->tdi_session_, *dev_tgt, *flags, *real_table_key->table_key_,
+      *real_session->tdi_session_, *dev_tgt, flags, *real_table_key->table_key_,
       *real_table_data->table_data_))
       << "Could not modify table entry with: " << dump_args();
   return ::util::OkStatus();
@@ -138,9 +138,9 @@ using namespace stratum::hal::tdi::helpers;
   std::unique_ptr<::tdi::Target> dev_tgt;
   device->createTarget(&dev_tgt);
 
-  ::tdi::Flags *flags = new ::tdi::Flags(0);
+  const auto flags = ::tdi::Flags(0);
   RETURN_IF_TDI_ERROR(table->entryDel(
-      *real_session->tdi_session_, *dev_tgt, *flags, *real_table_key->table_key_))
+      *real_session->tdi_session_, *dev_tgt, flags, *real_table_key->table_key_))
       << "Could not delete table entry with: " << dump_args();
   return ::util::OkStatus();
 }
@@ -164,9 +164,9 @@ using namespace stratum::hal::tdi::helpers;
   std::unique_ptr<::tdi::Target> dev_tgt;
   device->createTarget(&dev_tgt);
 
-  ::tdi::Flags *flags = new ::tdi::Flags(0);
+  const auto flags = ::tdi::Flags(0);
   RETURN_IF_TDI_ERROR(table->entryGet(
-      *real_session->tdi_session_, *dev_tgt, *flags, *real_table_key->table_key_,
+      *real_session->tdi_session_, *dev_tgt, flags, *real_table_key->table_key_,
       real_table_data->table_data_.get()));
   return ::util::OkStatus();
 }
@@ -220,10 +220,10 @@ using namespace stratum::hal::tdi::helpers;
   std::unique_ptr<::tdi::Target> dev_tgt;
   device->createTarget(&dev_tgt);
 
-  ::tdi::Flags *flags = new ::tdi::Flags(0);
+  const auto flags = ::tdi::Flags(0);
   RETURN_IF_TDI_ERROR(table->defaultEntrySet(
       *real_session->tdi_session_, *dev_tgt,
-      *flags, *real_table_data->table_data_));
+      flags, *real_table_data->table_data_));
   return ::util::OkStatus();
 }
 
@@ -241,9 +241,9 @@ using namespace stratum::hal::tdi::helpers;
   std::unique_ptr<::tdi::Target> dev_tgt;
   device->createTarget(&dev_tgt);
 
-  ::tdi::Flags *flags = new ::tdi::Flags(0);
+  const auto flags = ::tdi::Flags(0);
   RETURN_IF_TDI_ERROR(
-      table->defaultEntryReset(*real_session->tdi_session_, *dev_tgt, *flags));
+      table->defaultEntryReset(*real_session->tdi_session_, *dev_tgt, flags));
 
   return ::util::OkStatus();
 }
@@ -264,10 +264,9 @@ using namespace stratum::hal::tdi::helpers;
   std::unique_ptr<::tdi::Target> dev_tgt;
   device->createTarget(&dev_tgt);
 
-  ::tdi::Flags *flags = new ::tdi::Flags(0);
+  const auto flags = ::tdi::Flags(0);
   RETURN_IF_TDI_ERROR(table->defaultEntryGet(
-      *real_session->tdi_session_, *dev_tgt,
-      *flags,
+      *real_session->tdi_session_, *dev_tgt, flags,
       real_table_data->table_data_.get()));
 
   return ::util::OkStatus();


### PR DESCRIPTION
- A number of TDI modules were allocating ::tdi::Flags variables on the heap and not deleting them. Modified the code to create automatic (stack) variables instead.

Signed-off-by: Derek G Foster <derek.foster@intel.com>