### PR TITLE
Generalize krnlmon synchronization logic in DpdkHal

### DIFF
--- a/stratum/hal/bin/tdi/dpdk/dpdk_main.cc
+++ b/stratum/hal/bin/tdi/dpdk/dpdk_main.cc
@@ -10,6 +10,7 @@
 #include <ostream>
 #include <string>
 
+#include "absl/synchronization/notification.h"
 #include "gflags/gflags.h"
 #include "stratum/glue/init_google.h"
 #include "stratum/glue/logging.h"
@@ -44,7 +45,8 @@ namespace stratum {
 namespace hal {
 namespace tdi {
 
-::util::Status DpdkMain(int argc, char* argv[]) {
+::util::Status DpdkMain(int argc, char* argv[], absl::Notification* ready_sync,
+                        absl::Notification* done_sync) {
   // Default value for DPDK.
   FLAGS_chassis_config_file = DEFAULT_CONFIG_PREFIX "dpdk_port_config.pb.txt";
   FLAGS_log_dir = DEFAULT_LOG_DIR;
@@ -138,7 +140,7 @@ namespace tdi {
   auto* hal = DpdkHal::CreateSingleton(
       // NOTE: Shouldn't first parameter be 'mode'?
       stratum::hal::OPERATION_MODE_STANDALONE, dpdk_switch.get(),
-      auth_policy_checker.get());
+      auth_policy_checker.get(), ready_sync, done_sync);
   CHECK_RETURN_IF_FALSE(hal) << "Failed to create the Stratum Hal instance.";
 
   // Set up P4 runtime servers.

--- a/stratum/hal/bin/tdi/dpdk/dpdk_main.h
+++ b/stratum/hal/bin/tdi/dpdk/dpdk_main.h
@@ -5,12 +5,15 @@
 #define STRATUM_HAL_BIN_TDI_DPDK_DPDK_MAIN_H_
 
 #include "stratum/glue/status/status.h"
+#include "absl/synchronization/notification.h"
 
 namespace stratum {
 namespace hal {
 namespace tdi {
 
-::util::Status DpdkMain(int argc, char* argv[]);
+::util::Status DpdkMain(int argc, char* argv[],
+                        absl::Notification* ready_sync = nullptr,
+                        absl::Notification* done_sync = nullptr);
 
 }  // namespace tdi
 }  // namespace hal

--- a/stratum/hal/lib/tdi/dpdk/dpdk_hal.cc
+++ b/stratum/hal/lib/tdi/dpdk/dpdk_hal.cc
@@ -14,22 +14,13 @@
 #include "absl/strings/str_join.h"
 #include "absl/strings/str_split.h"
 #include "absl/synchronization/mutex.h"
+#include "absl/synchronization/notification.h"
 #include "gflags/gflags.h"
 #include "stratum/glue/logging.h"
 #include "stratum/lib/constants.h"
 #include "stratum/lib/macros.h"
-#include "stratum/lib/utils.h"
 #include "stratum/lib/security/credentials_manager.h"
-
-#ifdef KRNLMON_SUPPORT
-extern int rpc_start_cookie;
-extern pthread_cond_t rpc_start_cond;
-extern pthread_mutex_t rpc_start_lock;
-
-extern int rpc_stop_cookie;
-extern pthread_cond_t rpc_stop_cond;
-extern pthread_mutex_t rpc_stop_lock;
-#endif
+#include "stratum/lib/utils.h"
 
 // TODO(unknown): Use FLAG_DEFINE for all flags.
 DEFINE_string(external_stratum_urls, stratum::kExternalStratumUrls,
@@ -53,7 +44,7 @@ DEFINE_uint32(grpc_max_recv_msg_size, 256 * 1024 * 1024,
 DEFINE_uint32(grpc_max_send_msg_size, 0,
               "grpc server max send message size (0 = gRPC default).");
 DEFINE_bool(grpc_open_insecure_mode, false,
-              "grpc open server ports in insecure mode for gNMI, gNOI & P4RT (false = closed)");
+            "open grpc server ports in insecure mode for gNMI, gNOI, and P4RT");
 
 DECLARE_string(forwarding_pipeline_configs_file);
 
@@ -98,7 +89,9 @@ int DpdkHal::pipe_read_fd_ = -1;
 int DpdkHal::pipe_write_fd_ = -1;
 
 DpdkHal::DpdkHal(OperationMode mode, SwitchInterface* switch_interface,
-                 AuthPolicyChecker* auth_policy_checker)
+                 AuthPolicyChecker* auth_policy_checker,
+                 absl::Notification* ready_sync,
+                 absl::Notification* done_sync)
     : mode_(mode),
       switch_interface_(ABSL_DIE_IF_NULL(switch_interface)),
       auth_policy_checker_(ABSL_DIE_IF_NULL(auth_policy_checker)),
@@ -107,7 +100,9 @@ DpdkHal::DpdkHal(OperationMode mode, SwitchInterface* switch_interface,
       p4_service_(nullptr),
       external_server_(nullptr),
       old_signal_handlers_(),
-      signal_waiter_tid_(0) {}
+      signal_waiter_tid_(0),
+      ready_sync_(ready_sync),
+      done_sync_(done_sync) {}
 
 DpdkHal::~DpdkHal() {
   // TODO(unknown): Handle this error?
@@ -276,26 +271,19 @@ DpdkHal::~DpdkHal() {
                << FLAGS_local_stratum_url << "...";
   }
 
-#ifdef KRNLMON_SUPPORT
-  //Notify the krnlmon start thread that stratum server is listening
-  pthread_mutex_lock(&rpc_start_lock);
-  rpc_start_cookie = 1;
-  pthread_cond_signal(&rpc_start_cond);
-  pthread_mutex_unlock(&rpc_start_lock);
-#endif
+  // Signal that the server is listening.
+  if (ready_sync_ != nullptr) {
+    ready_sync_->Notify();
+  }
 
   // Block until external_server_->Shutdown() is called.
   // We don't wait on internal_service.
   external_server_->Wait();
 
-#ifdef KRNLMON_SUPPORT
-  //Notify the krnlmon stop thread that stratum server has stopped
-  pthread_mutex_lock(&rpc_stop_lock);
-  rpc_stop_cookie = 1;
-  pthread_cond_signal(&rpc_stop_cond);
-  pthread_mutex_unlock(&rpc_stop_lock);
-#endif
-
+  // Signal that the server is terminating.
+  if (done_sync_ != nullptr) {
+    done_sync_->Notify();
+  }
 
   return Teardown();
 }
@@ -312,16 +300,20 @@ void DpdkHal::HandleSignal(int value) {
 
 DpdkHal* DpdkHal::CreateSingleton(OperationMode mode,
                                   SwitchInterface* switch_interface,
-                                  AuthPolicyChecker* auth_policy_checker) {
+                                  AuthPolicyChecker* auth_policy_checker,
+                                  absl::Notification* ready_sync,
+                                  absl::Notification* done_sync) {
   absl::WriterMutexLock l(&init_lock_);
   if (!singleton_) {
-    singleton_ = new DpdkHal(mode, switch_interface, auth_policy_checker);
+    singleton_ = new DpdkHal(mode, switch_interface, auth_policy_checker,
+                             ready_sync, done_sync);
 
     ::util::Status status = singleton_->RegisterSignalHandlers();
     if (!status.ok()) {
       LOG(ERROR) << "RegisterSignalHandlers() failed: " << status;
       delete singleton_;
       singleton_ = nullptr;
+      return nullptr;
     }
 
     status = singleton_->InitializeServer();

--- a/stratum/hal/lib/tdi/dpdk/dpdk_hal.h
+++ b/stratum/hal/lib/tdi/dpdk/dpdk_hal.h
@@ -18,6 +18,7 @@
 #include "absl/base/thread_annotations.h"
 #include "absl/container/flat_hash_map.h"
 #include "absl/synchronization/mutex.h"
+#include "absl/synchronization/notification.h"
 #include "grpcpp/grpcpp.h"
 #include "stratum/hal/lib/common/common.pb.h"
 #include "stratum/hal/lib/common/config_monitoring_service.h"
@@ -78,7 +79,9 @@ class DpdkHal final {
   // the instance.
   static DpdkHal* CreateSingleton(OperationMode mode,
                                   SwitchInterface* switch_interface,
-                                  AuthPolicyChecker* auth_policy_checker)
+                                  AuthPolicyChecker* auth_policy_checker,
+                                  absl::Notification* ready_sync = nullptr,
+                                  absl::Notification* done_sync = nullptr)
       LOCKS_EXCLUDED(init_lock_);
 
   // Return the singleton instance to be used in the signal handler..
@@ -96,7 +99,9 @@ class DpdkHal final {
   // Private constructor. Use CreateInstance() to create an instance of this
   // class.
   DpdkHal(OperationMode mode, SwitchInterface* switch_interface,
-          AuthPolicyChecker* auth_policy_checker);
+          AuthPolicyChecker* auth_policy_checker,
+          absl::Notification* ready_sync,
+          absl::Notification* done_sync);
 
   // Initializes the HAL server and all the services it provides. Called in
   // CreateSingleton() as soon as the class instance is created.
@@ -106,7 +111,7 @@ class DpdkHal final {
   ::util::Status RegisterSignalHandlers();
   ::util::Status UnregisterSignalHandlers();
 
-  // Thread function waiting for a signal in the pipe and then initialting the
+  // Thread function waiting for a signal in the pipe and then initiating the
   // HAL shutdown.
   static void* SignalWaiterThreadFunc(void*);
 
@@ -146,6 +151,12 @@ class DpdkHal final {
 
   // Thread id for the signal waiter thread.
   pthread_t signal_waiter_tid_;
+
+  // Object to signal when Hal is ready. Not owned by this class.
+  absl::Notification* ready_sync_;
+
+  // Object to signal when Hal is done. Not owned by this class;
+  absl::Notification* done_sync_;
 
   // The lock used for initialization of the singleton.
   static absl::Mutex init_lock_;


### PR DESCRIPTION
- Generalized the logic used to synchronize DpdkHal with krnlmon by replacing the global pthread variables with optional pointers to absl::Notification objects passed to the DpdkHal constructor.

Signed-off-by: Derek G Foster <derek.foster@intel.com>