### PR TITLE
Generalize krnlmon synchronization logic in DpdkHal

### DIFF
--- a/stratum/hal/bin/tdi/dpdk/dpdk_main.cc
+++ b/stratum/hal/bin/tdi/dpdk/dpdk_main.cc
@@ -49,7 +49,7 @@ static void SetDefault(const char *name, const char *value) {
   ::gflags::SetCommandLineOptionWithMode(name, value, ::gflags::SET_FLAGS_DEFAULT);
 }
 
-void InitCommandLineFlags() {
+static void InitCommandLineFlags() {
   // Chassis config file
   SetDefault("chassis_config_file", DEFAULT_CONFIG_DIR "dpdk_port_config.pb.txt");
 
@@ -69,16 +69,16 @@ void InitCommandLineFlags() {
   SetDefault("grpc_client_cert_req_type", "REQUIRE_CLIENT_CERT_AND_VERIFY");
 }
 
-void ParseCommandLine(int argc, char* argv[]) {
-  // Set our own default flag values
+void ParseCommandLine(int argc, char* argv[], bool remove_flags) {
+  // Set our own default values
   InitCommandLineFlags();
 
   // Parse command-line flags
-  gflags::ParseCommandLineFlags(&argc, &argv, true);
+  gflags::ParseCommandLineFlags(&argc, &argv, remove_flags);
 }
 
 ::util::Status DpdkMain(int argc, char* argv[]) {
-  ParseCommandLine(argc, argv);
+  ParseCommandLine(argc, argv, true);
   return DpdkMain(nullptr, nullptr);
 }
 

--- a/stratum/hal/bin/tdi/dpdk/dpdk_main.cc
+++ b/stratum/hal/bin/tdi/dpdk/dpdk_main.cc
@@ -45,34 +45,45 @@ namespace stratum {
 namespace hal {
 namespace tdi {
 
-static void InitCommandLineFlags() {
-  // Chassis config file
-  FLAGS_chassis_config_file = DEFAULT_CONFIG_DIR "dpdk_port_config.pb.txt";
-
-  // Logging options
-  FLAGS_log_dir = DEFAULT_LOG_DIR;
-  FLAGS_logtostderr = false;
-  FLAGS_alsologtostderr = false;
-
-  // Certificate options
-  FLAGS_ca_cert_file = DEFAULT_CERTS_DIR "ca.crt";
-  FLAGS_server_key_file = DEFAULT_CERTS_DIR "stratum.key";
-  FLAGS_server_cert_file = DEFAULT_CERTS_DIR "stratum.crt";
-  FLAGS_client_key_file = DEFAULT_CERTS_DIR "client.key";
-  FLAGS_client_cert_file = DEFAULT_CERTS_DIR "client.crt";
-
-  // Client certificate verification requirement
-  FLAGS_grpc_client_cert_req_type = "REQUIRE_CLIENT_CERT_AND_VERIFY";
+static void SetDefault(const char *name, const char *value) {
+  ::gflags::SetCommandLineOptionWithMode(name, value, ::gflags::SET_FLAGS_DEFAULT);
 }
 
-::util::Status DpdkMain(int argc, char* argv[], absl::Notification* ready_sync,
-                        absl::Notification* done_sync) {
+void InitCommandLineFlags() {
+  // Chassis config file
+  SetDefault("chassis_config_file", DEFAULT_CONFIG_DIR "dpdk_port_config.pb.txt");
+
+  // Logging options
+  SetDefault("log_dir", DEFAULT_LOG_DIR);
+  SetDefault("logtostderr", "false");
+  SetDefault("alsologtostderr", "false");
+
+  // Certificate options
+  SetDefault("ca_cert_file", DEFAULT_CERTS_DIR "ca.crt");
+  SetDefault("server_key_file", DEFAULT_CERTS_DIR "stratum.key");
+  SetDefault("server_cert_file", DEFAULT_CERTS_DIR "stratum.crt");
+  SetDefault("client_key_file", DEFAULT_CERTS_DIR "client.key");
+  SetDefault("client_cert_file", DEFAULT_CERTS_DIR "client.crt");
+
+  // Client certificate verification requirement
+  SetDefault("grpc_client_cert_req_type", "REQUIRE_CLIENT_CERT_AND_VERIFY");
+}
+
+void ParseCommandLine(int argc, char* argv[]) {
   // Set our own default flag values
   InitCommandLineFlags();
 
   // Parse command-line flags
   gflags::ParseCommandLineFlags(&argc, &argv, true);
+}
 
+::util::Status DpdkMain(int argc, char* argv[]) {
+  ParseCommandLine(argc, argv);
+  return DpdkMain(nullptr, nullptr);
+}
+
+::util::Status DpdkMain(absl::Notification* ready_sync,
+                        absl::Notification* done_sync) {
   InitStratumLogging();
 
   // TODO(antonin): The SDE expects 0-based device ids, so we instantiate

--- a/stratum/hal/bin/tdi/dpdk/dpdk_main.h
+++ b/stratum/hal/bin/tdi/dpdk/dpdk_main.h
@@ -16,7 +16,7 @@ namespace tdi {
 ::util::Status DpdkMain(absl::Notification* ready_sync = nullptr,
                         absl::Notification* done_sync = nullptr);
 
-void InitCommandLineFlags();
+void ParseCommandLine(int argc, char* argv[], bool remove_flags);
 
 } // namespace tdi
 } // namespace hal

--- a/stratum/hal/bin/tdi/dpdk/dpdk_main.h
+++ b/stratum/hal/bin/tdi/dpdk/dpdk_main.h
@@ -11,12 +11,15 @@ namespace stratum {
 namespace hal {
 namespace tdi {
 
-::util::Status DpdkMain(int argc, char* argv[],
-                        absl::Notification* ready_sync = nullptr,
+::util::Status DpdkMain(int argc, char* argv[]);
+
+::util::Status DpdkMain(absl::Notification* ready_sync = nullptr,
                         absl::Notification* done_sync = nullptr);
 
-}  // namespace tdi
-}  // namespace hal
-}  // namespace stratum
+void InitCommandLineFlags();
+
+} // namespace tdi
+} // namespace hal
+} // namespace stratum
 
 #endif  // STRATUM_HAL_BIN_TDI_DPDK_DPDK_MAIN_H_

--- a/stratum/hal/bin/tdi/dpdk/dpdk_main.h
+++ b/stratum/hal/bin/tdi/dpdk/dpdk_main.h
@@ -1,16 +1,19 @@
-// Copyright 2022 Intel Corporation
+// Copyright 2022-2023 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 #ifndef STRATUM_HAL_BIN_TDI_DPDK_DPDK_MAIN_H_
 #define STRATUM_HAL_BIN_TDI_DPDK_DPDK_MAIN_H_
 
 #include "stratum/glue/status/status.h"
+#include "absl/synchronization/notification.h"
 
 namespace stratum {
 namespace hal {
 namespace tdi {
 
-::util::Status DpdkMain(int argc, char* argv[]);
+::util::Status DpdkMain(int argc, char* argv[],
+                        absl::Notification* ready_sync = nullptr,
+                        absl::Notification* done_sync = nullptr);
 
 }  // namespace tdi
 }  // namespace hal

--- a/stratum/lib/security/credentials_manager.cc
+++ b/stratum/lib/security/credentials_manager.cc
@@ -27,10 +27,9 @@ DEFINE_string(client_cert_file, "", "Path to gRPC client certificate file");
 
 DEFINE_string(grpc_client_cert_req_type, "NO_REQUEST_CLIENT_CERT",
               "TLS server credentials option for client certificate verification. "
-              "Available options are: "
-              "NO_REQUEST_CLIENT_CERT, REQUEST_CLIENT_CERT_NO_VERIFY, "
-              "REQUEST_CLIENT_CERT_AND_VERIFY,  REQUIRE_CLIENT_CERT_NO_VERIFY, "
-              "REQUIRE_CLIENT_CERT_AND_VERIFY");
+              "Available options are: NO_REQUEST_CLIENT_CERT, "
+              "REQUEST_CLIENT_CERT_NO_VERIFY, REQUEST_CLIENT_CERT_AND_VERIFY, "
+              "REQUIRE_CLIENT_CERT_NO_VERIFY, REQUIRE_CLIENT_CERT_AND_VERIFY");
 
 namespace stratum {
 


### PR DESCRIPTION
- Replaced pthreads variables with `absl::Notification` objects. This simplifies the interface and replaces it with a native C++ implementation.

- Passed Notification objects as parameters instead of using global variables. Global variables create hidden coupling between components, reduce maintainability, make it more difficult to reason about the state of the system, and interfere with unit testing. Dependency injection is the preferred design pattern.

- Passed Notification objects by pointer, with non-null pointer values being used to determine whether to perform synchronization. This removes the need for conditional compilation, simplifying the code, and making it more maintainable.

- Refactored command-line flag initialization into a separate function.

This changelist must be coordinated with changes in the krnlmon submodule and the superproject.

Signed-off-by: Derek G Foster <derek.foster@intel.com>