### PR TITLE
Fix lpm key read bug

### DIFF
--- a/stratum/hal/lib/tdi/tdi_sde_table_key.cc
+++ b/stratum/hal/lib/tdi/tdi_sde_table_key.cc
@@ -216,6 +216,7 @@ using namespace stratum::hal::tdi::helpers;
   if (!FLAGS_incompatible_enable_tdi_legacy_bytestring_responses) {
     *prefix = ByteStringToP4RuntimeByteString(*prefix);
   }
+  *prefix_length = lpmKey.prefix_len_;
 
   return ::util::OkStatus();
 }

--- a/stratum/hal/lib/tdi/tdi_table_manager.cc
+++ b/stratum/hal/lib/tdi/tdi_table_manager.cc
@@ -413,7 +413,7 @@ std::unique_ptr<TdiTableManager> TdiTableManager::CreateInstance(
       }
       case ::p4::config::v1::MatchField::LPM: {
         std::string prefix;
-        uint16 prefix_length;
+        uint16 prefix_length = 0;
         RETURN_IF_ERROR(table_key->GetLpm(expected_match_field.id(), &prefix,
                                           &prefix_length));
         match.mutable_lpm()->set_value(prefix);


### PR DESCRIPTION
Signed-off-by: Ravi Vantipalli <ravi.vantipalli@intel.com>

The lpm prefix length is not updated after getting from SDE. Also, its initially value is not initialized.