### PR TITLE
Check status after setting the parameters to provide error checking

### DIFF
--- a/stratum/hal/lib/tdi/dpdk/dpdk_chassis_manager.cc
+++ b/stratum/hal/lib/tdi/dpdk/dpdk_chassis_manager.cc
@@ -143,7 +143,7 @@ bool DpdkChassisManager::IsPortParamSet(
     SetRequest::Request::Port::ValueCase value_case) {
 
   auto& config = node_id_to_port_id_to_port_config_[node_id][port_id];
-  config.SetParam(value_case, singleton_port);
+  RETURN_IF_ERROR(config.SetParam(value_case, singleton_port));
 
   if (config.HasAnyOf(GNMI_CONFIG_PORT_TYPE) && !config.port_done) {
     if (IsConfigComplete(config)) {


### PR DESCRIPTION
Explicitly check the status after setting port params to report error to the user in case of invalid or out of bound parameters

Signed-off-by: Nupur Uttarwar <nupur.uttarwar@intel.com>