### PR TITLE
Tls mode

### DIFF
--- a/stratum/hal/bin/tdi/dpdk/dpdk_main.cc
+++ b/stratum/hal/bin/tdi/dpdk/dpdk_main.cc
@@ -1,6 +1,6 @@
 // Copyright 2018-2019 Barefoot Networks, Inc.
 // Copyright 2020-present Open Networking Foundation
-// Copyright 2022 Intel Corporation
+// Copyright 2022-2023 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 #include "stratum/hal/bin/tdi/dpdk/dpdk_main.h"
@@ -28,9 +28,11 @@
 #include "stratum/hal/lib/tdi/tdi_table_manager.h"
 #include "stratum/lib/macros.h"
 #include "stratum/lib/security/auth_policy_checker.h"
+#include "stratum/lib/security/credentials_manager.h"
 
 #define DEFAULT_CONFIG_PREFIX "/usr/share/stratum/dpdk/"
 #define DEFAULT_LOG_DIR "/var/log/stratum/"
+#define DEFAULT_CERTS_DIR "/usr/share/stratum/certs/"
 
 DEFINE_string(dpdk_sde_install, "/usr",
               "Absolute path to the directory where the SDE is installed");
@@ -64,6 +66,11 @@ namespace tdi {
    * as process, InitGoogle call is removed and ParseCommandLineFlags is called
    * separately
    */
+
+  // Default certificate file location for TLS-mode
+  FLAGS_ca_cert_file = DEFAULT_CERTS_DIR "ca.crt";
+  FLAGS_server_key_file = DEFAULT_CERTS_DIR "stratum.key";
+  FLAGS_server_cert_file = DEFAULT_CERTS_DIR "stratum.crt";
 
   // Parse command line flags
   gflags::ParseCommandLineFlags(&argc, &argv, true);

--- a/stratum/hal/bin/tdi/dpdk/dpdk_main.cc
+++ b/stratum/hal/bin/tdi/dpdk/dpdk_main.cc
@@ -71,6 +71,8 @@ namespace tdi {
   FLAGS_ca_cert_file = DEFAULT_CERTS_DIR "ca.crt";
   FLAGS_server_key_file = DEFAULT_CERTS_DIR "stratum.key";
   FLAGS_server_cert_file = DEFAULT_CERTS_DIR "stratum.crt";
+  FLAGS_client_key_file = DEFAULT_CERTS_DIR "client.key";
+  FLAGS_client_cert_file = DEFAULT_CERTS_DIR "client.crt";
 
   // Parse command line flags
   gflags::ParseCommandLineFlags(&argc, &argv, true);

--- a/stratum/hal/lib/tdi/dpdk/dpdk_hal.cc
+++ b/stratum/hal/lib/tdi/dpdk/dpdk_hal.cc
@@ -1,6 +1,6 @@
 // Copyright 2018 Google LLC
 // Copyright 2018-present Open Networking Foundation
-// Copyright 2022 Intel Corporation
+// Copyright 2022-2023 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 #include "stratum/hal/lib/tdi/dpdk/dpdk_hal.h"
@@ -19,6 +19,7 @@
 #include "stratum/lib/constants.h"
 #include "stratum/lib/macros.h"
 #include "stratum/lib/utils.h"
+#include "stratum/lib/security/credentials_manager.h"
 
 #ifdef KRNLMON_SUPPORT
 extern int rpc_start_cookie;
@@ -51,6 +52,8 @@ DEFINE_uint32(grpc_max_recv_msg_size, 256 * 1024 * 1024,
               "grpc server max receive message size (0 = gRPC default).");
 DEFINE_uint32(grpc_max_send_msg_size, 0,
               "grpc server max send message size (0 = gRPC default).");
+DEFINE_bool(grpc_open_insecure_ports, false,
+              "grpc server open insecure ports for gNMI & P4RT (false = closed)");
 
 DECLARE_string(forwarding_pipeline_configs_file);
 
@@ -207,14 +210,41 @@ DpdkHal::~DpdkHal() {
   const std::vector<std::string> external_stratum_urls =
       absl::StrSplit(FLAGS_external_stratum_urls, ',');
   {
+    std::string log_output_str;
     ::grpc::ServerBuilder builder;
     SetGrpcServerKeepAliveArgs(&builder);
 
-    builder.AddListeningPort(FLAGS_local_stratum_url,
-                             ::grpc::InsecureServerCredentials());
+    if (FLAGS_grpc_open_insecure_ports) {
+      // User has chosen to open insecure ports
+      LOG(WARNING) << "Warning: Flag set to open gRPC insecure ports";
+      log_output_str = "[insecure mode] ";
+      builder.AddListeningPort(FLAGS_local_stratum_url,
+                              ::grpc::InsecureServerCredentials());
 
-    for (const auto& url : external_stratum_urls) {
-      builder.AddListeningPort(url, ::grpc::InsecureServerCredentials());
+      for (const auto& url : external_stratum_urls) {
+        builder.AddListeningPort(url, ::grpc::InsecureServerCredentials());
+      }
+    } else {
+      log_output_str = "[secure mode] ";
+      auto credentials_manager = stratum::CredentialsManager::CreateInstance(true);
+      if(!credentials_manager.ok()) {
+        LOG(ERROR) << "Credentials Manager initialization failed. Unable to open ports for gRPC";
+      } else {
+        auto resp = credentials_manager.ConsumeValueOrDie();
+        auto server_credentials = resp.get()->GenerateExternalFacingServerCredentials();
+        if (server_credentials == nullptr) {
+          return MAKE_ERROR(ERR_INTERNAL)
+             << "Unable to initiate server credentials. This is an internal error.";
+        } else {
+
+          builder.AddListeningPort(FLAGS_local_stratum_url, server_credentials);
+          
+          for (const auto& url : external_stratum_urls) {
+            builder.AddListeningPort(url, server_credentials);
+          }
+        }
+
+      }
     }
 
     if (FLAGS_grpc_max_recv_msg_size > 0) {
@@ -236,7 +266,8 @@ DpdkHal::~DpdkHal() {
              << "Failed to start Stratum external facing services. This is an "
              << "internal error.";
     }
-    LOG(ERROR) << "Stratum external facing services are listening to "
+    LOG(ERROR) << log_output_str
+               << "Stratum external facing services are listening to "
                << absl::StrJoin(external_stratum_urls, ", ") << ", "
                << FLAGS_local_stratum_url << "...";
   }

--- a/stratum/hal/lib/tdi/dpdk/dpdk_hal.cc
+++ b/stratum/hal/lib/tdi/dpdk/dpdk_hal.cc
@@ -240,13 +240,12 @@ DpdkHal::~DpdkHal() {
           // assert(server_credentials); // Without gRPC, InfraP4D cannot do much. Exit process
           // TODO(5abeel): assert() is resulting in a no-op. Using exit(1) for now
           exit(1);        
-        } else {
+        }
 
-          builder.AddListeningPort(FLAGS_local_stratum_url, server_credentials);
-          
-          for (const auto& url : external_stratum_urls) {
-            builder.AddListeningPort(url, server_credentials);
-          }
+        builder.AddListeningPort(FLAGS_local_stratum_url, server_credentials);
+
+        for (const auto& url : external_stratum_urls) {
+          builder.AddListeningPort(url, server_credentials);
         }
 
       }

--- a/stratum/hal/lib/tdi/dpdk/dpdk_hal.cc
+++ b/stratum/hal/lib/tdi/dpdk/dpdk_hal.cc
@@ -227,7 +227,7 @@ DpdkHal::~DpdkHal() {
     } else {
       log_output_str = "[secure mode] ";
       auto credentials_manager = stratum::CredentialsManager::CreateInstance(true);
-      if(!credentials_manager.ok()) {
+      if (!credentials_manager.ok()) {
         LOG(ERROR) << "Credentials Manager initialization failed. Unable to open ports for gRPC";
       } else {
         auto resp = credentials_manager.ConsumeValueOrDie();

--- a/stratum/lib/security/credentials_manager.cc
+++ b/stratum/lib/security/credentials_manager.cc
@@ -1,5 +1,6 @@
 // Copyright 2018 Google LLC
 // Copyright 2018-present Open Networking Foundation
+// Copyright 2023 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 #include "stratum/lib/security/credentials_manager.h"
@@ -7,124 +8,154 @@
 #include <memory>
 #include <string>
 #include <utility>
+#include <fstream>
+#include <iostream>
 
 #include "absl/memory/memory.h"
+#include "absl/time/clock.h"
+#include "absl/time/time.h"
 #include "gflags/gflags.h"
-#include "grpcpp/security/server_credentials.h"
-#include "grpcpp/security/tls_credentials_options.h"
 #include "stratum/glue/logging.h"
-#include "stratum/glue/status/status.h"
 #include "stratum/lib/macros.h"
 #include "stratum/lib/utils.h"
 
-DEFINE_string(ca_cert, "", "CA certificate path");
-DEFINE_string(server_key, "", "gRPC Server pricate key path");
-DEFINE_string(server_cert, "", "gRPC Server certificate path");
+DEFINE_string(ca_cert_file, "", "Path to CA certificate file");
+DEFINE_string(server_key_file, "", "Path to gRPC server private key file");
+DEFINE_string(server_cert_file, "", "Path to gRPC server certificate file");
+DEFINE_string(client_key_file, "", "Path to gRPC client key file");
+DEFINE_string(client_cert_file, "", "Path to gRPC client certificate file");
 
 namespace stratum {
 
-CredentialsManager::~CredentialsManager() {}
+using ::grpc::experimental::FileWatcherCertificateProvider;
+using ::grpc::experimental::TlsChannelCredentialsOptions;
+using ::grpc::experimental::TlsServerCredentials;
+using ::grpc::experimental::TlsServerCredentialsOptions;
+
+constexpr unsigned int CredentialsManager::kFileRefreshIntervalSeconds;
+
 CredentialsManager::CredentialsManager() {}
+
+CredentialsManager::~CredentialsManager() {}
+
+::util::StatusOr<std::unique_ptr<CredentialsManager>>
+CredentialsManager::CreateInstance(bool secure_only /*=false*/) {
+  auto instance = absl::WrapUnique(new CredentialsManager());
+  RETURN_IF_ERROR(instance->Initialize(secure_only));
+  return std::move(instance);
+}
 
 std::shared_ptr<::grpc::ServerCredentials>
 CredentialsManager::GenerateExternalFacingServerCredentials() const {
   return server_credentials_;
 }
 
-::util::StatusOr<std::unique_ptr<CredentialsManager>>
-CredentialsManager::CreateInstance() {
-  auto instance_ = absl::WrapUnique(new CredentialsManager());
-  RETURN_IF_ERROR(instance_->Initialize());
-  return std::move(instance_);
+std::shared_ptr<::grpc::ChannelCredentials>
+CredentialsManager::GenerateExternalFacingClientCredentials() const {
+  return client_credentials_;
 }
 
-::util::Status CredentialsManager::Initialize() {
-  if (FLAGS_ca_cert.empty() && FLAGS_server_key.empty() &&
-      FLAGS_server_cert.empty()) {
-    LOG(WARNING) << "Using insecure server credentials";
-    server_credentials_ = ::grpc::InsecureServerCredentials();
-  } else {
-    // Load default credentials
-    ::util::Status status;
-    std::string pem_root_certs_;
-    std::string server_private_key_;
-    std::string server_cert_;
-    status.Update(ReadFileToString(FLAGS_ca_cert, &pem_root_certs_));
-    status.Update(ReadFileToString(FLAGS_server_key, &server_private_key_));
-    status.Update(ReadFileToString(FLAGS_server_cert, &server_cert_));
-    if (!status.ok()) {
-      RETURN_ERROR().without_logging()
-          << "Unable to load credentials: " << status.error_message();
+::util::Status CredentialsManager::Initialize(bool secure_only) {
+  // Server credentials.
+  if (FLAGS_ca_cert_file.empty() && FLAGS_server_key_file.empty() &&
+      FLAGS_server_cert_file.empty()) {
+    if (secure_only) {
+      LOG(WARNING) << "No crt/key files provided, cannot initiate gRPC server credentials";
+      server_credentials_ = nullptr;
+    } else {
+      LOG(WARNING) << "No key files provided, using insecure server credentials!";
+      server_credentials_ = ::grpc::InsecureServerCredentials();
     }
-    credentials_reload_interface_ =
-        std::make_shared<CredentialsReloadInterface>(
-            pem_root_certs_, server_private_key_, server_cert_);
-    auto credential_reload_config = std::make_shared<TlsCredentialReloadConfig>(
-        credentials_reload_interface_);
-
-    tls_opts_ = std::make_shared<TlsCredentialsOptions>(
-        GRPC_SSL_DONT_REQUEST_CLIENT_CERTIFICATE, GRPC_TLS_SERVER_VERIFICATION,
-        nullptr, credential_reload_config, nullptr);
-    server_credentials_ = TlsServerCredentials(*tls_opts_);
+  } else {
+    // Check if certificate files exist/accessible
+    std::ifstream ifile1, ifile2, ifile3;
+    ifile1.open(FLAGS_server_key_file);
+    ifile2.open(FLAGS_server_cert_file);
+    ifile3.open(FLAGS_ca_cert_file);
+    if(ifile1 && ifile2 && ifile3) {
+      auto certificate_provider =
+          std::make_shared<FileWatcherCertificateProvider>(
+              FLAGS_server_key_file, FLAGS_server_cert_file, FLAGS_ca_cert_file,
+              kFileRefreshIntervalSeconds);
+      auto tls_opts =
+          std::make_shared<TlsServerCredentialsOptions>(certificate_provider);
+      tls_opts->set_cert_request_type(GRPC_SSL_DONT_REQUEST_CLIENT_CERTIFICATE);
+      tls_opts->watch_root_certs();
+      tls_opts->watch_identity_key_cert_pairs();
+      server_credentials_ = TlsServerCredentials(*tls_opts);
+    } else {
+      LOG(WARNING) << "Key files provided, but cannot open. Unable to initiate server_credentials.";
+      server_credentials_ = nullptr;
+    }
   }
+
+  // Client credentials.
+  if (FLAGS_ca_cert_file.empty() && FLAGS_client_key_file.empty() &&
+      FLAGS_client_cert_file.empty()) {
+    if (secure_only) {
+      LOG(WARNING) << "No crt/key files provided, cannot initiate gRPC server credentials";
+    } else {
+      client_credentials_ = ::grpc::InsecureChannelCredentials();
+      LOG(WARNING) << "No key files provided, using insecure client credentials!";
+    }
+  } else {
+    // Check if certificate files exist/accessible
+    std::ifstream ifile4, ifile5, ifile6;
+    ifile4.open(FLAGS_client_key_file);
+    ifile5.open(FLAGS_client_cert_file);
+    ifile6.open(FLAGS_ca_cert_file);
+    if(ifile4 && ifile5 && ifile6) {
+      auto certificate_provider =
+          std::make_shared<FileWatcherCertificateProvider>(
+              FLAGS_client_key_file, FLAGS_client_cert_file, FLAGS_ca_cert_file,
+              kFileRefreshIntervalSeconds);
+      auto tls_opts = std::make_shared<TlsChannelCredentialsOptions>();
+      tls_opts->set_certificate_provider(certificate_provider);
+      tls_opts->set_server_verification_option(GRPC_TLS_SERVER_VERIFICATION);
+      tls_opts->watch_root_certs();
+      if (!FLAGS_ca_cert_file.empty() && !FLAGS_client_key_file.empty()) {
+        tls_opts->watch_identity_key_cert_pairs();
+      }
+      client_credentials_ = ::grpc::experimental::TlsCredentials(*tls_opts);
+    } else {
+      LOG(WARNING) << "Key files provided, but cannot open. Unable to initiate client_credentials.";
+      client_credentials_ = nullptr;
+    }
+  }
+
   return ::util::OkStatus();
 }
 
-::util::Status CredentialsManager::LoadNewCredential(
-    const std::string root_certs, const std::string cert_chain,
-    const std::string private_key) {
-  return credentials_reload_interface_->LoadNewCredential(
-      root_certs, cert_chain, private_key);
+::util::Status CredentialsManager::LoadNewServerCredentials(
+    const std::string& root_certs, const std::string& cert_chain,
+    const std::string& private_key) {
+  ::util::Status status;
+  // TODO(Kevin): Validate the provided key material if possible
+  // TODO(max): According to the API of FileWatcherCertificateProvider, any key
+  // and certifcate update must happen atomically. The below code does not
+  // guarantee that.
+  status.Update(WriteStringToFile(root_certs, FLAGS_ca_cert_file));
+  status.Update(WriteStringToFile(cert_chain, FLAGS_server_cert_file));
+  status.Update(WriteStringToFile(private_key, FLAGS_server_key_file));
+  absl::SleepFor(absl::Seconds(kFileRefreshIntervalSeconds + 1));
+
+  return status;
 }
 
-CredentialsReloadInterface::CredentialsReloadInterface(
-    std::string pem_root_certs, std::string server_private_key,
-    std::string server_cert)
-    : reload_credential_(true),
-      pem_root_certs_(pem_root_certs),
-      server_private_key_(server_private_key),
-      server_cert_(server_cert) {}
+::util::Status CredentialsManager::LoadNewClientCredentials(
+    const std::string& root_certs, const std::string& cert_chain,
+    const std::string& private_key) {
+  ::util::Status status;
+  // TODO(Kevin): Validate the provided key material if possible
+  // TODO(max): According to the API of FileWatcherCertificateProvider, any key
+  // and certifcate update must happen atomically. The below code does not
+  // guarantee that.
+  status.Update(WriteStringToFile(root_certs, FLAGS_ca_cert_file));
+  status.Update(WriteStringToFile(cert_chain, FLAGS_client_cert_file));
+  status.Update(WriteStringToFile(private_key, FLAGS_client_key_file));
+  absl::SleepFor(absl::Seconds(kFileRefreshIntervalSeconds + 1));
 
-int CredentialsReloadInterface::Schedule(TlsCredentialReloadArg* arg) {
-  absl::WriterMutexLock l(&credential_lock_);
-  if (arg == nullptr) {
-    arg->set_status(GRPC_SSL_CERTIFICATE_CONFIG_RELOAD_FAIL);
-    return 1;
-  }
-  if (!reload_credential_) {
-    arg->set_status(GRPC_SSL_CERTIFICATE_CONFIG_RELOAD_UNCHANGED);
-    return 0;
-  }
-
-  TlsKeyMaterialsConfig::PemKeyCertPair pem_key_cert_pair_ = {
-      server_private_key_, server_cert_};
-
-  arg->set_pem_root_certs(pem_root_certs_);
-  arg->add_pem_key_cert_pair(pem_key_cert_pair_);
-  arg->set_status(GRPC_SSL_CERTIFICATE_CONFIG_RELOAD_NEW);
-  reload_credential_ = false;
-  return 0;
-}
-
-void CredentialsReloadInterface::Cancel(TlsCredentialReloadArg* arg) {
-  if (arg == nullptr) return;
-  arg->set_status(GRPC_SSL_CERTIFICATE_CONFIG_RELOAD_FAIL);
-  arg->set_error_details("Cancelled.");
-}
-
-::util::Status CredentialsReloadInterface::LoadNewCredential(
-    const std::string root_certs, const std::string cert_chain,
-    const std::string private_key) {
-  absl::WriterMutexLock l(&credential_lock_);
-  // TODO(Yi): verify if key and cert are valid format
-  CHECK_RETURN_IF_FALSE(!root_certs.empty());
-  CHECK_RETURN_IF_FALSE(!cert_chain.empty());
-  CHECK_RETURN_IF_FALSE(!private_key.empty());
-  pem_root_certs_ = root_certs;
-  server_cert_ = cert_chain;
-  server_private_key_ = private_key;
-  reload_credential_ = true;
-  return ::util::OkStatus();
+  return status;
 }
 
 }  // namespace stratum

--- a/stratum/lib/security/credentials_manager.cc
+++ b/stratum/lib/security/credentials_manager.cc
@@ -60,10 +60,10 @@ CredentialsManager::GenerateExternalFacingClientCredentials() const {
   if (FLAGS_ca_cert_file.empty() && FLAGS_server_key_file.empty() &&
       FLAGS_server_cert_file.empty()) {
     if (secure_only) {
-      LOG(WARNING) << "No crt/key files provided, cannot initiate gRPC server credentials";
+      LOG(WARNING) << "No certificate/key files provided, cannot initiate gRPC server credentials";
       server_credentials_ = nullptr;
     } else {
-      LOG(WARNING) << "No key files provided, using insecure server credentials!";
+      LOG(WARNING) << "No certificate/key files provided, using insecure server credentials!";
       server_credentials_ = ::grpc::InsecureServerCredentials();
     }
   } else {
@@ -84,7 +84,7 @@ CredentialsManager::GenerateExternalFacingClientCredentials() const {
       tls_opts->watch_identity_key_cert_pairs();
       server_credentials_ = TlsServerCredentials(*tls_opts);
     } else {
-      LOG(WARNING) << "Key files provided, but cannot open. Unable to initiate server_credentials.";
+      LOG(ERROR) << "Cannot access certificate/key files. Unable to initiate server_credentials.";
       server_credentials_ = nullptr;
     }
   }
@@ -93,7 +93,7 @@ CredentialsManager::GenerateExternalFacingClientCredentials() const {
   if (FLAGS_ca_cert_file.empty() && FLAGS_client_key_file.empty() &&
       FLAGS_client_cert_file.empty()) {
     if (secure_only) {
-      LOG(WARNING) << "No crt/key files provided, cannot initiate gRPC server credentials";
+      LOG(WARNING) << "No certificate/key files provided, cannot initiate gRPC client credentials";
     } else {
       client_credentials_ = ::grpc::InsecureChannelCredentials();
       LOG(WARNING) << "No key files provided, using insecure client credentials!";
@@ -118,7 +118,7 @@ CredentialsManager::GenerateExternalFacingClientCredentials() const {
       }
       client_credentials_ = ::grpc::experimental::TlsCredentials(*tls_opts);
     } else {
-      LOG(WARNING) << "Key files provided, but cannot open. Unable to initiate client_credentials.";
+      LOG(ERROR) << "Cannot access certificate/key files. Unable to initiate client_credentials.";
       client_credentials_ = nullptr;
     }
   }

--- a/stratum/lib/security/credentials_manager.cc
+++ b/stratum/lib/security/credentials_manager.cc
@@ -67,7 +67,8 @@ CredentialsManager::GenerateExternalFacingClientCredentials() const {
       server_credentials_ = ::grpc::InsecureServerCredentials();
     }
   } else {
-    // Check if certificate files exist/accessible
+    // Verify that the certificate files exist and can be read
+    // If files are not present or not accesible, method will return with nullptr
     std::ifstream ifile1, ifile2, ifile3;
     ifile1.open(FLAGS_server_key_file);
     ifile2.open(FLAGS_server_cert_file);
@@ -99,7 +100,8 @@ CredentialsManager::GenerateExternalFacingClientCredentials() const {
       LOG(WARNING) << "No key files provided, using insecure client credentials!";
     }
   } else {
-    // Check if certificate files exist/accessible
+    // Verify that the certificate files exist and can be read
+    // If files are not present or not accesible, method will return with nullptr
     std::ifstream ifile4, ifile5, ifile6;
     ifile4.open(FLAGS_client_key_file);
     ifile5.open(FLAGS_client_cert_file);

--- a/stratum/lib/security/credentials_manager.h
+++ b/stratum/lib/security/credentials_manager.h
@@ -15,6 +15,9 @@
 #include "stratum/glue/status/status.h"
 #include "stratum/glue/status/statusor.h"
 
+// Declaring the flags in the header file, so that all other files that
+// "#include" the header file already get the flags declared. This is one of
+// the recommended methods of using gflags according to documentation
 DECLARE_string(ca_cert_file);
 DECLARE_string(server_key_file);
 DECLARE_string(server_cert_file);
@@ -50,7 +53,9 @@ class CredentialsManager {
                                                   const std::string& key);
 
   // Factory functions for creating the instance of the class.
-  // If TLS certificates are unavailable, the flag secure_only=false allows insecure_mode for gRPC port
+  // CreateInstance updated to have a flag parameter with a default to false
+  // which maintains backward compatibility. If caller uses secure_only=true
+  // the CredentialsManager will only attempt to initiate using TLS certificates
   static ::util::StatusOr<std::unique_ptr<CredentialsManager>> CreateInstance(bool secure_only=false);
 
   // CredentialsManager is neither copyable nor movable.

--- a/stratum/lib/security/credentials_manager.h
+++ b/stratum/lib/security/credentials_manager.h
@@ -18,6 +18,8 @@
 DECLARE_string(ca_cert_file);
 DECLARE_string(server_key_file);
 DECLARE_string(server_cert_file);
+DECLARE_string(client_key_file);
+DECLARE_string(client_cert_file);
 
 namespace stratum {
 

--- a/stratum/tools/gnmi/gnmi_cli.cc
+++ b/stratum/tools/gnmi/gnmi_cli.cc
@@ -22,6 +22,8 @@
 #include "stratum/lib/security/credentials_manager.h"
 #include "stratum/lib/utils.h"
 
+#define DEFAULT_CERTS_DIR "/usr/share/stratum/certs/"
+
 DEFINE_string(grpc_addr, stratum::kLocalStratumUrl, "gNMI server address");
 DEFINE_string(bool_val, "", "Boolean value to be set");
 DEFINE_string(int_val, "", "Integer value to be set (64-bit)");
@@ -218,6 +220,17 @@ void BuildGnmiPath(std::string path_str, ::gnmi::Path* path) {
 }
 
 ::util::Status Main(int argc, char** argv) {
+
+  // Default certificate file location for TLS-mode
+  FLAGS_ca_cert_file = DEFAULT_CERTS_DIR "ca.crt";
+  FLAGS_server_key_file = DEFAULT_CERTS_DIR "stratum.key";
+  FLAGS_server_cert_file = DEFAULT_CERTS_DIR "stratum.crt";
+  FLAGS_client_key_file = DEFAULT_CERTS_DIR "client.key";
+  FLAGS_client_cert_file = DEFAULT_CERTS_DIR "client.crt";
+
+  // Parse command line flags
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+
   ::gflags::SetUsageMessage(kUsage);
   InitGoogle(argv[0], &argc, &argv, true);
   stratum::InitStratumLogging();

--- a/stratum/tools/gnmi/gnmi_cli.cc
+++ b/stratum/tools/gnmi/gnmi_cli.cc
@@ -1,5 +1,4 @@
 // Copyright 2019-present Open Networking Foundation
-// Copyright 2023 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 #include <csignal>
@@ -251,7 +250,7 @@ void BuildGnmiPath(std::string path_str, ::gnmi::Path* path) {
   });
 
   ASSIGN_OR_RETURN(auto credentials_manager,
-                   CredentialsManager::CreateInstance());
+                   CredentialsManager::CreateInstance(true));
   auto channel = ::grpc::CreateChannel(
       FLAGS_grpc_addr,
       credentials_manager->GenerateExternalFacingClientCredentials());
@@ -328,4 +327,3 @@ void BuildGnmiPath(std::string path_str, ::gnmi::Path* path) {
 int main(int argc, char** argv) {
   return stratum::tools::gnmi::Main(argc, argv).error_code();
 }
-

--- a/stratum/tools/gnmi/gnmi_cli.cc
+++ b/stratum/tools/gnmi/gnmi_cli.cc
@@ -1,4 +1,5 @@
 // Copyright 2019-present Open Networking Foundation
+// Copyright 2023 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 #include <csignal>
@@ -7,34 +8,33 @@
 #include <string>
 #include <vector>
 
-#define STRIP_FLAG_HELP 1  // remove additional flag help text from gflag
+#include "absl/cleanup/cleanup.h"
 #include "gflags/gflags.h"
 #include "gnmi/gnmi.grpc.pb.h"
 #include "grpcpp/grpcpp.h"
 #include "grpcpp/security/credentials.h"
 #include "grpcpp/security/tls_credentials_options.h"
 #include "re2/re2.h"
-#include "stratum/glue/gtl/cleanup.h"
 #include "stratum/glue/init_google.h"
 #include "stratum/glue/status/status.h"
 #include "stratum/glue/status/status_macros.h"
+#include "stratum/lib/constants.h"
 #include "stratum/lib/macros.h"
+#include "stratum/lib/security/credentials_manager.h"
 #include "stratum/lib/utils.h"
 
-DEFINE_string(grpc_addr, "127.0.0.1:9339", "gNMI server address");
+DEFINE_string(grpc_addr, stratum::kLocalStratumUrl, "gNMI server address");
 DEFINE_string(bool_val, "", "Boolean value to be set");
 DEFINE_string(int_val, "", "Integer value to be set (64-bit)");
 DEFINE_string(uint_val, "", "Unsigned integer value to be set (64-bit)");
 DEFINE_string(string_val, "", "String value to be set");
 DEFINE_string(float_val, "", "Floating point value to be set");
 DEFINE_string(bytes_val_file, "", "A file to be sent as bytes value");
+DEFINE_string(proto_bytes, "", "Floating point value to be set");
 
 DEFINE_uint64(interval, 5000, "Subscribe poll interval in ms");
 DEFINE_bool(replace, false, "Use replace instead of update");
 DEFINE_string(get_type, "ALL", "The gNMI get request type");
-DEFINE_string(ca_cert, "", "CA certificate");
-DEFINE_string(client_cert, "", "Client certificate");
-DEFINE_string(client_key, "", "Client key");
 
 #define PRINT_MSG(msg, prompt)                   \
   do {                                           \
@@ -70,7 +70,6 @@ positional arguments:
   path                                              gNMI path
 
 optional arguments:
-  --help            show this help message and exit
   --grpc_addr GRPC_ADDR    gNMI server address
   --bool_val BOOL_VAL      [SetRequest only] Set boolean value
   --int_val INT_VAL        [SetRequest only] Set int value (64-bit)
@@ -81,9 +80,6 @@ optional arguments:
   --interval INTERVAL      [Sample subscribe only] Sample subscribe poll interval in ms
   --replace                [SetRequest only] Use replace instead of update
   --get-type               [GetRequest only] Use specific data type for get request (ALL,CONFIG,STATE,OPERATIONAL)
-  --ca-cert                CA certificate
-  --client-cert            gRPC Client certificate
-  --client-key             gRPC Client key
 )USAGE";
 
 // Pipe file descriptors used to transfer signals from the handler to the cancel
@@ -177,6 +173,8 @@ void BuildGnmiPath(std::string path_str, ::gnmi::Path* path) {
     update->mutable_val()->set_uint_val(stoull(FLAGS_uint_val));
   } else if (!FLAGS_float_val.empty()) {
     update->mutable_val()->set_float_val(stof(FLAGS_float_val));
+  } else if (!FLAGS_proto_bytes.empty()) {
+    update->mutable_val()->set_proto_bytes(FLAGS_proto_bytes);
   } else if (!FLAGS_string_val.empty()) {
     update->mutable_val()->set_string_val(FLAGS_string_val);
   } else if (!FLAGS_bytes_val_file.empty()) {
@@ -226,7 +224,7 @@ void BuildGnmiPath(std::string path_str, ::gnmi::Path* path) {
   stratum::InitStratumLogging();
   if (argc < 2) {
     std::cout << kUsage << std::endl;
-    RETURN_ERROR(ERR_INVALID_PARAM) << "Invalid number of arguments.";
+    return MAKE_ERROR(ERR_INVALID_PARAM) << "Invalid number of arguments.";
   }
 
   ::grpc::ClientContext ctx;
@@ -239,8 +237,8 @@ void BuildGnmiPath(std::string path_str, ::gnmi::Path* path) {
   CHECK_RETURN_IF_FALSE(std::signal(SIGINT, HandleSignal) != SIG_ERR);
   pthread_t context_cancel_tid;
   CHECK_RETURN_IF_FALSE(pthread_create(&context_cancel_tid, nullptr,
-                                       ContextCancelThreadFunc, nullptr) == 0);
-  auto cleaner = gtl::MakeCleanup([&context_cancel_tid, &ctx] {
+                           ContextCancelThreadFunc, nullptr) == 0);
+  auto cleaner = absl::MakeCleanup([&context_cancel_tid, &ctx] {
     int signal = SIGINT;
     write(pipe_write_fd_, &signal, sizeof(signal));
     if (pthread_join(context_cancel_tid, nullptr) != 0) {
@@ -252,37 +250,11 @@ void BuildGnmiPath(std::string path_str, ::gnmi::Path* path) {
     ctx.TryCancel();
   });
 
-  std::shared_ptr<::grpc::ChannelCredentials> channel_credentials =
-      ::grpc::InsecureChannelCredentials();
-#if 0
-  if (!FLAGS_ca_cert.empty()) {
-    ::grpc::string pem_root_certs;
-    ::grpc::experimental::TlsKeyMaterialsConfig::PemKeyCertPair
-        pem_key_cert_pair;
-    auto key_materials_config =
-        std::make_shared<::grpc::experimental::TlsKeyMaterialsConfig>();
-    ::util::Status status;
-    status.Update(::stratum::ReadFileToString(FLAGS_ca_cert, &pem_root_certs));
-    key_materials_config->set_pem_root_certs(pem_root_certs);
-
-    if (!FLAGS_client_cert.empty() && !FLAGS_client_key.empty()) {
-      status.Update(::stratum::ReadFileToString(FLAGS_client_cert,
-                                                &pem_key_cert_pair.cert_chain));
-      status.Update(::stratum::ReadFileToString(
-          FLAGS_client_key, &pem_key_cert_pair.private_key));
-      key_materials_config->add_pem_key_cert_pair(pem_key_cert_pair);
-    }
-
-    auto cred_opts = ::grpc::experimental::TlsCredentialsOptions(
-        GRPC_SSL_DONT_REQUEST_CLIENT_CERTIFICATE, GRPC_TLS_SERVER_VERIFICATION,
-        key_materials_config, nullptr, nullptr);
-
-    if (status.ok()) {
-      channel_credentials = ::grpc::experimental::TlsCredentials(cred_opts);
-    }
-  }
-#endif
-  auto channel = ::grpc::CreateChannel(FLAGS_grpc_addr, channel_credentials);
+  ASSIGN_OR_RETURN(auto credentials_manager,
+                   CredentialsManager::CreateInstance());
+  auto channel = ::grpc::CreateChannel(
+      FLAGS_grpc_addr,
+      credentials_manager->GenerateExternalFacingClientCredentials());
   auto stub = ::gnmi::gNMI::NewStub(channel);
   std::string cmd = std::string(argv[1]);
 
@@ -296,8 +268,8 @@ void BuildGnmiPath(std::string path_str, ::gnmi::Path* path) {
   }
 
   if (argc < 3) {
-    RETURN_ERROR(ERR_INVALID_PARAM)
-        << "Missing path for " << cmd << " request.";
+    return MAKE_ERROR(ERR_INVALID_PARAM)
+           << "Missing path for " << cmd << " request.";
   }
   std::string path = std::string(argv[2]);
 
@@ -323,8 +295,7 @@ void BuildGnmiPath(std::string path_str, ::gnmi::Path* path) {
     auto stream_reader_writer = stub->Subscribe(&ctx);
     ::gnmi::SubscribeRequest req = BuildGnmiSubOnchangeRequest(path);
     PRINT_MSG(req, "REQUEST");
-    CHECK_RETURN_IF_FALSE(stream_reader_writer->Write(req))
-        << "Can not write request.";
+    CHECK_RETURN_IF_FALSE(stream_reader_writer->Write(req)) << "Can not write request.";
     ::gnmi::SubscribeResponse resp;
     while (stream_reader_writer->Read(&resp)) {
       PRINT_MSG(resp, "RESPONSE");
@@ -335,15 +306,14 @@ void BuildGnmiPath(std::string path_str, ::gnmi::Path* path) {
     ::gnmi::SubscribeRequest req =
         BuildGnmiSubSampleRequest(path, FLAGS_interval);
     PRINT_MSG(req, "REQUEST");
-    CHECK_RETURN_IF_FALSE(stream_reader_writer->Write(req))
-        << "Can not write request.";
+    CHECK_RETURN_IF_FALSE(stream_reader_writer->Write(req)) << "Can not write request.";
     ::gnmi::SubscribeResponse resp;
     while (stream_reader_writer->Read(&resp)) {
       PRINT_MSG(resp, "RESPONSE");
     }
     RETURN_IF_GRPC_ERROR(stream_reader_writer->Finish());
   } else {
-    RETURN_ERROR(ERR_INVALID_PARAM) << "Unknown command: " << cmd;
+    return MAKE_ERROR(ERR_INVALID_PARAM) << "Unknown command: " << cmd;
   }
   LOG(INFO) << "Done.";
 
@@ -358,3 +328,4 @@ void BuildGnmiPath(std::string path_str, ::gnmi::Path* path) {
 int main(int argc, char** argv) {
   return stratum::tools::gnmi::Main(argc, argv).error_code();
 }
+

--- a/tools/tls/generate-certs.sh
+++ b/tools/tls/generate-certs.sh
@@ -14,6 +14,7 @@ echo "[ req ]
 default_bits           = 2048
 distinguished_name     = stratum
 prompt                 = no
+req_extensions         = req_ext
 
 [ stratum ]
 C                      = US
@@ -22,28 +23,36 @@ L                      = Menlo Park
 O                      = Open Networking Foundation
 OU                     = Stratum
 CN                     = $COMMON_NAME
+
+[ alternate_names ]
+DNS.1                  = $COMMON_NAME
+
+[ req_ext ]
+subjectAltName         = @alternate_names
 " > "$SERVER_CONF_FILE"
 
 # Generate Private keys and certificates for CA
-openssl genrsa -out "$THIS_DIR/certs/ca.key" 2048
-openssl req -x509 -nodes -new -config "$THIS_DIR/ca.conf" -key "$THIS_DIR/certs/ca.key" \
+openssl genrsa -out "$THIS_DIR/certs/ca.key" 4096
+openssl req -sha512 -x509 -nodes -new -config "$THIS_DIR/ca.conf" -key "$THIS_DIR/certs/ca.key" \
                   -days 365 -out "$THIS_DIR/certs/ca.crt"
 
 # Generate Private keys and certificate signing request(CSR) for Stratum gRPC server
-openssl genrsa -out "$THIS_DIR/certs/stratum.key" 2048
+openssl genrsa -out "$THIS_DIR/certs/stratum.key" 4096
 openssl req -new -config "$SERVER_CONF_FILE" -key "$THIS_DIR/certs/stratum.key" -out "$THIS_DIR/certs/stratum.csr"
 
 # Sing a certificate for Stratum with CA
-openssl x509 -req -in "$THIS_DIR/certs/stratum.csr" -CA "$THIS_DIR/certs/ca.crt" \
+openssl x509 -sha512 -req -in "$THIS_DIR/certs/stratum.csr" -CA "$THIS_DIR/certs/ca.crt" \
              -CAkey "$THIS_DIR/certs/ca.key" -CAcreateserial \
-             -out "$THIS_DIR/certs/stratum.crt" -days 30
+             -out "$THIS_DIR/certs/stratum.crt" -days 30 \
+             -extensions req_ext -extfile "$SERVER_CONF_FILE"
 
 # (Optional) Generate Private keys and certificate for gRPC client
-openssl genrsa -out "$THIS_DIR/certs/client.key" 2048
+openssl genrsa -out "$THIS_DIR/certs/client.key" 4096
 openssl req -new -config "$THIS_DIR/grpc-client.conf" -key "$THIS_DIR/certs/client.key" -out "$THIS_DIR/certs/client.csr"
-openssl x509 -req -in "$THIS_DIR/certs/client.csr" -CA "$THIS_DIR/certs/ca.crt" \
+openssl x509 -sha512 -req -in "$THIS_DIR/certs/client.csr" -CA "$THIS_DIR/certs/ca.crt" \
              -CAkey "$THIS_DIR/certs/ca.key" -CAcreateserial \
              -out "$THIS_DIR/certs/client.crt" -days 30
 
 # Cleanup
 rm "$SERVER_CONF_FILE"
+


### PR DESCRIPTION
Code changes in this PR:
- Enable TLS secure-mode by default
- Allows to user to specify certificate location via flag
- Allows user to launch InfraP4D in insecure mode (this will be a conscious decision by the user if they choose to run in insecure-mode)