### PR TITLE
Abseil 2023 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,10 @@ endif()
 
 set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)
 
+if(absl_VERSION VERSION_GREATER_EQUAL "20230125")
+  add_compile_definitions(ABSL_LEGACY_THREAD_ANNOTATIONS)
+endif()
+
 # Suppress "warning: attribute ignored" on ABSL_MUST_USE_RESULT [[nodiscard]]
 add_compile_options(-Wno-attributes)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,6 +100,9 @@ function(add_stratum_abseil_libs _TGT)
         absl::bad_optional_access
         absl::bad_variant_access
     )
+    if(absl_VERSION VERSION_GREATER_EQUAL 20230125)
+        target_link_libraries(${_TGT} PUBLIC absl::log_internal_check_op)
+    endif()
 endfunction()
 
 # Google libraries


### PR DESCRIPTION
- Google renamed the Abseil thread annotation macros in the
  20030125 release. Define ABSL_LEGACY_THREAD_ANNOTATIONS to
  reenable the legacy macro names.

- Add absl::log_internal_check_op to list of required libraries.