### PR TITLE
Fix GetAllEntries

### DIFF
--- a/stratum/hal/lib/tdi/tdi_sde_helpers.cc
+++ b/stratum/hal/lib/tdi/tdi_sde_helpers.cc
@@ -392,7 +392,7 @@ namespace helpers {
 
 ::util::Status GetAllEntries(
     std::shared_ptr<::tdi::Session> tdi_session,
-    ::tdi::Target tdi_dev_target, const ::tdi::Table* table,
+    ::tdi::Target &tdi_dev_target, const ::tdi::Table* table,
     std::vector<std::unique_ptr<::tdi::TableKey>>* table_keys,
     std::vector<std::unique_ptr<::tdi::TableData>>* table_values) {
   CHECK_RETURN_IF_FALSE(table_keys) << "table_keys is null";

--- a/stratum/hal/lib/tdi/tdi_sde_helpers.h
+++ b/stratum/hal/lib/tdi/tdi_sde_helpers.h
@@ -115,7 +115,7 @@ template <typename T>
 
 ::util::Status GetAllEntries(
     std::shared_ptr<::tdi::Session> tdi_session,
-    ::tdi::Target tdi_dev_target, const ::tdi::Table* table,
+    ::tdi::Target &tdi_dev_target, const ::tdi::Table* table,
     std::vector<std::unique_ptr<::tdi::TableKey>>* table_keys,
     std::vector<std::unique_ptr<::tdi::TableData>>* table_values);
 


### PR DESCRIPTION
Signed-off-by: Ravi Vantipalli <ravi.vantipalli@intel.com>

The absence of a copy constructor for both the tdi::Target and tdi::tna::tofino::Target (derived from tdi::Target), copying this type by value uses the default copy constructor from the base class. This is causing the tofino specific properties to be messed up.
For now, copying the dev_target by reference for GetAllEntries.