### PR TITLE
Fix gnmi-ctl tdi-portin-id configured retrieval issue

### DIFF
--- a/stratum/hal/lib/tdi/dpdk/dpdk_switch.cc
+++ b/stratum/hal/lib/tdi/dpdk/dpdk_switch.cc
@@ -172,7 +172,7 @@ DpdkSwitch::~DpdkSwitch() {}
       case DataRequest::Request::kMacAddress:
       case DataRequest::Request::kLacpRouterMac:
       case DataRequest::Request::kPortCounters:
-      case DataRequest::Request::kSdnPortId: {
+      case DataRequest::Request::kTargetDpId: {
         auto port_data = chassis_manager_->GetPortData(req);
         if (!port_data.ok()) {
           status.Update(port_data.status());


### PR DESCRIPTION
Changes to address the issue happening with gnmi-ctl tdi-portin-id get operation.

Signed-off-by: Venkata Suresh Kumar P <venkata.suresh.kumar.p@intel.com>