### PR TITLE
Fix failing test cases in es2k_hal_test

### DIFF
--- a/stratum/hal/lib/tdi/es2k/es2k_hal_test.cc
+++ b/stratum/hal/lib/tdi/es2k/es2k_hal_test.cc
@@ -201,20 +201,6 @@ TEST_F(Es2kHalTest, ColdbootSetupSuccessForSavedConfigs) {
 
   EXPECT_CALL(*switch_mock_, PushChassisConfig(EqualsProto(chassis_config)))
       .WillOnce(Return(::util::OkStatus()));
-  EXPECT_CALL(
-      *switch_mock_,
-      PushForwardingPipelineConfig(
-          kNodeId1,
-          EqualsProto(
-              forwarding_pipeline_configs.node_id_to_config().at(kNodeId1))))
-      .WillOnce(Return(::util::OkStatus()));
-  EXPECT_CALL(
-      *switch_mock_,
-      PushForwardingPipelineConfig(
-          kNodeId2,
-          EqualsProto(
-              forwarding_pipeline_configs.node_id_to_config().at(kNodeId2))))
-      .WillOnce(Return(::util::OkStatus()));
   EXPECT_CALL(*switch_mock_, RegisterEventNotifyWriter(_))
       .WillOnce(Return(::util::OkStatus()));
 
@@ -268,21 +254,6 @@ TEST_F(Es2kHalTest, ColdbootSetupSuccessForNoChassisConfig) {
   if (PathExists(FLAGS_chassis_config_file)) {
     ASSERT_OK(RemoveFile(FLAGS_chassis_config_file));
   }
-
-  EXPECT_CALL(
-      *switch_mock_,
-      PushForwardingPipelineConfig(
-          kNodeId1,
-          EqualsProto(
-              forwarding_pipeline_configs.node_id_to_config().at(kNodeId1))))
-      .WillOnce(Return(::util::OkStatus()));
-  EXPECT_CALL(
-      *switch_mock_,
-      PushForwardingPipelineConfig(
-          kNodeId2,
-          EqualsProto(
-              forwarding_pipeline_configs.node_id_to_config().at(kNodeId2))))
-      .WillOnce(Return(::util::OkStatus()));
 
   // Call and validate results.
   FLAGS_warmboot = false;


### PR DESCRIPTION
In the ColdbootSetupSuccessForSavedConfigs and ColdbootSetupSuccessForNoChassisConfig test cases, remove the expectation that the Setup() call will result in calls to PushForwardingPipelineConfig. This does not happen in ES2K.

This change will allow us to run all the unit tests in //stratum/hal/lib/tdi/es2k.