### PR TITLE
Reformat tdi/tofino files with clang-format

### DIFF
--- a/stratum/hal/bin/tdi/tofino/main.cc
+++ b/stratum/hal/bin/tdi/tofino/main.cc
@@ -6,4 +6,3 @@
 int main(int argc, char* argv[]) {
   return stratum::hal::tdi::Main(argc, argv).error_code();
 }
-

--- a/stratum/hal/bin/tdi/tofino/tofino_main.cc
+++ b/stratum/hal/bin/tdi/tofino/tofino_main.cc
@@ -3,11 +3,10 @@
 // Copyright 2022-2023 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-#include "stratum/hal/bin/tdi/main.h"
-
 #include "gflags/gflags.h"
 #include "stratum/glue/init_google.h"
 #include "stratum/glue/logging.h"
+#include "stratum/hal/bin/tdi/main.h"
 #include "stratum/hal/lib/phal/phal_sim.h"
 #include "stratum/hal/lib/tdi/tdi_action_profile_manager.h"
 #include "stratum/hal/lib/tdi/tdi_counter_manager.h"
@@ -16,8 +15,8 @@
 #include "stratum/hal/lib/tdi/tdi_sde_wrapper.h"
 #include "stratum/hal/lib/tdi/tdi_table_manager.h"
 #include "stratum/hal/lib/tdi/tofino/tofino_chassis_manager.h"
-#include "stratum/hal/lib/tdi/tofino/tofino_port_manager.h"
 #include "stratum/hal/lib/tdi/tofino/tofino_hal.h"
+#include "stratum/hal/lib/tdi/tofino/tofino_port_manager.h"
 #include "stratum/hal/lib/tdi/tofino/tofino_switch.h"
 #include "stratum/lib/security/auth_policy_checker.h"
 
