### PR TITLE
Address Klocwork issues in stratum constructors

### DIFF
--- a/stratum/hal/lib/p4/p4_info_manager.cc
+++ b/stratum/hal/lib/p4/p4_info_manager.cc
@@ -36,7 +36,8 @@ P4InfoManager::P4InfoManager(const ::p4::config::v1::P4Info& p4_info)
       direct_meter_map_("Direct-Meter"),
       meter_map_("Meter"),
       value_set_map_("ValueSet"),
-      register_map_("Register") {}
+      register_map_("Register"),
+      all_resource_ids_() {}
 
 P4InfoManager::P4InfoManager()
     : table_map_("Table"),
@@ -47,7 +48,8 @@ P4InfoManager::P4InfoManager()
       direct_meter_map_("Direct-Meter"),
       meter_map_("Meter"),
       value_set_map_("ValueSet"),
-      register_map_("Register") {}
+      register_map_("Register"),
+      all_resource_ids_() {}
 
 P4InfoManager::~P4InfoManager() {}
 

--- a/stratum/hal/lib/tdi/tdi_sde_wrapper.cc
+++ b/stratum/hal/lib/tdi/tdi_sde_wrapper.cc
@@ -45,6 +45,7 @@ TdiSdeWrapper* TdiSdeWrapper::singleton_ = nullptr;
 ABSL_CONST_INIT absl::Mutex TdiSdeWrapper::init_lock_(absl::kConstInit);
 
 TdiSdeWrapper::TdiSdeWrapper() : port_status_event_writer_(nullptr),
+                                 device_to_packet_rx_writer_(),
                                  tdi_info_(nullptr) {}
 
 // Create and start an new session.


### PR DESCRIPTION
- Explicitly initialize data members in constructors.

Signed-off-by: Derek G Foster <derek.foster@intel.com>