### PR TITLE
Update configuration file with config queue parameter

### DIFF
--- a/stratum/hal/bin/tdi/es2k/es2k_skip_p4.conf
+++ b/stratum/hal/bin/tdi/es2k/es2k_skip_p4.conf
@@ -9,6 +9,7 @@
     }
     ],
     "instance": 0,
+    "cfgqs-idx": "0-15",
     "p4_devices": [
     {
         "device-id": 0,


### PR DESCRIPTION
New SDE changes expects application to specify number of configure queues to be used. This PR updates configuration file with parameter introduced for this purpose.

If you want 16 cfgqs, use "cfgqs-idx": "0-15". Specify the range as a string. Index numbers from 0 to 15 are supported.

In multi process environment, user should plan and split the queues between primary and secondary processes and specify the range with cfgqs-idx parameter. Total number of queues split between processes should not exceed 16.