@@ -47,11 +46,11 @@ namespace tdi {
 
   auto tofino_port_manager = TofinoPortManager::CreateSingleton();
 
-  RETURN_IF_ERROR(sde_wrapper->InitializeSde(
-      FLAGS_tdi_sde_install, FLAGS_tdi_switchd_cfg, FLAGS_tdi_switchd_background));
+  RETURN_IF_ERROR(sde_wrapper->InitializeSde(FLAGS_tdi_sde_install,
+                                             FLAGS_tdi_switchd_cfg,
+                                             FLAGS_tdi_switchd_background));
 
-  ASSIGN_OR_RETURN(bool is_sw_model,
-                   sde_wrapper->IsSoftwareModel(device_id));
+  ASSIGN_OR_RETURN(bool is_sw_model, sde_wrapper->IsSoftwareModel(device_id));
   const OperationMode mode =
       is_sw_model ? OPERATION_MODE_SIM : OPERATION_MODE_STANDALONE;
 
@@ -68,16 +67,14 @@ namespace tdi {
   auto packetio_manager =
       TdiPacketioManager::CreateInstance(sde_wrapper, device_id);
 
-  auto pre_manager =
-      TdiPreManager::CreateInstance(sde_wrapper, device_id);
+  auto pre_manager = TdiPreManager::CreateInstance(sde_wrapper, device_id);
 
   auto counter_manager =
       TdiCounterManager::CreateInstance(sde_wrapper, device_id);
 
   auto tdi_node = TdiNode::CreateInstance(
-      table_manager.get(), action_profile_manager.get(),
-      packetio_manager.get(), pre_manager.get(),
-      counter_manager.get(), sde_wrapper, device_id);
+      table_manager.get(), action_profile_manager.get(), packetio_manager.get(),
+      pre_manager.get(), counter_manager.get(), sde_wrapper, device_id);
 
   PhalInterface* phal = PhalSim::CreateSingleton();
 
@@ -88,15 +85,15 @@ namespace tdi {
   auto chassis_manager = TofinoChassisManager::CreateInstance(
       mode, phal, sde_wrapper, tofino_port_manager);
 
-  auto tdi_switch = TofinoSwitch::CreateInstance(
-      chassis_manager.get(), device_id_to_tdi_node);
+  auto tdi_switch = TofinoSwitch::CreateInstance(chassis_manager.get(),
+                                                 device_id_to_tdi_node);
 
   auto auth_policy_checker = AuthPolicyChecker::CreateInstance();
 
   // Create the 'Hal' class instance.
-  auto* hal = TofinoHal::CreateSingleton(
-      stratum::hal::OPERATION_MODE_STANDALONE, tdi_switch.get(),
-      auth_policy_checker.get());
+  auto* hal =
+      TofinoHal::CreateSingleton(stratum::hal::OPERATION_MODE_STANDALONE,
+                                 tdi_switch.get(), auth_policy_checker.get());
   CHECK_RETURN_IF_FALSE(hal) << "Failed to create the Stratum Hal instance.";
 
   // Set up P4 runtime servers.

--- a/stratum/hal/lib/tdi/tofino/tofino_chassis_manager.h
+++ b/stratum/hal/lib/tdi/tofino/tofino_chassis_manager.h
@@ -14,12 +14,12 @@
 #include "absl/time/time.h"
 #include "absl/types/optional.h"
 #include "stratum/glue/integral_types.h"
-#include "stratum/hal/lib/tdi/tdi_sde_interface.h"
-#include "stratum/hal/lib/tdi/tofino/tofino_port_manager.h"
 #include "stratum/hal/lib/common/gnmi_events.h"
 #include "stratum/hal/lib/common/phal_interface.h"
 #include "stratum/hal/lib/common/utils.h"
 #include "stratum/hal/lib/common/writer_interface.h"
+#include "stratum/hal/lib/tdi/tdi_sde_interface.h"
+#include "stratum/hal/lib/tdi/tofino/tofino_port_manager.h"
 #include "stratum/lib/channel/channel.h"
 
 namespace stratum {
@@ -122,7 +122,8 @@ class TofinoChassisManager {
   // Private constructor. Use CreateInstance() to create an instance of this
   // class.
   TofinoChassisManager(OperationMode mode, PhalInterface* phal_interface,
-      TdiSdeInterface* tdi_sde_interface, TofinoPortManager* tofino_port_manager);
+                       TdiSdeInterface* tdi_sde_interface,
+                       TofinoPortManager* tofino_port_manager);
 
   ::util::StatusOr<const PortConfig*> GetPortConfig(uint64 node_id,
                                                     uint32 port_id) const
@@ -156,8 +157,8 @@ class TofinoChassisManager {
   // a ChannelReader thread which processes transceiver module insert/removal
   // events. Port is the 1-based frontpanel port number.
   // NOTE: This method should never be executed directly from a context which
-  // first accesses the internal structures of a class below TofinoChassisManager
-  // as this may result in deadlock.
+  // first accesses the internal structures of a class below
+  // TofinoChassisManager as this may result in deadlock.
   void TransceiverEventHandler(int slot, int port, HwState new_state)
       LOCKS_EXCLUDED(chassis_lock);
 

--- a/stratum/hal/lib/tdi/tofino/tofino_chassis_manager_test.cc
+++ b/stratum/hal/lib/tdi/tofino/tofino_chassis_manager_test.cc
@@ -19,11 +19,11 @@
 #include "stratum/glue/status/status.h"
 #include "stratum/glue/status/status_test_util.h"
 #include "stratum/glue/status/statusor.h"
-#include "stratum/hal/lib/tdi/tdi_sde_mock.h"
-#include "stratum/hal/lib/tdi/tofino/tofino_port_manager_mock.h"
 #include "stratum/hal/lib/common/common.pb.h"
 #include "stratum/hal/lib/common/phal_mock.h"
 #include "stratum/hal/lib/common/writer_mock.h"
+#include "stratum/hal/lib/tdi/tdi_sde_mock.h"
+#include "stratum/hal/lib/tdi/tofino/tofino_port_manager_mock.h"
 #include "stratum/lib/constants.h"
 #include "stratum/lib/test_utils/matchers.h"
 #include "stratum/lib/utils.h"
@@ -327,7 +327,7 @@ TEST_F(TofinoChassisManagerTest, AddPortFec) {
   RegisterSdkPortId(builder.AddPort(portId, port, ADMIN_STATE_ENABLED,
                                     kHundredGigBps, FEC_MODE_ON));
   EXPECT_CALL(*port_manager_, AddPort(kUnit, portId + kSdkPortOffset,
-                                     kHundredGigBps, FEC_MODE_ON));
+                                      kHundredGigBps, FEC_MODE_ON));
   EXPECT_CALL(*port_manager_, EnablePort(kUnit, portId + kSdkPortOffset));
   ASSERT_OK(PushChassisConfig(builder));
 
@@ -377,11 +377,12 @@ TEST_F(TofinoChassisManagerTest, ApplyPortShaping) {
   builder.SetVendorConfig(vendor_config);
   ASSERT_OK(PushBaseChassisConfig(&builder));
 
-  EXPECT_CALL(*port_manager_, SetPortShapingRate(kUnit, kPortId + kSdkPortOffset,
-                                                false, 16384, kTenGigBps))
+  EXPECT_CALL(*port_manager_,
+              SetPortShapingRate(kUnit, kPortId + kSdkPortOffset, false, 16384,
+                                 kTenGigBps))
       .Times(AtLeast(1));
   EXPECT_CALL(*port_manager_, EnablePortShaping(kUnit, kPortId + kSdkPortOffset,
-                                               TRI_STATE_TRUE))
+                                                TRI_STATE_TRUE))
       .Times(AtLeast(1));
   EXPECT_CALL(*port_manager_, EnablePort(kUnit, kPortId + kSdkPortOffset))
       .Times(AtLeast(1));
@@ -474,7 +475,8 @@ TEST_F(TofinoChassisManagerTest, ReplayPorts) {
   // For now, when replaying the port configuration, we set the mtu and autoneg
   // even if the values where already the defaults. This seems like a good idea
   // to ensure configuration consistency.
-  EXPECT_CALL(*port_manager_, SetPortMtu(kUnit, sdkPortId, 0)).Times(AtLeast(1));
+  EXPECT_CALL(*port_manager_, SetPortMtu(kUnit, sdkPortId, 0))
+      .Times(AtLeast(1));
   EXPECT_CALL(*port_manager_,
               SetPortAutonegPolicy(kUnit, sdkPortId, TRI_STATE_UNKNOWN))
       .Times(AtLeast(1));

--- a/stratum/hal/lib/tdi/tofino/tofino_hal.cc
+++ b/stratum/hal/lib/tdi/tofino/tofino_hal.cc
@@ -6,6 +6,7 @@
 #include "stratum/hal/lib/tdi/tofino/tofino_hal.h"
 
 #include <limits.h>
+
 #include <utility>
 
 #include "absl/base/macros.h"
@@ -106,13 +107,10 @@ TofinoHal::~TofinoHal() {
 
   auto it = std::find_if(
       external_stratum_urls.begin(), external_stratum_urls.end(),
-      [](const std::string& url) {
-          return (url == FLAGS_local_stratum_url);
-      });
+      [](const std::string& url) { return (url == FLAGS_local_stratum_url); });
   CHECK_RETURN_IF_FALSE(it == external_stratum_urls.end())
       << "You used one of these reserved local URLs as an external URL: "
-      << FLAGS_local_stratum_url
-      << ".";
+      << FLAGS_local_stratum_url << ".";
 
   CHECK_RETURN_IF_FALSE(!FLAGS_persistent_config_dir.empty())
       << "persistent_config_dir flag needs to be explicitly given.";
@@ -122,13 +120,11 @@ TofinoHal::~TofinoHal() {
   return ::util::OkStatus();
 }
 
-::util::Status TofinoHal::Setup() {
-    return Setup(FLAGS_warmboot);
-}
+::util::Status TofinoHal::Setup() { return Setup(FLAGS_warmboot); }
 
 ::util::Status TofinoHal::Setup(bool warmboot) {
-  LOG(INFO) << "Setting up HAL in "
-            << (warmboot ? "WARMBOOT" : "COLDBOOT") << " mode...";
+  LOG(INFO) << "Setting up HAL in " << (warmboot ? "WARMBOOT" : "COLDBOOT")
+            << " mode...";
 
   RETURN_IF_ERROR(RecursivelyCreateDir(FLAGS_persistent_config_dir));
 
@@ -235,10 +231,9 @@ void TofinoHal::HandleSignal(int value) {
   external_server_->Shutdown(absl::ToChronoTime(absl::Now()));
 }
 
-TofinoHal* TofinoHal::CreateSingleton(
-    OperationMode mode,
-    SwitchInterface* switch_interface,
-    AuthPolicyChecker* auth_policy_checker) {
+TofinoHal* TofinoHal::CreateSingleton(OperationMode mode,
+                                      SwitchInterface* switch_interface,
+                                      AuthPolicyChecker* auth_policy_checker) {
   absl::WriterMutexLock l(&init_lock_);
   if (!singleton_) {
     singleton_ = new TofinoHal(mode, switch_interface, auth_policy_checker);

--- a/stratum/hal/lib/tdi/tofino/tofino_hal.h
+++ b/stratum/hal/lib/tdi/tofino/tofino_hal.h
@@ -88,7 +88,8 @@ class TofinoHal final {
   TofinoHal(const TofinoHal&) = delete;
   TofinoHal& operator=(const TofinoHal&) = delete;
 
-  // Pipe file descriptors used to deliver signals from the handler to TofinoHal.
+  // Pipe file descriptors used to deliver signals from the handler to
+  // TofinoHal.
   static int pipe_read_fd_;
   static int pipe_write_fd_;
 

--- a/stratum/hal/lib/tdi/tofino/tofino_hal_test.cc
+++ b/stratum/hal/lib/tdi/tofino/tofino_hal_test.cc
@@ -50,8 +50,8 @@ class TofinoHalTest : public ::testing::Test {
     switch_mock_ = new ::testing::StrictMock<SwitchMock>();
     auth_policy_checker_mock_ =
         new ::testing::StrictMock<AuthPolicyCheckerMock>();
-    hal_ = TofinoHal::CreateSingleton(
-	kMode, switch_mock_, auth_policy_checker_mock_);
+    hal_ = TofinoHal::CreateSingleton(kMode, switch_mock_,
+                                      auth_policy_checker_mock_);
     ASSERT_NE(hal_, nullptr);
   }
 
@@ -313,7 +313,8 @@ TEST_F(TofinoHalTest, ColdbootSetupFailureWhenChassisConfigPushFails) {
   EXPECT_THAT(errors[0].error_message(), HasSubstr("saved chassis config"));
 }
 
-TEST_F(TofinoHalTest, ColdbootSetupFailureWhenPipelineConfigPushFailsForSomeNodes) {
+TEST_F(TofinoHalTest,
+       ColdbootSetupFailureWhenPipelineConfigPushFailsForSomeNodes) {
   // Setup and save the test config(s).
   ChassisConfig chassis_config;
   ForwardingPipelineConfigs forwarding_pipeline_configs;
@@ -436,7 +437,8 @@ TEST_F(TofinoHalTest, ColdbootTeardownFailureWhenSwitchInterfaceShutdownFails) {
   EXPECT_THAT(errors[0].error_message(), HasSubstr("shut down"));
 }
 
-TEST_F(TofinoHalTest, ColdbootTeardownFailureWhenAuthPolicyCheckerShutdownFails) {
+TEST_F(TofinoHalTest,
+       ColdbootTeardownFailureWhenAuthPolicyCheckerShutdownFails) {
   EXPECT_CALL(*switch_mock_, Shutdown()).WillOnce(Return(::util::OkStatus()));
   EXPECT_CALL(*auth_policy_checker_mock_, Shutdown())
       .WillOnce(

--- a/stratum/hal/lib/tdi/tofino/tofino_port_manager.h
+++ b/stratum/hal/lib/tdi/tofino/tofino_port_manager.h
@@ -30,12 +30,11 @@ class TofinoPortManager : public TdiPortManager {
   ::util::Status UnregisterPortStatusEventWriter()
       LOCKS_EXCLUDED(port_status_event_writer_lock_);
   ::util::Status GetPortInfo(int device, int port,
-                             TargetDatapathId *target_dp_id);
+                             TargetDatapathId* target_dp_id);
   ::util::StatusOr<PortState> GetPortState(int device, int port);
-  ::util::Status GetPortCounters(int device, int port,
-                                 PortCounters* counters);
-  ::util::StatusOr<uint32> GetPortIdFromPortKey(
-      int device, const PortKey& port_key);
+  ::util::Status GetPortCounters(int device, int port, PortCounters* counters);
+  ::util::StatusOr<uint32> GetPortIdFromPortKey(int device,
+                                                const PortKey& port_key);
   bool IsValidPort(int device, int port);
   ::util::Status AddPort(int device, int port);
   ::util::Status DeletePort(int device, int port);
@@ -45,9 +44,9 @@ class TofinoPortManager : public TdiPortManager {
   // Tofino-specific methods
   virtual ::util::Status AddPort(int device, int port, uint64 speed_bps,
                                  FecMode fec_mode);
-  virtual ::util::Status SetPortShapingRate(
-      int device, int port, bool is_in_pps, uint32 burst_size,
-      uint64 rate_per_second);
+  virtual ::util::Status SetPortShapingRate(int device, int port,
+                                            bool is_in_pps, uint32 burst_size,
+                                            uint64 rate_per_second);
   virtual ::util::Status EnablePortShaping(int device, int port,
                                            TriState enable);
   virtual ::util::Status SetPortAutonegPolicy(int device, int port,
@@ -99,7 +98,7 @@ class TofinoPortManager : public TdiPortManager {
   // Writer to forward the port status change message to. It is registered
   // by chassis manager to receive SDE port status change events.
   std::unique_ptr<ChannelWriter<PortStatusEvent>> port_status_event_writer_
-    GUARDED_BY(port_status_event_writer_lock_);
+      GUARDED_BY(port_status_event_writer_lock_);
 };
 
 }  // namespace tdi

--- a/stratum/hal/lib/tdi/tofino/tofino_port_manager_dummy.cc
+++ b/stratum/hal/lib/tdi/tofino/tofino_port_manager_dummy.cc
@@ -4,8 +4,6 @@
 
 // Dummy implementation of Tofino Port Manager.
 
-#include "stratum/hal/lib/tdi/tofino/tofino_port_manager.h"
-
 #include "absl/synchronization/mutex.h"
 #include "stratum/glue/integral_types.h"
 #include "stratum/glue/logging.h"
@@ -14,6 +12,7 @@
 #include "stratum/glue/status/statusor.h"
 #include "stratum/hal/lib/common/common.pb.h"
 #include "stratum/hal/lib/common/utils.h"
+#include "stratum/hal/lib/tdi/tofino/tofino_port_manager.h"
 #include "stratum/lib/channel/channel.h"
 #include "stratum/lib/constants.h"
 
@@ -42,12 +41,13 @@ TofinoPortManager* TofinoPortManager::GetSingleton() {
   return singleton_;
 }
 
-::util::StatusOr<PortState> TofinoPortManager::GetPortState(int device, int port) {
+::util::StatusOr<PortState> TofinoPortManager::GetPortState(int device,
+                                                            int port) {
   return PORT_STATE_UP;
 }
 
-::util::Status TofinoPortManager::GetPortCounters(
-    int device, int port, PortCounters* counters) {
+::util::Status TofinoPortManager::GetPortCounters(int device, int port,
+                                                  PortCounters* counters) {
   counters->set_in_octets(0);
   counters->set_out_octets(1);
   counters->set_in_unicast_pkts(2);
@@ -66,8 +66,9 @@ TofinoPortManager* TofinoPortManager::GetSingleton() {
   return ::util::OkStatus();
 }
 
-::util::Status TofinoPortManager::OnPortStatusEvent(
-    int device, int port, bool up, absl::Time timestamp) {
+::util::Status TofinoPortManager::OnPortStatusEvent(int device, int port,
+                                                    bool up,
+                                                    absl::Time timestamp) {
   return ::util::OkStatus();
 }
 
@@ -84,8 +85,8 @@ TofinoPortManager* TofinoPortManager::GetSingleton() {
   return ::util::OkStatus();
 }
 
-::util::Status TofinoPortManager::GetPortInfo(
-    int device, int port, TargetDatapathId *target_dp_id) {
+::util::Status TofinoPortManager::GetPortInfo(int device, int port,
+                                              TargetDatapathId* target_dp_id) {
   return ::util::OkStatus();
 }
 
@@ -93,8 +94,8 @@ TofinoPortManager* TofinoPortManager::GetSingleton() {
   return ::util::OkStatus();
 }
 
-::util::Status TofinoPortManager::AddPort(
-    int device, int port, uint64 speed_bps, FecMode fec_mode) {
+::util::Status TofinoPortManager::AddPort(int device, int port,
+                                          uint64 speed_bps, FecMode fec_mode) {
   return ::util::OkStatus();
 }
 
@@ -110,19 +111,20 @@ TofinoPortManager* TofinoPortManager::GetSingleton() {
   return ::util::OkStatus();
 }
 
-::util::Status TofinoPortManager::SetPortShapingRate(
-    int device, int port, bool is_in_pps, uint32 burst_size,
-    uint64 rate_per_second) {
+::util::Status TofinoPortManager::SetPortShapingRate(int device, int port,
+                                                     bool is_in_pps,
+                                                     uint32 burst_size,
+                                                     uint64 rate_per_second) {
   return ::util::OkStatus();
 }
 
-::util::Status TofinoPortManager::EnablePortShaping(
-    int device, int port, TriState enable) {
+::util::Status TofinoPortManager::EnablePortShaping(int device, int port,
+                                                    TriState enable) {
   return ::util::OkStatus();
 }
 
-::util::Status TofinoPortManager::SetPortAutonegPolicy(
-    int device, int port, TriState autoneg) {
+::util::Status TofinoPortManager::SetPortAutonegPolicy(int device, int port,
+                                                       TriState autoneg) {
   return ::util::OkStatus();
 }
 
@@ -130,9 +132,7 @@ TofinoPortManager* TofinoPortManager::GetSingleton() {
   return ::util::OkStatus();
 }
 
-bool TofinoPortManager::IsValidPort(int device, int port) {
-  return true;
-}
+bool TofinoPortManager::IsValidPort(int device, int port) { return true; }
 
 ::util::Status TofinoPortManager::SetPortLoopbackMode(
     int device, int port, LoopbackState loopback_mode) {
@@ -152,8 +152,9 @@ bool TofinoPortManager::IsValidPort(int device, int port) {
   return ::util::OkStatus();
 }
 
-::util::Status TofinoPortManager::SetDeflectOnDropDestination(
-    int device, int port, int queue) {
+::util::Status TofinoPortManager::SetDeflectOnDropDestination(int device,
+                                                              int port,
+                                                              int queue) {
   return ::util::OkStatus();
 }
 

--- a/stratum/hal/lib/tdi/tofino/tofino_port_manager_mock.h
+++ b/stratum/hal/lib/tdi/tofino/tofino_port_manager_mock.h
@@ -14,21 +14,21 @@ namespace tdi {
 
 class TofinoPortManagerMock : public TofinoPortManager {
  public:
-  MOCK_METHOD(
-      ::util::Status, RegisterPortStatusEventWriter,
-      (std::unique_ptr<ChannelWriter<PortStatusEvent>> writer), (override));
+  MOCK_METHOD(::util::Status, RegisterPortStatusEventWriter,
+              (std::unique_ptr<ChannelWriter<PortStatusEvent>> writer),
+              (override));
 
   MOCK_METHOD(::util::Status, UnregisterPortStatusEventWriter, (), (override));
 
   MOCK_METHOD(::util::Status, GetPortInfo,
-              (int device, int port, TargetDatapathId *target_dp_id),
+              (int device, int port, TargetDatapathId* target_dp_id),
               (override));
 
   MOCK_METHOD(::util::StatusOr<PortState>, GetPortState, (int device, int port),
               (override));
 
   MOCK_METHOD(::util::Status, GetPortCounters,
-               (int device, int port, PortCounters* counters), (override));
+              (int device, int port, PortCounters* counters), (override));
 
   MOCK_METHOD(::util::StatusOr<uint32>, GetPortIdFromPortKey,
               (int device, const PortKey& port_key), (override));
@@ -51,7 +51,8 @@ class TofinoPortManagerMock : public TofinoPortManager {
 
   MOCK_METHOD(::util::Status, SetPortShapingRate,
               (int device, int port, bool is_in_pps, uint32 burst_size,
-               uint64 rate_per_second), (override));
+               uint64 rate_per_second),
+              (override));
 
   MOCK_METHOD(::util::Status, EnablePortShaping,
               (int device, int port, TriState enable), (override));

--- a/stratum/hal/lib/tdi/tofino/tofino_sde_utils.cc
+++ b/stratum/hal/lib/tdi/tofino/tofino_sde_utils.cc
@@ -4,7 +4,6 @@
 // Target-agnostic utility functions exposed for use outside TdiSdeWrapper.
 
 #include "stratum/hal/lib/tdi/tdi_sde_utils.h"
-
 #include "tdi/common/tdi_table.hpp"
 #include "tdi_tofino/tdi_tofino_defs.h"
 
@@ -13,19 +12,19 @@ namespace hal {
 namespace tdi {
 
 tdi_sde_table_type GetSdeTableType(const ::tdi::Table& table) {
-  auto table_type =
-      static_cast<tdi_tofino_table_type_e>(table.tableInfoGet()->tableTypeGet());
+  auto table_type = static_cast<tdi_tofino_table_type_e>(
+      table.tableInfoGet()->tableTypeGet());
   switch (table_type) {
-  case TDI_TOFINO_TABLE_TYPE_ACTION_PROFILE:
-    return TDI_SDE_TABLE_TYPE_ACTION_PROFILE;
-  case TDI_TOFINO_TABLE_TYPE_COUNTER:
-    return TDI_SDE_TABLE_TYPE_ACTION_PROFILE;
-  case TDI_TOFINO_TABLE_TYPE_METER:
-    return TDI_SDE_TABLE_TYPE_METER;
-  case TDI_TOFINO_TABLE_TYPE_SELECTOR:
-    return TDI_SDE_TABLE_TYPE_SELECTOR;
-  default:
-    return TDI_SDE_TABLE_TYPE_NONE;
+    case TDI_TOFINO_TABLE_TYPE_ACTION_PROFILE:
+      return TDI_SDE_TABLE_TYPE_ACTION_PROFILE;
+    case TDI_TOFINO_TABLE_TYPE_COUNTER:
+      return TDI_SDE_TABLE_TYPE_ACTION_PROFILE;
+    case TDI_TOFINO_TABLE_TYPE_METER:
+      return TDI_SDE_TABLE_TYPE_METER;
+    case TDI_TOFINO_TABLE_TYPE_SELECTOR:
+      return TDI_SDE_TABLE_TYPE_SELECTOR;
+    default:
+      return TDI_SDE_TABLE_TYPE_NONE;
   }
 }
 

--- a/stratum/hal/lib/tdi/tofino/tofino_switch.cc
+++ b/stratum/hal/lib/tdi/tofino/tofino_switch.cc
@@ -14,8 +14,8 @@
 #include "stratum/glue/integral_types.h"
 #include "stratum/glue/logging.h"
 #include "stratum/glue/status/status_macros.h"
-#include "stratum/hal/lib/tdi/tofino/tofino_chassis_manager.h"
 #include "stratum/hal/lib/tdi/tdi_node.h"
+#include "stratum/hal/lib/tdi/tofino/tofino_chassis_manager.h"
 #include "stratum/hal/lib/tdi/utils.h"
 #include "stratum/lib/constants.h"
 #include "stratum/lib/macros.h"
@@ -24,9 +24,8 @@ namespace stratum {
 namespace hal {
 namespace tdi {
 
-TofinoSwitch::TofinoSwitch(
-    TofinoChassisManager* chassis_manager,
-    const std::map<int, TdiNode*>& device_id_to_tdi_node)
+TofinoSwitch::TofinoSwitch(TofinoChassisManager* chassis_manager,
+                           const std::map<int, TdiNode*>& device_id_to_tdi_node)
     : chassis_manager_(ABSL_DIE_IF_NULL(chassis_manager)),
       device_id_to_tdi_node_(device_id_to_tdi_node),
       node_id_to_tdi_node_() {
@@ -177,8 +176,7 @@ TofinoSwitch::~TofinoSwitch() {}
 }
 
 ::util::Status TofinoSwitch::RetrieveValue(
-    uint64 node_id,
-    const DataRequest& request,
+    uint64 node_id, const DataRequest& request,
     WriterInterface<DataResponse>* writer,
     std::vector<::util::Status>* details) {
   absl::ReaderMutexLock l(&chassis_lock);
@@ -239,9 +237,8 @@ TofinoSwitch::~TofinoSwitch() {}
   return ::util::OkStatus();
 }
 
-::util::Status TofinoSwitch::SetValue(
-    uint64 node_id, const SetRequest& request,
-    std::vector<::util::Status>* details) {
+::util::Status TofinoSwitch::SetValue(uint64 node_id, const SetRequest& request,
+                                      std::vector<::util::Status>* details) {
   LOG(INFO) << "TofinoSwitch::SetValue is not implemented yet. Changes will "
             << "be applied when ChassisConfig is pushed again. "
             << request.ShortDebugString() << ".";

--- a/stratum/hal/lib/tdi/tofino/tofino_switch.h
+++ b/stratum/hal/lib/tdi/tofino/tofino_switch.h
@@ -11,9 +11,9 @@
 #include <vector>
 
 #include "absl/synchronization/mutex.h"
+#include "stratum/hal/lib/common/switch_interface.h"
 #include "stratum/hal/lib/tdi/tdi_node.h"
 #include "stratum/hal/lib/tdi/tofino/tofino_chassis_manager.h"
-#include "stratum/hal/lib/common/switch_interface.h"
 
 // Suppress clang errors
 #undef LOCKS_EXCLUDED
@@ -92,7 +92,7 @@ class TofinoSwitch : public SwitchInterface {
   // Private constructor. Use CreateInstance() to create an instance of this
   // class.
   TofinoSwitch(TofinoChassisManager* chassis_manager,
-      const std::map<int, TdiNode*>& device_id_to_tdi_node);
+               const std::map<int, TdiNode*>& device_id_to_tdi_node);
 
   // Helper to get TdiNode pointer from device_id number or return error
   // indicating invalid device_id.

--- a/stratum/hal/lib/tdi/tofino/tofino_switch_test.cc
+++ b/stratum/hal/lib/tdi/tofino/tofino_switch_test.cc
@@ -78,12 +78,12 @@ class TofinoSwitchTest : public ::testing::Test {
     // Use NiceMock to suppress "uninteresting mock function call" warnings
     phal_mock_ = absl::make_unique<NiceMock<PhalMock>>();
     sde_mock_ = absl::make_unique<NiceMock<TdiSdeMock>>();
-    chassis_manager_mock_ = absl::make_unique<NiceMock<TofinoChassisManagerMock>>();
+    chassis_manager_mock_ =
+        absl::make_unique<NiceMock<TofinoChassisManagerMock>>();
     node_mock_ = absl::make_unique<NiceMock<TdiNodeMock>>();
     unit_to_ipdk_node_mock_[kUnit] = node_mock_.get();
-    switch_ = TofinoSwitch::CreateInstance(
-        chassis_manager_mock_.get(),
-        unit_to_ipdk_node_mock_);
+    switch_ = TofinoSwitch::CreateInstance(chassis_manager_mock_.get(),
+                                           unit_to_ipdk_node_mock_);
 #if 0
     // no 'shutdown'
     shutdown = false;  // global variable initialization
@@ -100,8 +100,7 @@ class TofinoSwitchTest : public ::testing::Test {
   void PushChassisConfigSuccessfully() {
     ChassisConfig config;
     config.add_nodes()->set_id(kNodeId);
-    EXPECT_CALL(*node_mock_,
-                PushChassisConfig(EqualsProto(config), kNodeId))
+    EXPECT_CALL(*node_mock_, PushChassisConfig(EqualsProto(config), kNodeId))
         .WillOnce(Return(::util::OkStatus()));
     EXPECT_OK(switch_->PushChassisConfig(config));
   }
@@ -119,7 +118,7 @@ class TofinoSwitchTest : public ::testing::Test {
 };
 
 TEST_F(TofinoSwitchTest, PushChassisConfigSucceeds) {
-    PushChassisConfigSuccessfully();
+  PushChassisConfigSuccessfully();
 }
 
 TEST_F(TofinoSwitchTest, PushChassisConfigFailsWhenNodePushFails) {
@@ -183,8 +182,7 @@ TEST_F(TofinoSwitchTest, PushForwardingPipelineConfigFailsWhenPushFails) {
   PushChassisConfigSuccessfully();
 
   ::p4::v1::ForwardingPipelineConfig config;
-  EXPECT_CALL(*node_mock_,
-              PushForwardingPipelineConfig(EqualsProto(config)))
+  EXPECT_CALL(*node_mock_, PushForwardingPipelineConfig(EqualsProto(config)))
       .WillOnce(Return(DefaultError()));
   EXPECT_THAT(switch_->PushForwardingPipelineConfig(kNodeId, config),
               DerivedFromStatus(DefaultError()));
@@ -195,8 +193,7 @@ TEST_F(TofinoSwitchTest, VerifyForwardingPipelineConfigSucceeds) {
 
   ::p4::v1::ForwardingPipelineConfig config;
   // Verify should always be called before push.
-  EXPECT_CALL(*node_mock_,
-              VerifyForwardingPipelineConfig(EqualsProto(config)))
+  EXPECT_CALL(*node_mock_, VerifyForwardingPipelineConfig(EqualsProto(config)))
       .WillOnce(Return(::util::OkStatus()));
   EXPECT_OK(switch_->VerifyForwardingPipelineConfig(kNodeId, config));
 }


### PR DESCRIPTION
This brings the code into conformance with Stratum coding standards. It's the first step in getting it ready to upstream.