### PR TITLE
 Update gRPC to v1.54.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,9 @@ set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)
 # Suppress "warning: attribute ignored" on ABSL_MUST_USE_RESULT [[nodiscard]]
 add_compile_options(-Wno-attributes)
 
+# Suppress "warning: <symbol> is deprecated"
+add_compile_options(-Wno-deprecated-declarations)
+
 add_subdirectory(stratum)
 
 #######################
@@ -99,6 +102,7 @@ function(add_stratum_google_libs _TGT)
     target_link_libraries(${_TGT} PUBLIC
         glog
         gflags
+        gpr
         grpc
         protobuf
         grpc++


### PR DESCRIPTION
- Add gpr to list of link libraries required by libstratum. This is needed to build against gRPC v1.54.2.

- Suppress "&lt;symbol&gt; is deprecated" warning.