### PR TITLE
Remove CMAKE_POSITION_INDEPENDENT_CODE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,8 +35,6 @@ if(ES2K_TARGET)
     find_package(OpenSSL REQUIRED)
 endif()
 
-set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)
-
 # Suppress "warning: attribute ignored" on ABSL_MUST_USE_RESULT [[nodiscard]]
 add_compile_options(-Wno-attributes)
 


### PR DESCRIPTION
- Remove local definition of CMAKE_POSITION_INDEPENDENT_CODE. This option is currently the responsibility of the superproject, which is responsible for handling the security settings.

Related to [recipe PR #249](https://github.com/ipdk-io/networking-recipe/pull/249), but the two do not depend on each other.