### PR TITLE
Remove test cases not relevant for DPDK and ES2K targets

### DIFF
--- a/stratum/hal/lib/tdi/dpdk/dpdk_hal_test.cc
+++ b/stratum/hal/lib/tdi/dpdk/dpdk_hal_test.cc
@@ -312,46 +312,6 @@ TEST_F(DpdkHalTest, ColdbootSetupFailureWhenChassisConfigPushFails) {
   EXPECT_THAT(errors[0].error_message(), HasSubstr("saved chassis config"));
 }
 
-// Test fails for DPDK because the the forwarding pipeline config is missing
-// or empty and PushSavedForwardingPipelineConfigs() returns OkStatus without
-// invoking switch_mock.
-TEST_F(DpdkHalTest, DISABLED_ColdbootSetupFailureWhenPipelineConfigPushFailsForSomeNodes) {
-  // Setup and save the test config(s).
-  ChassisConfig chassis_config;
-  ForwardingPipelineConfigs forwarding_pipeline_configs;
-  FillTestChassisConfigAndSave(&chassis_config);
-  FillTestForwardingPipelineConfigsAndSave(&forwarding_pipeline_configs);
-
-  EXPECT_CALL(*switch_mock_, PushChassisConfig(EqualsProto(chassis_config)))
-      .WillOnce(Return(::util::OkStatus()));
-  EXPECT_CALL(
-      *switch_mock_,
-      PushForwardingPipelineConfig(
-          kNodeId1,
-          EqualsProto(
-              forwarding_pipeline_configs.node_id_to_config().at(kNodeId1))))
-      .WillOnce(
-          Return(::util::Status(StratumErrorSpace(), ERR_INTERNAL, kErrorMsg)));
-  EXPECT_CALL(
-      *switch_mock_,
-      PushForwardingPipelineConfig(
-          kNodeId2,
-          EqualsProto(
-              forwarding_pipeline_configs.node_id_to_config().at(kNodeId2))))
-      .WillOnce(Return(::util::OkStatus()));
-
-  // Call and validate results.
-  FLAGS_warmboot = false;
-  ::util::Status status = hal_->Setup();
-  ASSERT_EQ(ERR_INTERNAL, status.error_code());
-  EXPECT_THAT(status.error_message(), HasSubstr(kErrorMsg));
-  const auto& errors = hal_->GetErrors();
-  ASSERT_EQ(1U, errors.size());
-  EXPECT_THAT(errors[0].error_message(), HasSubstr(kErrorMsg));
-  EXPECT_THAT(errors[0].error_message(),
-              HasSubstr("saved forwarding pipeline configs"));
-}
-
 TEST_F(DpdkHalTest, WarmbootSetupSuccessForSavedConfig) {
   // Setup and save the test config(s).
   ChassisConfig chassis_config;

--- a/stratum/hal/lib/tdi/es2k/es2k_hal_test.cc
+++ b/stratum/hal/lib/tdi/es2k/es2k_hal_test.cc
@@ -313,43 +313,6 @@ TEST_F(Es2kHalTest, ColdbootSetupFailureWhenChassisConfigPushFails) {
   EXPECT_THAT(errors[0].error_message(), HasSubstr("saved chassis config"));
 }
 
-TEST_F(Es2kHalTest, ColdbootSetupFailureWhenPipelineConfigPushFailsForSomeNodes) {
-  // Setup and save the test config(s).
-  ChassisConfig chassis_config;
-  ForwardingPipelineConfigs forwarding_pipeline_configs;
-  FillTestChassisConfigAndSave(&chassis_config);
-  FillTestForwardingPipelineConfigsAndSave(&forwarding_pipeline_configs);
-
-  EXPECT_CALL(*switch_mock_, PushChassisConfig(EqualsProto(chassis_config)))
-      .WillOnce(Return(::util::OkStatus()));
-  EXPECT_CALL(
-      *switch_mock_,
-      PushForwardingPipelineConfig(
-          kNodeId1,
-          EqualsProto(
-              forwarding_pipeline_configs.node_id_to_config().at(kNodeId1))))
-      .WillOnce(
-          Return(::util::Status(StratumErrorSpace(), ERR_INTERNAL, kErrorMsg)));
-  EXPECT_CALL(
-      *switch_mock_,
-      PushForwardingPipelineConfig(
-          kNodeId2,
-          EqualsProto(
-              forwarding_pipeline_configs.node_id_to_config().at(kNodeId2))))
-      .WillOnce(Return(::util::OkStatus()));
-
-  // Call and validate results.
-  FLAGS_warmboot = false;
-  ::util::Status status = hal_->Setup();
-  ASSERT_EQ(ERR_INTERNAL, status.error_code());
-  EXPECT_THAT(status.error_message(), HasSubstr(kErrorMsg));
-  const auto& errors = hal_->GetErrors();
-  ASSERT_EQ(1U, errors.size());
-  EXPECT_THAT(errors[0].error_message(), HasSubstr(kErrorMsg));
-  EXPECT_THAT(errors[0].error_message(),
-              HasSubstr("saved forwarding pipeline configs"));
-}
-
 TEST_F(Es2kHalTest, WarmbootSetupSuccessForSavedConfig) {
   // Setup and save the test config(s).
   ChassisConfig chassis_config;


### PR DESCRIPTION
Both DPDK and ES2K targets have a non standard behavior where we always set up HAL with empty config, so earlier saved configs are NOT pushed as part of HAL setup.

The test(ColdbootSetupFailureWhenPipelineConfigPushFailsForSomeNodes) being removed checks the scenario where Cold boot setup should fail when pushing saved forwarding pipeline config fails for one node and succeeds for other. For DPDK and ES2K target, this scenario doesn’t apply since we always truncate the saved forwarding pipeline config.