### PR TITLE
Enable running infrap4d as background process

### DIFF
--- a/stratum/hal/bin/tdi/dpdk/dpdk_main.cc
+++ b/stratum/hal/bin/tdi/dpdk/dpdk_main.cc
@@ -29,13 +29,12 @@
 #include "stratum/lib/macros.h"
 #include "stratum/lib/security/auth_policy_checker.h"
 
-#define CONFIG_PREFIX "/usr/share/stratum/dpdk/"
+#define DEFAULT_CONFIG_PREFIX "/usr/share/stratum/dpdk/"
+#define DEFAULT_LOG_DIR "/var/log/stratum/"
 
 DEFINE_string(dpdk_sde_install, "/usr",
               "Absolute path to the directory where the SDE is installed");
-DEFINE_bool(dpdk_infrap4d_background, false,
-            "Run infrap4d in the background with no interactive features");
-DEFINE_string(dpdk_infrap4d_cfg, CONFIG_PREFIX "dpdk_skip_p4.conf",
+DEFINE_string(dpdk_infrap4d_cfg, DEFAULT_CONFIG_PREFIX "dpdk_skip_p4.conf",
               "Path to the infrap4d json config file");
 DECLARE_string(chassis_config_file);
 
@@ -45,19 +44,42 @@ namespace tdi {
 
 ::util::Status DpdkMain(int argc, char* argv[]) {
   // Default value for DPDK.
-  FLAGS_chassis_config_file = CONFIG_PREFIX "dpdk_port_config.pb.txt";
-  InitGoogle(argv[0], &argc, &argv, true);
+  FLAGS_chassis_config_file = DEFAULT_CONFIG_PREFIX "dpdk_port_config.pb.txt";
+  FLAGS_log_dir = DEFAULT_LOG_DIR;
+  FLAGS_logtostderr = false;
+  FLAGS_alsologtostderr = false;
+
+  /* Note:
+   * InitGoogle by default initializes following options if not explicitly
+   * set by user through command line
+   * logtostderr = true
+   * colorlogtostderr = true
+   * stderrthreshold = 0 (Copy log messages at or above this level to stderr
+   * in addition to logfiles. The numbers of severity levels INFO, WARNING,
+   * ERROR, and FATAL are 0, 1, 2, and 3, respectively.)
+   * minloglevel = 0. Log messages at or above this level. Again, the numbers
+   * of severity levels INFO, WARNING, ERROR, and FATAL are 0, 1, 2, and 3,
+   * respectively)
+   * To be able to define our own requirements for logging when running infrap4d
+   * as process, InitGoogle call is removed and ParseCommandLineFlags is called
+   * separately
+   */
+
+  // Parse command line flags
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+
   InitStratumLogging();
 
   // TODO(antonin): The SDE expects 0-based device ids, so we instantiate
   // components with "device_id" instead of "node_id".
   const int device_id = 0;
+  const bool dpdk_shell_background = true;
 
   auto sde_wrapper = TdiSdeWrapper::CreateSingleton();
 
   RETURN_IF_ERROR(sde_wrapper->InitializeSde(
       FLAGS_dpdk_sde_install, FLAGS_dpdk_infrap4d_cfg,
-      FLAGS_dpdk_infrap4d_background));
+      dpdk_shell_background));
 
   /* ========== */
   // NOTE: Rework for DPDK

--- a/stratum/hal/lib/tdi/dpdk/dpdk_sde_target.cc
+++ b/stratum/hal/lib/tdi/dpdk/dpdk_sde_target.cc
@@ -340,6 +340,20 @@ std::string TdiSdeWrapper::GetSdeVersion() const {
       << "Error when starting switchd.";
   LOG(INFO) << "switchd started successfully";
 
+  // Set SDE log levels for modules of interest.
+  // TODO(max): create story around SDE logs. How to get them into glog? What
+  // levels to enable for which modules?
+  CHECK_RETURN_IF_FALSE(
+      bf_sys_log_level_set(BF_MOD_BFRT, BF_LOG_DEST_STDOUT, BF_LOG_WARN) == 0);
+  CHECK_RETURN_IF_FALSE(
+      bf_sys_log_level_set(BF_MOD_PKT, BF_LOG_DEST_STDOUT, BF_LOG_WARN) == 0);
+  CHECK_RETURN_IF_FALSE(
+      bf_sys_log_level_set(BF_MOD_PIPE, BF_LOG_DEST_STDOUT, BF_LOG_WARN) == 0);
+  if (VLOG_IS_ON(2)) {
+    CHECK_RETURN_IF_FALSE(bf_sys_log_level_set(BF_MOD_PIPE, BF_LOG_DEST_STDOUT,
+                                               BF_LOG_WARN) == 0);
+  }
+
   return ::util::OkStatus();
 }
 
@@ -410,20 +424,6 @@ std::string TdiSdeWrapper::GetSdeVersion() const {
   // This call re-initializes most SDE components.
   RETURN_IF_TDI_ERROR(bf_pal_device_add(dev_id, &device_profile));
   RETURN_IF_TDI_ERROR(bf_pal_device_warm_init_end(dev_id));
-
-  // Set SDE log levels for modules of interest.
-  // TODO(max): create story around SDE logs. How to get them into glog? What
-  // levels to enable for which modules?
-  CHECK_RETURN_IF_FALSE(
-      bf_sys_log_level_set(BF_MOD_BFRT, BF_LOG_DEST_STDOUT, BF_LOG_WARN) == 0);
-  CHECK_RETURN_IF_FALSE(
-      bf_sys_log_level_set(BF_MOD_PKT, BF_LOG_DEST_STDOUT, BF_LOG_WARN) == 0);
-  CHECK_RETURN_IF_FALSE(
-      bf_sys_log_level_set(BF_MOD_PIPE, BF_LOG_DEST_STDOUT, BF_LOG_WARN) == 0);
-  if (VLOG_IS_ON(2)) {
-    CHECK_RETURN_IF_FALSE(bf_sys_log_level_set(BF_MOD_PIPE, BF_LOG_DEST_STDOUT,
-                                               BF_LOG_WARN) == 0);
-  }
 
   ::tdi::DevMgr::getInstance().deviceGet(dev_id, &device);
   RETURN_IF_TDI_ERROR(device->tdiInfoGet(


### PR DESCRIPTION
Enable running infrap4d as background process and enable logging for stratum to /var/log/stratum instead of logging to console

Signed-off-by: Nupur Uttarwar <nupur.uttarwar@intel.com>