### PR TITLE
Check for symbolic links before accessing files from filesystem

### DIFF
--- a/stratum/hal/lib/common/config_monitoring_service.cc
+++ b/stratum/hal/lib/common/config_monitoring_service.cc
@@ -95,8 +95,10 @@ ConfigMonitoringService::~ConfigMonitoringService() {
   // config push will initialize the switch if it is done for the first time.
   LOG(INFO) << "Pushing the saved chassis config read from "
             << FLAGS_chassis_config_file << "...";
-  // Verify that FLAGS_chassis_config_file is a regular file and not a symlink
-  RETURN_IF_ERROR(VerifyRegularFile(FLAGS_chassis_config_file));
+  if (!IsRegularFile(FLAGS_chassis_config_file)) {
+    return MAKE_ERROR(ERR_INVALID_PARAM)
+          << "'"<< FLAGS_chassis_config_file << "' is not a regular file";
+  }
   auto config = absl::make_unique<ChassisConfig>();
   ::util::Status status =
       ReadProtoFromTextFile(FLAGS_chassis_config_file, config.get());

--- a/stratum/hal/lib/common/config_monitoring_service.cc
+++ b/stratum/hal/lib/common/config_monitoring_service.cc
@@ -21,6 +21,7 @@
 #include "stratum/glue/status/status_macros.h"
 #include "stratum/hal/lib/common/gnmi_publisher.h"
 #include "stratum/hal/lib/common/openconfig_converter.h"
+#include "stratum/hal/lib/common/utils.h"
 #include "stratum/lib/macros.h"
 #include "stratum/lib/utils.h"
 #include "stratum/public/lib/error.h"
@@ -94,6 +95,8 @@ ConfigMonitoringService::~ConfigMonitoringService() {
   // config push will initialize the switch if it is done for the first time.
   LOG(INFO) << "Pushing the saved chassis config read from "
             << FLAGS_chassis_config_file << "...";
+  // Verify that FLAGS_chassis_config_file is a regular file and not a symlink
+  RETURN_IF_ERROR(VerifyRegularFile(FLAGS_chassis_config_file));
   auto config = absl::make_unique<ChassisConfig>();
   ::util::Status status =
       ReadProtoFromTextFile(FLAGS_chassis_config_file, config.get());

--- a/stratum/hal/lib/common/utils.cc
+++ b/stratum/hal/lib/common/utils.cc
@@ -479,16 +479,10 @@ std::string ConvertLogSeverityToString(const LoggingConfig& logging_config) {
   }
 }
 
-::util::Status VerifyRegularFile(const std::string& filename) {
+bool IsRegularFile(const std::string& filename) {
     struct stat buf;
-    int x;
-    x = lstat (filename.c_str(), &buf);
-    if (S_ISREG(buf.st_mode)) {
-      return ::util::OkStatus();
-    }
-  
-    return MAKE_ERROR(ERR_INTERNAL)
-      << filename << " is not a regular file!";
+    int rc = lstat(filename.c_str(), &buf);
+    return (rc==0 && S_ISREG(buf.st_mode));
 }
 
 

--- a/stratum/hal/lib/common/utils.cc
+++ b/stratum/hal/lib/common/utils.cc
@@ -480,9 +480,9 @@ std::string ConvertLogSeverityToString(const LoggingConfig& logging_config) {
 }
 
 bool IsRegularFile(const std::string& filename) {
-    struct stat buf;
-    int rc = lstat(filename.c_str(), &buf);
-    return (rc==0 && S_ISREG(buf.st_mode));
+  struct stat buf;
+  int rc = lstat(filename.c_str(), &buf);
+  return (rc==0 && S_ISREG(buf.st_mode));
 }
 
 

--- a/stratum/hal/lib/common/utils.cc
+++ b/stratum/hal/lib/common/utils.cc
@@ -8,6 +8,7 @@
 #include <cmath>
 #include <regex>    // NOLINT
 #include <sstream>  // IWYU pragma: keep
+#include <sys/stat.h>
 
 #include "stratum/lib/constants.h"
 #include "stratum/lib/macros.h"
@@ -477,6 +478,19 @@ std::string ConvertLogSeverityToString(const LoggingConfig& logging_config) {
     return "UNKNOWN";
   }
 }
+
+::util::Status VerifyRegularFile(const std::string& filename) {
+    struct stat buf;
+    int x;
+    x = lstat (filename.c_str(), &buf);
+    if (S_ISREG(buf.st_mode)) {
+      return ::util::OkStatus();
+    }
+  
+    return MAKE_ERROR(ERR_INTERNAL)
+      << filename << " is not a regular file!";
+}
+
 
 }  // namespace hal
 }  // namespace stratum

