### PR TITLE
Formalize support for Stratum dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,14 +27,6 @@ if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
     list(APPEND CMAKE_PREFIX_PATH ${DEPEND_INSTALL_DIR})
 endif()
 
-find_package(absl REQUIRED)
-find_package(gflags REQUIRED)
-find_package(glog REQUIRED)
-
-if(ES2K_TARGET)
-    find_package(OpenSSL REQUIRED)
-endif()
-
 if(absl_VERSION VERSION_GREATER_EQUAL "20230125")
   add_compile_definitions(ABSL_LEGACY_THREAD_ANNOTATIONS)
 endif()
@@ -106,18 +98,18 @@ endfunction()
 # Google libraries
 function(add_stratum_google_libs _TGT)
     target_link_libraries(${_TGT} PUBLIC
-        glog
-        gflags
-        gpr
-        grpc
-        protobuf
-        grpc++
+        gflags::gflags_shared
+        glog::glog
+        gRPC::gpr
+        gRPC::grpc
+        gRPC::grpc++
+        protobuf::libprotobuf
     )
 endfunction()
 
 # OpenSSL libraries
 function(add_stratum_openssl_libs _TGT)
-    if(ES2K_TARGET)
+    if(WITH_OPENSSL)
         target_link_libraries(${_TGT} PUBLIC OpenSSL::Crypto)
     endif()
 endfunction()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,9 @@ function(add_stratum_abseil_libs _TGT)
         absl::bad_optional_access
         absl::bad_variant_access
     )
+    if(absl_VERSION VERSION_GREATER_EQUAL 20230125)
+        target_link_libraries(${_TGT} PUBLIC absl::log_internal_check_op)
+    endif()
 endfunction()
 
 # Google libraries

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,10 @@ if(ES2K_TARGET)
     find_package(OpenSSL REQUIRED)
 endif()
 
+if(absl_VERSION VERSION_GREATER_EQUAL "20230125")
+  add_compile_definitions(ABSL_LEGACY_THREAD_ANNOTATIONS)
+endif()
+
 # Suppress "warning: attribute ignored" on ABSL_MUST_USE_RESULT [[nodiscard]]
 add_compile_options(-Wno-attributes)
 

--- a/stratum/glue/CMakeLists.txt
+++ b/stratum/glue/CMakeLists.txt
@@ -35,8 +35,8 @@ add_library(stratum_utils SHARED
 target_link_libraries(stratum_utils PUBLIC
     absl::strings
     absl::synchronization
-    gflags
-    glog
+    gflags::gflags_shared
+    glog::glog
 )
 
 target_link_directories(stratum_utils PRIVATE

--- a/stratum/glue/status/CMakeLists.txt
+++ b/stratum/glue/status/CMakeLists.txt
@@ -23,4 +23,7 @@ target_sources(stratum_glue_o PRIVATE
 
 target_include_directories(stratum_glue_o PUBLIC ${DEPEND_INSTALL_DIR}/include)
 
-target_link_libraries(stratum_glue_o PUBLIC gflags glog)
+target_link_libraries(stratum_glue_o PUBLIC
+    gflags::gflags_shared
+    glog::glog
+)

--- a/stratum/hal/bin/tdi/CMakeLists.txt
+++ b/stratum/hal/bin/tdi/CMakeLists.txt
@@ -53,11 +53,11 @@ target_link_libraries(tdi_pipeline_builder PUBLIC
 )
 
 target_link_libraries(tdi_pipeline_builder PUBLIC
-    protobuf
-    gflags
-    glog
-    grpc
-    grpc++
+    gflags::gflags_shared
+    glog::glog
+    gRPC::grpc
+    gRPC::grpc++
+    protobuf::libprotobuf
 )
 
 #add_dependencies(tdi_pipeline_builder p4runtime_proto stratum_proto)

--- a/stratum/tools/CMakeLists.txt
+++ b/stratum/tools/CMakeLists.txt
@@ -16,12 +16,12 @@ target_link_libraries(gnmi_cli PUBLIC
     stratum_static
     gnmi_proto
     grpc_proto
-    grpc
-    protobuf
-    gflags
-    grpc++
+    gflags::gflags_shared
+    gRPC::grpc
+    gRPC::grpc++
+    gRPC::re2
+    protobuf::libprotobuf
     pthread
-    re2
 )
 
 if(HAVE_POSIX_AIO)


### PR DESCRIPTION
- Move find_package() commands to superproject.

- Replace library names with namespaced library targets.

- Add support for Abseil version 20230125.

- Add absl::log_internal_check_op to list of required libraries.

- Replace target-specific conditional (ES2K) with feature-specific
  conditional (WITH_OPENSSL).