### PR TITLE
Fix GNMI-CTL issue to fetch TargetDpId

### DIFF
--- a/stratum/hal/lib/tdi/dpdk/dpdk_switch.cc
+++ b/stratum/hal/lib/tdi/dpdk/dpdk_switch.cc
@@ -172,7 +172,7 @@ DpdkSwitch::~DpdkSwitch() {}
       case DataRequest::Request::kMacAddress:
       case DataRequest::Request::kLacpRouterMac:
       case DataRequest::Request::kPortCounters:
-      case DataRequest::Request::kSdnPortId: {
+      case DataRequest::Request::kTargetDpId: {
         auto port_data = chassis_manager_->GetPortData(req);
         if (!port_data.ok()) {
           status.Update(port_data.status());


### PR DESCRIPTION
Missing switch case statement in dpdk_switch.cc to handle get TargetDpId request

Signed-off-by: Sandeep N [sandeep.nagapattinam@intel.com](mailto:sandeep.nagapattinam@intel.com)