### PR TITLE
Address Klocwork issues in DpdkHal::InitializeServer

### DIFF
--- a/stratum/hal/lib/tdi/dpdk/dpdk_hal.cc
+++ b/stratum/hal/lib/tdi/dpdk/dpdk_hal.cc
@@ -348,9 +348,9 @@ DpdkHal* DpdkHal::GetSingleton() {
   }
 
 ::util::Status DpdkHal::InitializeServer() {
-  CHECK_IS_NULL(config_monitoring_service_);
-  CHECK_IS_NULL(p4_service_);
-  CHECK_IS_NULL(external_server_);
+  CHECK_IS_NULL(config_monitoring_service_.get());
+  CHECK_IS_NULL(p4_service_.get());
+  CHECK_IS_NULL(external_server_.get());
   // FIXME(boc) google only
   // CHECK_IS_NULL(internal_server_);
 


### PR DESCRIPTION
Klocwork reports LOCRET.ARG ("Address of a local variable is returned through formal argument") when CHECK_IS_NULL() is performed on a std::unique_ptr. Attempt to resolve this by checking ptr.get() instead of ptr.

Signed-off-by: Derek G Foster <derek.foster@intel.com>