### PR TITLE
Sanitize IPsec key after setting config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,10 @@ find_package(absl REQUIRED)
 find_package(gflags REQUIRED)
 find_package(glog REQUIRED)
 
+if(ES2K_TARGET)
+    find_package(OpenSSL REQUIRED)
+endif()
+
 set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)
 
 # Suppress "warning: attribute ignored" on ABSL_MUST_USE_RESULT [[nodiscard]]
@@ -106,6 +110,13 @@ function(add_stratum_google_libs _TGT)
     )
 endfunction()
 
+# OpenSSL libraries
+function(add_stratum_openssl_libs _TGT)
+    if(ES2K_TARGET)
+        target_link_libraries(${_TGT} PUBLIC OpenSSL::Crypto)
+    endif()
+endfunction()
+
 # Protobuf libraries
 function(add_stratum_proto_libs _TGT)
     target_link_libraries(${_TGT} PUBLIC
@@ -120,6 +131,7 @@ endfunction()
 function(add_stratum_libraries _TGT)
     add_stratum_abseil_libs(${_TGT})
     add_stratum_google_libs(${_TGT})
+    add_stratum_openssl_libs(${_TGT})
     add_stratum_proto_libs(${_TGT})
     target_link_libraries(${_TGT} PUBLIC pthread)
 endfunction()

--- a/stratum/hal/lib/tdi/tdi_fixed_function_manager.cc
+++ b/stratum/hal/lib/tdi/tdi_fixed_function_manager.cc
@@ -11,6 +11,10 @@
 #include "stratum/hal/lib/tdi/utils.h"
 #include "stratum/lib/utils.h"
 
+extern "C" {
+#include "openssl/crypto.h"
+}
+
 namespace stratum {
 namespace hal {
 namespace tdi {
@@ -22,10 +26,7 @@ class SadbConfigWrapper {
   ~SadbConfigWrapper() {
     std::string* key = get_key_ptr();
     if (key) {
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wclass-memaccess"
-      memset(&key[0], 0, key->capacity());
-#pragma GCC diagnostic pop
+      OPENSSL_cleanse(&key[0], key->size());
     }
   }
 

--- a/stratum/hal/lib/tdi/tdi_fixed_function_manager.cc
+++ b/stratum/hal/lib/tdi/tdi_fixed_function_manager.cc
@@ -22,7 +22,10 @@ class SadbConfigWrapper {
   ~SadbConfigWrapper() {
     std::string* key = get_key_ptr();
     if (key) {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wclass-memaccess"
       memset(&key[0], 0, key->capacity());
+#pragma GCC diagnostic pop
     }
   }
 
@@ -129,8 +132,7 @@ TdiFixedFunctionManager::CreateInstance(OperationMode mode,
 ::util::Status TdiFixedFunctionManager::BuildSadbTableData(
     TdiSdeInterface::TableDataInterface* table_data,
     IPsecSADBConfig& sadb_config) {
-  // Wrapper object ensures that sadb_config is scrubbed on exit.
-  SadbConfigWrapper w(sadb_config);
+  SadbConfigWrapper sanitize_on_exit(sadb_config);
 
   CHECK_RETURN_IF_FALSE(table_data);
 

--- a/stratum/hal/lib/tdi/tdi_fixed_function_manager.cc
+++ b/stratum/hal/lib/tdi/tdi_fixed_function_manager.cc
@@ -15,36 +15,61 @@ namespace stratum {
 namespace hal {
 namespace tdi {
 
-TdiFixedFunctionManager::TdiFixedFunctionManager (OperationMode mode,
-                                   TdiSdeInterface* tdi_sde_interface, int device)
+class SadbConfigWrapper {
+ public:
+  explicit SadbConfigWrapper(IPsecSADBConfig& sadb_config)
+      : config_(sadb_config) {}
+  ~SadbConfigWrapper() {
+    std::string* key = get_key_ptr();
+    if (key) {
+      memset(&key[0], 0, key->capacity());
+    }
+  }
+
+ private:
+  // Returns mutable pointer to key field.
+  inline std::string* get_key_ptr() {
+    if (auto payload = config_.mutable_esp_payload()) {
+      if (auto encryption = payload->mutable_encryption()) {
+        return encryption->mutable_key();
+      }
+    }
+    return nullptr;
+  }
+  IPsecSADBConfig& config_;
+};
+
+TdiFixedFunctionManager::TdiFixedFunctionManager(
+    OperationMode mode, TdiSdeInterface* tdi_sde_interface, int device)
     : mode_(mode),
       tdi_sde_interface_(ABSL_DIE_IF_NULL(tdi_sde_interface)),
       device_(device) {}
 
-std::unique_ptr<TdiFixedFunctionManager> TdiFixedFunctionManager::CreateInstance(
-    OperationMode mode, TdiSdeInterface* tdi_sde_interface, int device) {
-  return absl::WrapUnique(new TdiFixedFunctionManager(mode, tdi_sde_interface, device));
+std::unique_ptr<TdiFixedFunctionManager>
+TdiFixedFunctionManager::CreateInstance(OperationMode mode,
+                                        TdiSdeInterface* tdi_sde_interface,
+                                        int device) {
+  return absl::WrapUnique(
+      new TdiFixedFunctionManager(mode, tdi_sde_interface, device));
 }
 
 ::util::Status TdiFixedFunctionManager::InitNotificationTableWithCallback(
     std::string table_name,
-    void (*ipsec_notif_cb)(uint32_t, uint32_t, bool, uint8_t, char*, bool, void*),
-    void *cookie) {
-
+    void (*ipsec_notif_cb)(uint32_t, uint32_t, bool, uint8_t, char*, bool,
+                           void*),
+    void* cookie) {
   absl::ReaderMutexLock l(&lock_);
 
   ASSIGN_OR_RETURN(auto session, tdi_sde_interface_->CreateSession());
 
-  return tdi_sde_interface_->InitNotificationTableWithCallback(device_, session,
-                                                               table_name, ipsec_notif_cb,
-                                                               cookie);
+  return tdi_sde_interface_->InitNotificationTableWithCallback(
+      device_, session, table_name, ipsec_notif_cb, cookie);
 }
 
 ::util::Status TdiFixedFunctionManager::WriteSadbEntry(
     std::shared_ptr<TdiSdeInterface::SessionInterface> session,
     std::string table_name, const IPsecSadbConfigOp op_type,
-    IPsecSADBConfig &sadb_config) {
-
+    IPsecSADBConfig& sadb_config) {
   absl::ReaderMutexLock l(&lock_);
 
   ASSIGN_OR_RETURN(uint32 table_id, tdi_sde_interface_->GetTableId(table_name));
@@ -52,10 +77,10 @@ std::unique_ptr<TdiFixedFunctionManager> TdiFixedFunctionManager::CreateInstance
                    tdi_sde_interface_->CreateTableKey(table_id));
   RETURN_IF_ERROR(BuildSadbTableKey(table_key.get(), sadb_config));
   ASSIGN_OR_RETURN(auto table_data,
-                  tdi_sde_interface_->CreateTableData(table_id, 0));
+                   tdi_sde_interface_->CreateTableData(table_id, 0));
   if (op_type == IPSEC_SADB_CONFIG_OP_ADD_ENTRY ||
       op_type == IPSEC_SADB_CONFIG_OP_MOD_ENTRY) {
-      RETURN_IF_ERROR(BuildSadbTableData(table_data.get(), sadb_config));
+    RETURN_IF_ERROR(BuildSadbTableData(table_data.get(), sadb_config));
   }
   switch (op_type) {
     case IPSEC_SADB_CONFIG_OP_ADD_ENTRY:
@@ -74,70 +99,71 @@ std::unique_ptr<TdiFixedFunctionManager> TdiFixedFunctionManager::CreateInstance
 }
 
 ::util::Status TdiFixedFunctionManager::FetchSpi(
-  std::shared_ptr<TdiSdeInterface::SessionInterface> session,
-  std::string table_name, uint32 *spi) {
-
+    std::shared_ptr<TdiSdeInterface::SessionInterface> session,
+    std::string table_name, uint32* spi) {
   absl::ReaderMutexLock l(&lock_);
 
   uint64 spi_val;
   ASSIGN_OR_RETURN(uint32 table_id, tdi_sde_interface_->GetTableId(table_name));
-  ASSIGN_OR_RETURN(auto table_data, tdi_sde_interface_->CreateTableData(table_id, 0));
+  ASSIGN_OR_RETURN(auto table_data,
+                   tdi_sde_interface_->CreateTableData(table_id, 0));
   RETURN_IF_ERROR(tdi_sde_interface_->GetDefaultTableEntry(
-            device_, session, table_id, table_data.get()));
+      device_, session, table_id, table_data.get()));
   RETURN_IF_ERROR(table_data->GetParam(kIpsecFetchSpi, &spi_val));
-  *spi = (uint32) spi_val;
+  *spi = (uint32)spi_val;
   return ::util::OkStatus();
 }
 
 ::util::Status TdiFixedFunctionManager::BuildSadbTableKey(
-  TdiSdeInterface::TableKeyInterface* table_key,
-  IPsecSADBConfig &sadb_config) {
+    TdiSdeInterface::TableKeyInterface* table_key,
+    IPsecSADBConfig& sadb_config) {
+  CHECK_RETURN_IF_FALSE(table_key);
 
-    CHECK_RETURN_IF_FALSE(table_key);
-
-    RETURN_IF_ERROR(table_key->SetExact(
-      kIpsecSadbOffloadId, sadb_config.offload_id()));
-    RETURN_IF_ERROR(table_key->SetExact(
-      kIpsecSadbDir, ((uint8)sadb_config.direction())));
-    return ::util::OkStatus();
+  RETURN_IF_ERROR(
+      table_key->SetExact(kIpsecSadbOffloadId, sadb_config.offload_id()));
+  RETURN_IF_ERROR(
+      table_key->SetExact(kIpsecSadbDir, ((uint8)sadb_config.direction())));
+  return ::util::OkStatus();
 }
 
 ::util::Status TdiFixedFunctionManager::BuildSadbTableData(
-  TdiSdeInterface::TableDataInterface* table_data,
-  IPsecSADBConfig &sadb_config) {
+    TdiSdeInterface::TableDataInterface* table_data,
+    IPsecSADBConfig& sadb_config) {
+  // Wrapper object ensures that sadb_config is scrubbed on exit.
+  SadbConfigWrapper w(sadb_config);
 
-    CHECK_RETURN_IF_FALSE(table_data);
+  CHECK_RETURN_IF_FALSE(table_data);
 
-    RETURN_IF_ERROR(table_data->SetParam(kIpsecSadbReqId, sadb_config.req_id()));
-    RETURN_IF_ERROR(table_data->SetParam(kIpsecSadbSpi, sadb_config.spi()));
+  RETURN_IF_ERROR(table_data->SetParam(kIpsecSadbReqId, sadb_config.req_id()));
+  RETURN_IF_ERROR(table_data->SetParam(kIpsecSadbSpi, sadb_config.spi()));
+  RETURN_IF_ERROR(table_data->SetParam(kIpsecSadbSeqNum,
+                                       ((uint8)sadb_config.ext_seq_num())));
+  RETURN_IF_ERROR(table_data->SetParam(kIpsecSadbReplayWindow,
+                                       sadb_config.anti_replay_window_size()));
+  RETURN_IF_ERROR(table_data->SetParam(
+      kIpsecSadbProtoParams, ((uint8)sadb_config.protocol_parameters())));
+  RETURN_IF_ERROR(
+      table_data->SetParam(kIpsecSadbMode, ((uint8)sadb_config.mode())));
+  if (sadb_config.has_esp_payload()) {
+    RETURN_IF_ERROR(table_data->SetParam(kIpsecSadbEspAlgo,
+                                         ((uint16)sadb_config.esp_payload()
+                                              .encryption()
+                                              .encryption_algorithm())));
     RETURN_IF_ERROR(table_data->SetParam(
-        kIpsecSadbSeqNum, ((uint8)sadb_config.ext_seq_num())));
+        kIpsecSadbEspKey, sadb_config.esp_payload().encryption().key()));
     RETURN_IF_ERROR(table_data->SetParam(
-        kIpsecSadbReplayWindow, sadb_config.anti_replay_window_size()));
+        kIpsecSadbEspKeylen,
+        ((uint8)sadb_config.esp_payload().encryption().key_len())));
+  }
+  if (sadb_config.has_sa_hard_lifetime()) {
     RETURN_IF_ERROR(table_data->SetParam(
-        kIpsecSadbProtoParams, ((uint8)sadb_config.protocol_parameters())));
+        kIpsecSaLtHard, sadb_config.sa_hard_lifetime().bytes()));
+  }
+  if (sadb_config.has_sa_soft_lifetime()) {
     RETURN_IF_ERROR(table_data->SetParam(
-        kIpsecSadbMode, ((uint8)sadb_config.mode())));
-    if(sadb_config.has_esp_payload()) {
-        RETURN_IF_ERROR(table_data->SetParam(
-            kIpsecSadbEspAlgo,
-            ((uint16)sadb_config.esp_payload().encryption().encryption_algorithm())));
-        RETURN_IF_ERROR(table_data->SetParam(
-            kIpsecSadbEspKey,
-            sadb_config.esp_payload().encryption().key()));
-        RETURN_IF_ERROR(table_data->SetParam(
-          kIpsecSadbEspKeylen,
-          ((uint8)sadb_config.esp_payload().encryption().key_len())));
-    }
-    if(sadb_config.has_sa_hard_lifetime()) {
-        RETURN_IF_ERROR(table_data->SetParam(
-            kIpsecSaLtHard, sadb_config.sa_hard_lifetime().bytes()));
-    }
-    if(sadb_config.has_sa_soft_lifetime()) {
-        RETURN_IF_ERROR(table_data->SetParam(
-            kIpsecSaLtSoft, sadb_config.sa_soft_lifetime().bytes()));
-    }
-    return ::util::OkStatus();
+        kIpsecSaLtSoft, sadb_config.sa_soft_lifetime().bytes()));
+  }
+  return ::util::OkStatus();
 }
 
 }  // namespace tdi


### PR DESCRIPTION
- Implement wrapper class to zero key field in sadb_config object.

- Use clang-format to fix line wrapping and indentation.