### PR TITLE
Make InitNotificationTableWithCallback standard

### DIFF
--- a/stratum/hal/lib/tdi/dpdk/dpdk_sde_target.cc
+++ b/stratum/hal/lib/tdi/dpdk/dpdk_sde_target.cc
@@ -196,6 +196,15 @@ std::string TdiSdeWrapper::GetSdeVersion() const {
   return ::util::OkStatus();
 }
 
+// IPsec notification
+
+::util::Status TdiSdeWrapper::InitNotificationTableWithCallback(
+    int dev_id, std::shared_ptr<TdiSdeInterface::SessionInterface> session,
+    const std::string& table_name, notification_table_callback_t callback,
+    void* cookie) const LOCKS_EXCLUDED(data_lock_) {
+  RETURN_ERROR(ERR_OPER_NOT_SUPPORTED) << "Notification Table not supported";
+}
+
 }  // namespace tdi
 }  // namespace hal
 }  // namespace stratum

--- a/stratum/hal/lib/tdi/es2k/es2k_sde_target.cc
+++ b/stratum/hal/lib/tdi/es2k/es2k_sde_target.cc
@@ -209,6 +209,8 @@ std::string TdiSdeWrapper::GetChipType(int device) const {
   return ::util::OkStatus();
 }
 
+// IPsec notification
+
 ::util::Status TdiSdeWrapper::InitNotificationTableWithCallback(
     int dev_id, std::shared_ptr<TdiSdeInterface::SessionInterface> session,
     const std::string &table_name,

--- a/stratum/hal/lib/tdi/tdi_ipsec_manager.cc
+++ b/stratum/hal/lib/tdi/tdi_ipsec_manager.cc
@@ -39,16 +39,15 @@ namespace tdi {
 ABSL_CONST_INIT absl::Mutex _ipsec_mgr_lock(absl::kConstInit);
 
 /* #### C function callback #### */
-void ipsec_notification_callback(uint32_t dev_id,
-                                 uint32_t ipsec_sa_spi,
-                                 bool soft_lifetime_expire,
-                                 uint8_t ipsec_sa_protocol,
-                                 char *ipsec_sa_dest_address,
-                                 bool ipv4,
-                                 void *cookie) {
-  //printf("IPsec callback: dev_id=%d, ipsec_sa_spi=%d, soft_lifetime=%d, \
-  //       ipsec_sa_protocol=%d, \
-  //       ipsec_sa_dest_address=%s, ipv4=%d, cookie=%p\n",
+static void ipsec_notification_callback(uint32_t dev_id,
+                                        uint32_t ipsec_sa_spi,
+                                        bool soft_lifetime_expire,
+                                        uint8_t ipsec_sa_protocol,
+                                        char *ipsec_sa_dest_address,
+                                        bool ipv4, void *cookie) {
+  //printf("IPsec callback: dev_id=%d, ipsec_sa_spi=%d, soft_lifetime=%d, "
+  //       "ipsec_sa_protocol=%d, "
+  //       "ipsec_sa_dest_address=%s, ipv4=%d, cookie=%p\n",
   //       dev_id, ipsec_sa_spi, soft_lifetime_expire, ipsec_sa_protocol,
   //       ipsec_sa_dest_address, ipv4, cookie);
   auto ipsec_mgr_hdl = reinterpret_cast<TdiIpsecManager *>(cookie);

--- a/stratum/hal/lib/tdi/tdi_sde_interface.h
+++ b/stratum/hal/lib/tdi/tdi_sde_interface.h
@@ -461,7 +461,6 @@ class TdiSdeInterface {
   virtual ::util::StatusOr<uint32> GetTableId(
       std::string& table_name) const = 0;
 
-  // FIXME: Target-specific code in a target-agnostic class.
   virtual ::util::Status InitNotificationTableWithCallback(
       int dev_id, std::shared_ptr<TdiSdeInterface::SessionInterface> session,
       const std::string& table_name, notification_table_callback_t callback,

--- a/stratum/hal/lib/tdi/tdi_sde_interface.h
+++ b/stratum/hal/lib/tdi/tdi_sde_interface.h
@@ -13,15 +13,17 @@
 #include "stratum/glue/integral_types.h"
 #include "stratum/glue/status/status.h"
 #include "stratum/glue/status/statusor.h"
-#include "stratum/hal/lib/tdi/tdi.pb.h"
 #include "stratum/hal/lib/common/common.pb.h"
 #include "stratum/hal/lib/common/utils.h"
+#include "stratum/hal/lib/tdi/tdi.pb.h"
 #include "stratum/lib/channel/channel.h"
 
-#ifdef ES2K_TARGET
-typedef void (*notification_table_callback_t)(uint32_t, uint32_t, bool,
-                                              uint8_t, char*, bool, void*);
-#endif
+typedef void (*notification_table_callback_t)(uint32_t dev_id,
+                                              uint32_t ipsec_sa_api,
+                                              bool soft_lifetime_expire,
+                                              uint8_t ipsec_sa_protocol,
+                                              char* ipsec_sa_dest_address,
+                                              bool ipv4, void* cke);
 
 namespace stratum {
 namespace hal {
@@ -104,7 +106,8 @@ class TdiSdeInterface {
     virtual ::util::Status SetParam(std::string field_name, uint64 value) = 0;
 
     // Sets a table data action parameter.
-    virtual ::util::Status SetParam(std::string field_name, const std::string& value) = 0;
+    virtual ::util::Status SetParam(std::string field_name,
+                                    const std::string& value) = 0;
 
     // Get a table data action parameter.
     virtual ::util::Status GetParam(int id, std::string* value) const = 0;
@@ -455,15 +458,14 @@ class TdiSdeInterface {
       uint32 action_selector_id) const = 0;
 
   // Gets the Tdi table id from the Table name.
-  virtual ::util::StatusOr<uint32> GetTableId(std::string &table_name) const = 0;
+  virtual ::util::StatusOr<uint32> GetTableId(
+      std::string& table_name) const = 0;
 
-#ifdef ES2K_TARGET
   // FIXME: Target-specific code in a target-agnostic class.
-  virtual ::util::Status InitNotificationTableWithCallback(int dev_id,
-    std::shared_ptr<TdiSdeInterface::SessionInterface> session,
-    const std::string &table_name, notification_table_callback_t callback,
-    void *cookie) const = 0;
-#endif
+  virtual ::util::Status InitNotificationTableWithCallback(
+      int dev_id, std::shared_ptr<TdiSdeInterface::SessionInterface> session,
+      const std::string& table_name, notification_table_callback_t callback,
+      void* cookie) const = 0;
 
  protected:
   // Default constructor. To be called by the Mock class instance only.

--- a/stratum/hal/lib/tdi/tdi_sde_mock.h
+++ b/stratum/hal/lib/tdi/tdi_sde_mock.h
@@ -336,13 +336,11 @@ class TdiSdeMock : public TdiSdeInterface {
   MOCK_METHOD(::util::StatusOr<uint32>, GetTableId, (std::string& table_name),
               (const));
 
-#ifdef ES2K_TARGET
   MOCK_METHOD(::util::Status, InitNotificationTableWithCallback,
               (int dev_id, std::shared_ptr<SessionInterface> session,
                const std::string& table_name,
                notification_table_callback_t callback, void* cookie),
               (const));
-#endif
 };
 
 }  // namespace tdi

--- a/stratum/hal/lib/tdi/tofino/tofino_sde_target.cc
+++ b/stratum/hal/lib/tdi/tofino/tofino_sde_target.cc
@@ -334,6 +334,15 @@ bf_status_t TdiSdeWrapper::BfPktRxNotifyCallback(
   return bf_pkt_free(device, pkt);
 }
 
+// IPsec notification
+
+::util::Status TdiSdeWrapper::InitNotificationTableWithCallback(
+    int dev_id, std::shared_ptr<TdiSdeInterface::SessionInterface> session,
+    const std::string& table_name, notification_table_callback_t callback,
+    void* cookie) const LOCKS_EXCLUDED(data_lock_) {
+  RETURN_ERROR(ERR_OPER_NOT_SUPPORTED) << "Notification Table not supported";
+}
+
 }  // namespace tdi
 }  // namespace hal
 }  // namespace stratum


### PR DESCRIPTION
- Make the TdiSdeInterface::InitNotificationTableWithCallback method unconditional, eliminating the need to define ES2K_TARGET when compiling TDI for ES2K. Implement stubs that return an ERR_OPER_NOT_SUPPORTED error for the DPDK and Tofino targets.

- Fix a couple of compiler warnings in tdi_ipsec_manager.cc.