--- a/stratum/hal/lib/common/utils.h
+++ b/stratum/hal/lib/common/utils.h
@@ -248,9 +248,8 @@ std::string ConvertLogSeverityToString(const LoggingConfig& logging_config);
 ::util::Status ConvertStringToLogSeverity(const std::string& severity_string,
                                           LoggingConfig* logging_config);
 
-// Verify filename is a regular file. This performs an lstat() on specified file
-// and checks if it is a regular file and not a symlink to an unknown file.
-::util::Status VerifyRegularFile(const std::string& filename);
+// Checks whether filename is a regular file and not a symlink
+bool IsRegularFile(const std::string& filename);
 
 }  // namespace hal
 }  // namespace stratum

--- a/stratum/hal/lib/common/utils.h
+++ b/stratum/hal/lib/common/utils.h
@@ -248,6 +248,10 @@ std::string ConvertLogSeverityToString(const LoggingConfig& logging_config);
 ::util::Status ConvertStringToLogSeverity(const std::string& severity_string,
                                           LoggingConfig* logging_config);
 
+// Verify filename is a regular file. This performs an lstat() on specified file
+// and checks if it is a regular file and not a symlink to an unknown file.
+::util::Status VerifyRegularFile(const std::string& filename);
+
 }  // namespace hal
 }  // namespace stratum
 

--- a/stratum/lib/security/credentials_manager.cc
+++ b/stratum/lib/security/credentials_manager.cc
@@ -69,9 +69,9 @@ CredentialsManager::GenerateExternalFacingClientCredentials() const {
   } else {
     // Verify that the certificate files exist and are regular (non-symlink) files
     // If files are not present or not accesible, method will return with nullptr
-    if (stratum::hal::VerifyRegularFile(FLAGS_ca_cert_file) == ::util::OkStatus() &&
-        stratum::hal::VerifyRegularFile(FLAGS_server_cert_file) == ::util::OkStatus() &&
-        stratum::hal::VerifyRegularFile(FLAGS_server_key_file) == ::util::OkStatus()) {
+    if (stratum::hal::IsRegularFile(FLAGS_ca_cert_file) &&
+        stratum::hal::IsRegularFile(FLAGS_server_cert_file) &&
+        stratum::hal::IsRegularFile(FLAGS_server_key_file)) {
       auto certificate_provider =
           std::make_shared<FileWatcherCertificateProvider>(
               FLAGS_server_key_file, FLAGS_server_cert_file, FLAGS_ca_cert_file,
@@ -100,9 +100,9 @@ CredentialsManager::GenerateExternalFacingClientCredentials() const {
   } else {
     // Verify that the certificate files exist and are regular (non-symlink) files
     // If files are not present or not accesible, method will return with nullptr
-    if (stratum::hal::VerifyRegularFile(FLAGS_ca_cert_file) == ::util::OkStatus() &&
-        stratum::hal::VerifyRegularFile(FLAGS_client_cert_file) == ::util::OkStatus() &&
-        stratum::hal::VerifyRegularFile(FLAGS_client_key_file) == ::util::OkStatus()) {
+    if (stratum::hal::IsRegularFile(FLAGS_ca_cert_file) &&
+        stratum::hal::IsRegularFile(FLAGS_client_cert_file) &&
+        stratum::hal::IsRegularFile(FLAGS_client_key_file)) {
       auto certificate_provider =
           std::make_shared<FileWatcherCertificateProvider>(
               FLAGS_client_key_file, FLAGS_client_cert_file, FLAGS_ca_cert_file,


### PR DESCRIPTION
This checks if the files being accessed are regular files. If they are symbolic files linking to other files, we avoid opening them as this may be a security risk.

Signed-off-by: Sabeel Ansari <sabeel.ansari@intel.com>