### PR TITLE
Localize no-deprecated-declarations flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,9 +36,6 @@ set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)
 # Suppress "warning: attribute ignored" on ABSL_MUST_USE_RESULT [[nodiscard]]
 add_compile_options(-Wno-attributes)
 
-# Suppress "warning: <symbol> is deprecated"
-add_compile_options(-Wno-deprecated-declarations)
-
 add_subdirectory(stratum)
 
 #######################

--- a/stratum/hal/lib/tdi/CMakeLists.txt
+++ b/stratum/hal/lib/tdi/CMakeLists.txt
@@ -57,6 +57,11 @@ if(ES2K_TARGET)
     )
 endif()
 
+set_source_files_properties(
+    tdi_pre_manager.cc
+    PROPERTIES COMPILE_OPTIONS "-Wno-deprecated-declarations"
+)
+
 target_include_directories(stratum_tdi_common_o PRIVATE
     ${STRATUM_INCLUDES}
     ${SDE_INSTALL_DIR}/include


### PR DESCRIPTION
- Apply the -Wno-deprecated-declarations compiler flag directly to tdi_pre_manager.cc instead of setting it globally.