### PR TITLE
Install TLS utility files

### DIFF
--- a/stratum/hal/bin/tdi/dpdk/CMakeLists.txt
+++ b/stratum/hal/bin/tdi/dpdk/CMakeLists.txt
@@ -12,6 +12,15 @@ install(
     FILES
         dpdk_port_config.pb.txt
         dpdk_skip_p4.conf
+        ${STRATUM_SOURCE_DIR}/tools/tls/ca.conf
+        ${STRATUM_SOURCE_DIR}/tools/tls/grpc-client.conf
     DESTINATION
         ${CMAKE_INSTALL_DATAROOTDIR}/stratum/dpdk
+)
+
+install(
+    PROGRAMS
+        ${STRATUM_SOURCE_DIR}/tools/tls/generate-certs.sh
+    TYPE
+        SBIN
 )

--- a/stratum/hal/bin/tdi/es2k/CMakeLists.txt
+++ b/stratum/hal/bin/tdi/es2k/CMakeLists.txt
@@ -12,6 +12,15 @@ install(
     FILES
         es2k_port_config.pb.txt
         es2k_skip_p4.conf
+        ${STRATUM_SOURCE_DIR}/tools/tls/ca.conf
+        ${STRATUM_SOURCE_DIR}/tools/tls/grpc-client.conf
     DESTINATION
         ${CMAKE_INSTALL_DATAROOTDIR}/stratum/es2k
+)
+
+install(
+    PROGRAMS
+        ${STRATUM_SOURCE_DIR}/tools/tls/generate-certs.sh
+    TYPE
+        SBIN
 )


### PR DESCRIPTION
- Modify DPDK and ES2K builds to install TLS utility files.

This PR implements the Stratum port of https://github.com/ipdk-io/networking-recipe/pull/170.