### PR TITLE
Update CredentialsManager for client certification verification

### DIFF
--- a/stratum/hal/bin/tdi/dpdk/dpdk_main.cc
+++ b/stratum/hal/bin/tdi/dpdk/dpdk_main.cc
@@ -74,6 +74,9 @@ namespace tdi {
   FLAGS_client_key_file = DEFAULT_CERTS_DIR "client.key";
   FLAGS_client_cert_file = DEFAULT_CERTS_DIR "client.crt";
 
+  // Overriding Stratum default to a stricter client certificate verification
+  FLAGS_grpc_client_cert_req_type = "REQUIRE_CLIENT_CERT_AND_VERIFY";
+
   // Parse command line flags
   gflags::ParseCommandLineFlags(&argc, &argv, true);
 

--- a/stratum/lib/security/credentials_manager.cc
+++ b/stratum/lib/security/credentials_manager.cc
@@ -26,11 +26,11 @@ DEFINE_string(client_key_file, "", "Path to gRPC client key file");
 DEFINE_string(client_cert_file, "", "Path to gRPC client certificate file");
 
 DEFINE_string(grpc_client_cert_req_type, "NO_REQUEST_CLIENT_CERT",
-              "TLS server credentials option for client certificate verification. \
-              Available options are: \
-              NO_REQUEST_CLIENT_CERT, REQUEST_CLIENT_CERT_NO_VERIFY, \
-              REQUEST_CLIENT_CERT_AND_VERIFY,  REQUIRE_CLIENT_CERT_NO_VERIFY, \
-              REQUIRE_CLIENT_CERT_AND_VERIFY");
+              "TLS server credentials option for client certificate verification. "
+              "Available options are: "
+              "NO_REQUEST_CLIENT_CERT, REQUEST_CLIENT_CERT_NO_VERIFY, "
+              "REQUEST_CLIENT_CERT_AND_VERIFY,  REQUIRE_CLIENT_CERT_NO_VERIFY, "
+              "REQUIRE_CLIENT_CERT_AND_VERIFY");
 
 namespace stratum {
 
@@ -41,27 +41,9 @@ using ::grpc::experimental::TlsServerCredentialsOptions;
 
 constexpr unsigned int CredentialsManager::kFileRefreshIntervalSeconds;
 
-CredentialsManager::CredentialsManager()
-  : client_cert_verification_map_() {
-    InitClientCertVerificationMap();
-}
+CredentialsManager::CredentialsManager() {}
 
 CredentialsManager::~CredentialsManager() {}
-
-::util::Status CredentialsManager::InitClientCertVerificationMap() {
-  client_cert_verification_map_["NO_REQUEST_CLIENT_CERT"] =
-    GRPC_SSL_DONT_REQUEST_CLIENT_CERTIFICATE;
-  client_cert_verification_map_["REQUEST_CLIENT_CERT_NO_VERIFY"] =
-    GRPC_SSL_REQUEST_CLIENT_CERTIFICATE_BUT_DONT_VERIFY;
-  client_cert_verification_map_["REQUEST_CLIENT_CERT_AND_VERIFY"] =
-    GRPC_SSL_REQUEST_CLIENT_CERTIFICATE_AND_VERIFY;
-  client_cert_verification_map_["REQUIRE_CLIENT_CERT_NO_VERIFY"] =
-    GRPC_SSL_REQUEST_AND_REQUIRE_CLIENT_CERTIFICATE_BUT_DONT_VERIFY;
-  client_cert_verification_map_["REQUIRE_CLIENT_CERT_AND_VERIFY"] =
-    GRPC_SSL_REQUEST_AND_REQUIRE_CLIENT_CERTIFICATE_AND_VERIFY;
-
-  return ::util::OkStatus();
-}
 
 ::util::StatusOr<std::unique_ptr<CredentialsManager>>
 CredentialsManager::CreateInstance(bool secure_only /*=false*/) {

--- a/stratum/lib/security/credentials_manager.h
+++ b/stratum/lib/security/credentials_manager.h
@@ -73,11 +73,14 @@ class CredentialsManager {
  private:
   static constexpr unsigned int kFileRefreshIntervalSeconds = 1;
 
-  std::map<std::string, grpc_ssl_client_certificate_request_type>
-    client_cert_verification_map_;
-
-  // Function to initialize the certificate verification map
-  ::util::Status InitClientCertVerificationMap();
+  const std::map<std::string, grpc_ssl_client_certificate_request_type>
+    client_cert_verification_map_ = {
+      {"NO_REQUEST_CLIENT_CERT", GRPC_SSL_DONT_REQUEST_CLIENT_CERTIFICATE},
+      {"REQUEST_CLIENT_CERT_NO_VERIFY", GRPC_SSL_REQUEST_CLIENT_CERTIFICATE_BUT_DONT_VERIFY},
+      {"REQUEST_CLIENT_CERT_AND_VERIFY", GRPC_SSL_REQUEST_CLIENT_CERTIFICATE_AND_VERIFY},
+      {"REQUIRE_CLIENT_CERT_NO_VERIFY", GRPC_SSL_REQUEST_AND_REQUIRE_CLIENT_CERTIFICATE_BUT_DONT_VERIFY},
+      {"REQUIRE_CLIENT_CERT_AND_VERIFY", GRPC_SSL_REQUEST_AND_REQUIRE_CLIENT_CERTIFICATE_AND_VERIFY}
+    };
 
   // Function to initialize the credentials manager.
   ::util::Status Initialize(bool secure_only);

--- a/stratum/lib/security/credentials_manager.h
+++ b/stratum/lib/security/credentials_manager.h
@@ -9,9 +9,11 @@
 #include <memory>
 #include <string>
 
+#include "grpc/grpc_security_constants.h"
 #include "grpcpp/grpcpp.h"
 #include "grpcpp/security/server_credentials.h"
 #include "grpcpp/security/tls_credentials_options.h"
+#include "stratum/glue/gtl/map_util.h"
 #include "stratum/glue/status/status.h"
 #include "stratum/glue/status/statusor.h"
 
@@ -23,6 +25,7 @@ DECLARE_string(server_key_file);
 DECLARE_string(server_cert_file);
 DECLARE_string(client_key_file);
 DECLARE_string(client_cert_file);
+DECLARE_string(grpc_client_cert_req_type);
 
 namespace stratum {
 
@@ -69,6 +72,12 @@ class CredentialsManager {
 
  private:
   static constexpr unsigned int kFileRefreshIntervalSeconds = 1;
+
+  std::map<std::string, grpc_ssl_client_certificate_request_type>
+    client_cert_verification_map_;
+
+  // Function to initialize the certificate verification map
+  ::util::Status InitClientCertVerificationMap();
 
   // Function to initialize the credentials manager.
   ::util::Status Initialize(bool secure_only);


### PR DESCRIPTION
Default Stratum started gRPC server with `GRPC_SSL_DONT_REQUEST_CLIENT_CERTIFICATE`. This is the weakest form of security, where the client certificate is not required from the server.

Updating to use a gflag where user can specify security level, with a default of `GRPC_SSL_REQUEST_AND_REQUIRE_CLIENT_CERTIFICATE_AND_VERIFY` in dpdk_main.cc

Signed-off-by: Sabeel Ansari <sabeel.ansari@intel.com>