### PR TITLE
Replace RETURN_ERROR() with return MAKE_ERROR()

### DIFF
--- a/stratum/glue/status/canonical_errors.cc
+++ b/stratum/glue/status/canonical_errors.cc
@@ -2,7 +2,6 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 #include "stratum/glue/status/canonical_errors.h"
 
 namespace util {
@@ -71,9 +70,7 @@ Status UnknownError(const std::string& message) {
   return Status(error::UNKNOWN, message);
 }
 
-bool IsAborted(const Status& status) {
-  return status.Matches(error::ABORTED);
-}
+bool IsAborted(const Status& status) { return status.Matches(error::ABORTED); }
 
 bool IsAlreadyExists(const Status& status) {
   return status.Matches(error::ALREADY_EXISTS);
@@ -131,8 +128,6 @@ bool IsUnimplemented(const Status& status) {
   return status.Matches(error::UNIMPLEMENTED);
 }
 
-bool IsUnknown(const Status& status) {
-  return status.Matches(error::UNKNOWN);
-}
+bool IsUnknown(const Status& status) { return status.Matches(error::UNKNOWN); }
 
 }  // namespace util

--- a/stratum/glue/status/canonical_errors.h
+++ b/stratum/glue/status/canonical_errors.h
@@ -2,7 +2,6 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 #ifndef STRATUM_GLUE_STATUS_CANONICAL_ERRORS_H_
 #define STRATUM_GLUE_STATUS_CANONICAL_ERRORS_H_
 

--- a/stratum/glue/status/posix_error_space.h
+++ b/stratum/glue/status/posix_error_space.h
@@ -2,7 +2,6 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 // This package defines the POSIX error space (think 'errno'
 // values). Given a (stable) errno value, this class can be used to
 // translate that value to a string description by calling the
@@ -20,7 +19,6 @@
 // circuited by the implementation of Status to be equivalent to
 // Status::OK, ignoring this error space and the provided message.
 //
-
 
 #ifndef STRATUM_GLUE_STATUS_POSIX_ERROR_SPACE_H_
 #define STRATUM_GLUE_STATUS_POSIX_ERROR_SPACE_H_

--- a/stratum/glue/status/posix_error_space_test.cc
+++ b/stratum/glue/status/posix_error_space_test.cc
@@ -2,11 +2,11 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 #include "stratum/glue/status/posix_error_space.h"
 
 #include <errno.h>
 #include <stddef.h>
+
 #include <string>
 
 #include "gtest/gtest.h"

--- a/stratum/glue/status/status_macros.h
+++ b/stratum/glue/status/status_macros.h
@@ -12,13 +12,14 @@
 //   ::util::StatusOr<ValueType> Method(arg, ...);
 //
 // Inside the method, to return errors, use the macros
-//   RETURN_ERROR() << "Message with ::util::error::UNKNOWN code";
-//   RETURN_ERROR(code_enum)
-//       << "Message with an error code, in that error_code's ErrorSpace "
-//       << "(See ErrorCodeOptions below)";
-//   RETURN_ERROR(error_space, code_int)
-//       << "Message with integer error code in specified ErrorSpace "
-//       << "(Not recommended - use previous form with an enum code instead)";
+//   return MAKE_ERROR() << "Message with ::util::error::UNKNOWN code";
+//   return MAKE_ERROR(code_enum)
+//          << "Message with an error code, in that error_code's ErrorSpace "
+//          << "(See ErrorCodeOptions below)";
+//   return MAKE_ERROR(error_space, code_int)
+//          << "Message with integer error code in specified ErrorSpace "
+//          << "(Not recommended - use previous form with an enum code "
+//          << "instead)";
 //
 // When calling another method, use this to propagate status easily.
 //   RETURN_IF_ERROR(method(args));
@@ -45,11 +46,7 @@
 // WARNING: ASSIGN_OR_RETURN expands into multiple statements; it cannot be used
 //  in a single statement (e.g. as the body of an if statement without {})!
 //
-// This can optionally be used to return ::util::Status::OK.
-//   RETURN_OK();
-//
-// To construct an error without immediately returning it, use MAKE_ERROR,
-// which supports the same argument types as RETURN_ERROR.
+// To construct an error without immediately returning it, use MAKE_ERROR.
 //   ::util::Status status = MAKE_ERROR(...) << "Message";
 //
 // To add additional text onto an existing error, use
@@ -61,7 +58,7 @@
 // They can also be used to return from a function that returns
 // ::util::StatusOr:
 //   ::util::StatusOr<T> MyFunction() {
-//     RETURN_ERROR(...) << "Message";
+//     return MAKE_ERROR(...) << "Message";
 //   }
 //
 //
@@ -78,16 +75,16 @@
 //
 // Logging:
 //
-// RETURN_ERROR and MAKE_ERROR log the error to LOG(ERROR) by default.
+// MAKE_ERROR logs the error to LOG(ERROR) by default.
 //
 // Logging can be turned on or off for a specific error by using
-//   RETURN_ERROR().with_logging() << "Message logged to LOG(ERROR)";
-//   RETURN_ERROR().without_logging() << "Message not logged";
-//   RETURN_ERROR().set_logging(false) << "Message not logged";
-//   RETURN_ERROR().severity(INFO) << "Message logged to LOG(INFO)";
+//   return MAKE_ERROR().with_logging() << "Message logged to LOG(ERROR)";
+//   return MAKE_ERROR().without_logging() << "Message not logged";
+//   return MAKE_ERROR().set_logging(false) << "Message not logged";
+//   return MAKE_ERROR().severity(INFO) << "Message logged to LOG(INFO)";
 //
 // If logging is enabled, this will make an error also log a stack trace.
-//   RETURN_ERROR().with_log_stack_trace() << "Message";
+//   return MAKE_ERROR().with_log_stack_trace() << "Message";
 //
 // Logging can also be controlled within a scope using
 // ScopedErrorLogSuppression.
@@ -372,15 +369,6 @@ class MakeErrorStream {
 //   return APPEND_ERROR(status) << ", more details";
 #define APPEND_ERROR(status) \
   ::util::status_macros::MakeErrorStream((status), __FILE__, __LINE__)
-
-// Shorthand to make an error (with MAKE_ERROR) and return it.
-//   if (error) {
-//     RETURN_ERROR() << "Message";
-//   }
-#define RETURN_ERROR return MAKE_ERROR
-
-// Return success.
-#define RETURN_OK() return ::util::Status::OK
 
 // Wraps a ::util::Status so it can be assigned and used in an if-statement.
 // Implicitly converts from status and to bool.

--- a/stratum/hal/bin/barefoot/bf_pipeline_builder.cc
+++ b/stratum/hal/bin/barefoot/bf_pipeline_builder.cc
@@ -47,7 +47,7 @@ p4_device_config field of the P4Runtime SetForwardingPipelineConfig message.
   // TODO(max): replace with <filesystem> once we move to C++17
   char* resolved_path = realpath(FLAGS_unpack_dir.c_str(), nullptr);
   if (!resolved_path) {
-    RETURN_ERROR(ERR_INTERNAL) << "Unable to resolve path " << FLAGS_unpack_dir;
+    return MAKE_ERROR(ERR_INTERNAL) << "Unable to resolve path " << FLAGS_unpack_dir;
   }
   std::string base_path(resolved_path);
   free(resolved_path);

--- a/stratum/hal/bin/np4intel/main.cc
+++ b/stratum/hal/bin/np4intel/main.cc
@@ -102,7 +102,7 @@ void registerDeviceMgrLogger() {
 
     // Now log the return code message
     if (rc != 0) {
-      RETURN_ERROR(ERR_INTERNAL) << "DPDK EAL Init failed";
+      return MAKE_ERROR(ERR_INTERNAL) << "DPDK EAL Init failed";
     }
     LOG(INFO) << "DPDK EAL Init successful";
   }

--- a/stratum/hal/bin/tdi/tdi_pipeline_builder.cc
+++ b/stratum/hal/bin/tdi/tdi_pipeline_builder.cc
@@ -48,7 +48,7 @@ p4_device_config field of the P4Runtime SetForwardingPipelineConfig message.
   // TODO(max): replace with <filesystem> once we move to C++17
   char* resolved_path = realpath(FLAGS_unpack_dir.c_str(), nullptr);
   if (!resolved_path) {
-    RETURN_ERROR(ERR_INTERNAL) << "Unable to resolve path " << FLAGS_unpack_dir;
+    return MAKE_ERROR(ERR_INTERNAL) << "Unable to resolve path " << FLAGS_unpack_dir;
   }
   std::string base_path(resolved_path);
   free(resolved_path);

--- a/stratum/hal/config/chassis_config_migrator.cc
+++ b/stratum/hal/config/chassis_config_migrator.cc
@@ -72,7 +72,7 @@ ls -1 stratum/hal/config/*/chassis_config.pb.txt | \
   RETURN_IF_ERROR(ReadProtoFromTextFile(FLAGS_chassis_config_file, &config));
   if (config.chassis().platform() != PLT_GENERIC_BAREFOOT_TOFINO &&
       config.chassis().platform() != PLT_GENERIC_BAREFOOT_TOFINO2) {
-    RETURN_ERROR(ERR_INVALID_PARAM)
+    return MAKE_ERROR(ERR_INVALID_PARAM)
         << "Chassis config is not for a Tofino platform";
   }
   for (auto& singleton_port : *config.mutable_singleton_ports()) {

--- a/stratum/hal/lib/barefoot/bf_chassis_manager.cc
+++ b/stratum/hal/lib/barefoot/bf_chassis_manager.cc
@@ -92,14 +92,14 @@ BfChassisManager::~BfChassisManager() = default;
 
   const auto& config_params = singleton_port.config_params();
   if (config_params.admin_state() == ADMIN_STATE_UNKNOWN) {
-    RETURN_ERROR(ERR_INVALID_PARAM)
-        << "Invalid admin state for port " << port_id << " in node " << node_id
-        << " (SDK Port " << sdk_port_id << ").";
+    return MAKE_ERROR(ERR_INVALID_PARAM)
+           << "Invalid admin state for port " << port_id << " in node "
+           << node_id << " (SDK Port " << sdk_port_id << ").";
   }
   if (config_params.admin_state() == ADMIN_STATE_DIAG) {
-    RETURN_ERROR(ERR_UNIMPLEMENTED)
-        << "Unsupported 'diags' admin state for port " << port_id << " in node "
-        << node_id << " (SDK Port " << sdk_port_id << ").";
+    return MAKE_ERROR(ERR_UNIMPLEMENTED)
+           << "Unsupported 'diags' admin state for port " << port_id
+           << " in node " << node_id << " (SDK Port " << sdk_port_id << ").";
   }
 
   LOG(INFO) << "Adding port " << port_id << " in node " << node_id
@@ -156,9 +156,9 @@ BfChassisManager::~BfChassisManager() = default;
     config->admin_state = ADMIN_STATE_UNKNOWN;
     config->speed_bps.reset();
     config->fec_mode.reset();
-    RETURN_ERROR(ERR_INTERNAL)
-        << "Port " << port_id << " in node " << node_id << " is not valid"
-        << " (SDK Port " << sdk_port_id << ").";
+    return MAKE_ERROR(ERR_INTERNAL)
+           << "Port " << port_id << " in node " << node_id << " is not valid"
+           << " (SDK Port " << sdk_port_id << ").";
   }
 
   const auto& config_params = singleton_port.config_params();
@@ -185,29 +185,29 @@ BfChassisManager::~BfChassisManager() = default;
       if (config_old.fec_mode)
         port_old.mutable_config_params()->set_fec_mode(*config_old.fec_mode);
       AddPortHelper(node_id, unit, sdk_port_id, port_old, config);
-      RETURN_ERROR(ERR_INVALID_PARAM)
-          << "Could not add port " << port_id << " with new speed "
-          << singleton_port.speed_bps() << " to BF SDE"
-          << " (SDK Port " << sdk_port_id << ").";
+      return MAKE_ERROR(ERR_INVALID_PARAM)
+             << "Could not add port " << port_id << " with new speed "
+             << singleton_port.speed_bps() << " to BF SDE"
+             << " (SDK Port " << sdk_port_id << ").";
     }
   }
   // same for FEC mode
   if (config_params.fec_mode() != config_old.fec_mode) {
-    RETURN_ERROR(ERR_UNIMPLEMENTED)
-        << "The FEC mode for port " << port_id << " in node " << node_id
-        << " has changed; you need to delete the port and add it again"
-        << " (SDK Port " << sdk_port_id << ").";
+    return MAKE_ERROR(ERR_UNIMPLEMENTED)
+           << "The FEC mode for port " << port_id << " in node " << node_id
+           << " has changed; you need to delete the port and add it again"
+           << " (SDK Port " << sdk_port_id << ").";
   }
 
   if (config_params.admin_state() == ADMIN_STATE_UNKNOWN) {
-    RETURN_ERROR(ERR_INVALID_PARAM)
-        << "Invalid admin state for port " << port_id << " in node " << node_id
-        << " (SDK Port " << sdk_port_id << ").";
+    return MAKE_ERROR(ERR_INVALID_PARAM)
+           << "Invalid admin state for port " << port_id << " in node "
+           << node_id << " (SDK Port " << sdk_port_id << ").";
   }
   if (config_params.admin_state() == ADMIN_STATE_DIAG) {
-    RETURN_ERROR(ERR_UNIMPLEMENTED)
-        << "Unsupported 'diags' admin state for port " << port_id << " in node "
-        << node_id << " (SDK Port " << sdk_port_id << ").";
+    return MAKE_ERROR(ERR_UNIMPLEMENTED)
+           << "Unsupported 'diags' admin state for port " << port_id
+           << " in node " << node_id << " (SDK Port " << sdk_port_id << ").";
   }
 
   bool config_changed = false;
@@ -314,9 +314,9 @@ BfChassisManager::~BfChassisManager() = default;
 
     auto* unit = gtl::FindOrNull(node_id_to_unit, node_id);
     if (unit == nullptr) {
-      RETURN_ERROR(ERR_INVALID_PARAM)
-          << "Invalid ChassisConfig, unknown node id " << node_id
-          << " for port " << port_id << ".";
+      return MAKE_ERROR(ERR_INVALID_PARAM)
+             << "Invalid ChassisConfig, unknown node id " << node_id
+             << " for port " << port_id << ".";
     }
     node_id_to_port_id_to_port_state[node_id][port_id] = PORT_STATE_UNKNOWN;
     node_id_to_port_id_to_time_last_changed[node_id][port_id] =
@@ -379,9 +379,9 @@ BfChassisManager::~BfChassisManager() = default;
       // sanity-check: if admin_state is not ADMIN_STATE_UNKNOWN, then the port
       // was added and the speed_bps was set.
       if (!config_old->speed_bps) {
-        RETURN_ERROR(ERR_INTERNAL)
-            << "Invalid internal state in BfChassisManager, "
-            << "speed_bps field should contain a value";
+        return MAKE_ERROR(ERR_INTERNAL)
+               << "Invalid internal state in BfChassisManager, "
+               << "speed_bps field should contain a value";
       }
 
       // if anything fails, config.admin_state will be set to
@@ -445,9 +445,9 @@ BfChassisManager::~BfChassisManager() = default;
             break;
           }
           default:
-            RETURN_ERROR(ERR_INVALID_PARAM)
-                << "Unsupported port type in DropTarget "
-                << drop_target.ShortDebugString();
+            return MAKE_ERROR(ERR_INVALID_PARAM)
+                   << "Unsupported port type in DropTarget "
+                   << drop_target.ShortDebugString();
         }
         RETURN_IF_ERROR(bf_sde_interface_->SetDeflectOnDropDestination(
             unit, sdk_port_id, drop_target.queue()));
@@ -515,9 +515,9 @@ BfChassisManager::~BfChassisManager() = default;
           shaping_config.byte_shaping().max_rate_bps()));
       break;
     default:
-      RETURN_ERROR(ERR_INVALID_PARAM)
-          << "Invalid port shaping config " << shaping_config.ShortDebugString()
-          << ".";
+      return MAKE_ERROR(ERR_INVALID_PARAM)
+             << "Invalid port shaping config "
+             << shaping_config.ShortDebugString() << ".";
   }
   RETURN_IF_ERROR(
       bf_sde_interface_->EnablePortShaping(unit, sdk_port_id, TRI_STATE_TRUE));
@@ -643,17 +643,17 @@ BfChassisManager::~BfChassisManager() = default;
   if (initialized_) {
     if (node_id_to_port_id_to_singleton_port_key !=
         node_id_to_port_id_to_singleton_port_key_) {
-      RETURN_ERROR(ERR_REBOOT_REQUIRED)
-          << "The switch is already initialized, but we detected the newly "
-          << "pushed config requires a change in the port layout. The stack "
-          << "needs to be rebooted to finish config push.";
+      return MAKE_ERROR(ERR_REBOOT_REQUIRED)
+             << "The switch is already initialized, but we detected the newly "
+             << "pushed config requires a change in the port layout. The stack "
+             << "needs to be rebooted to finish config push.";
     }
 
     if (node_id_to_unit != node_id_to_unit_) {
-      RETURN_ERROR(ERR_REBOOT_REQUIRED)
-          << "The switch is already initialized, but we detected the newly "
-          << "pushed config requires a change in node_id_to_unit. The stack "
-          << "needs to be rebooted to finish config push.";
+      return MAKE_ERROR(ERR_REBOOT_REQUIRED)
+             << "The switch is already initialized, but we detected the newly "
+             << "pushed config requires a change in node_id_to_unit. The stack "
+             << "needs to be rebooted to finish config push.";
     }
   }
 
@@ -832,7 +832,7 @@ BfChassisManager::GetPortConfig(uint64 node_id, uint32 port_id) const {
       break;
     }
     default:
-      RETURN_ERROR(ERR_INTERNAL) << "Not supported yet";
+      return MAKE_ERROR(ERR_INTERNAL) << "Not supported yet";
   }
   return resp;
 }
@@ -926,14 +926,14 @@ BfChassisManager::GetPortConfig(uint64 node_id, uint32 port_id) const {
     }
 
     if (!config.speed_bps) {
-      RETURN_ERROR(ERR_INTERNAL)
-          << "Invalid internal state in BfChassisManager, "
-          << "speed_bps field should contain a value";
+      return MAKE_ERROR(ERR_INTERNAL)
+             << "Invalid internal state in BfChassisManager, "
+             << "speed_bps field should contain a value";
     }
     if (!config.fec_mode) {
-      RETURN_ERROR(ERR_INTERNAL)
-          << "Invalid internal state in BfChassisManager, "
-          << "fec_mode field should contain a value";
+      return MAKE_ERROR(ERR_INTERNAL)
+             << "Invalid internal state in BfChassisManager, "
+             << "fec_mode field should contain a value";
     }
 
     ASSIGN_OR_RETURN(auto sdk_port_id, GetSdkPortId(node_id, port_id));
@@ -999,9 +999,9 @@ BfChassisManager::GetPortConfig(uint64 node_id, uint32 port_id) const {
         break;
       }
       default:
-        RETURN_ERROR(ERR_INVALID_PARAM)
-            << "Unsupported port type in DropTarget "
-            << drop_target.ShortDebugString();
+        return MAKE_ERROR(ERR_INVALID_PARAM)
+               << "Unsupported port type in DropTarget "
+               << drop_target.ShortDebugString();
     }
 
     RETURN_IF_ERROR(bf_sde_interface_->SetDeflectOnDropDestination(

--- a/stratum/hal/lib/barefoot/bf_pipeline_utils.cc
+++ b/stratum/hal/lib/barefoot/bf_pipeline_utils.cc
@@ -40,7 +40,8 @@ std::string Uint32ToLeByteStream(uint32 val) {
     return util::OkStatus();
   }
 
-  RETURN_ERROR(ERR_INVALID_PARAM) << "Unknown format for p4_device_config.";
+  return MAKE_ERROR(ERR_INVALID_PARAM)
+         << "Unknown format for p4_device_config.";
 }
 
 ::util::Status BfPipelineConfigToPiConfig(const BfPipelineConfig& bf_config,

--- a/stratum/hal/lib/barefoot/bf_sde_wrapper.cc
+++ b/stratum/hal/lib/barefoot/bf_sde_wrapper.cc
@@ -138,8 +138,8 @@ inline constexpr uint64 BytesPerSecondToKbits(uint64 bytes) {
         break;
       }
       default:
-        RETURN_ERROR(ERR_INTERNAL)
-            << "Unknown key_type: " << static_cast<int>(key_type) << ".";
+        return MAKE_ERROR(ERR_INTERNAL)
+               << "Unknown key_type: " << static_cast<int>(key_type) << ".";
     }
 
     absl::StrAppend(&s, field_name, " { field_id: ", field_id,
@@ -224,8 +224,8 @@ inline constexpr uint64 BytesPerSecondToKbits(uint64 bytes) {
         break;
       }
       default:
-        RETURN_ERROR(ERR_INTERNAL)
-            << "Unknown data_type: " << static_cast<int>(data_type) << ".";
+        return MAKE_ERROR(ERR_INTERNAL)
+               << "Unknown data_type: " << static_cast<int>(data_type) << ".";
     }
 
     absl::StrAppend(&s, field_name, " { field_id: ", field_id,
@@ -795,8 +795,8 @@ TableKey::CreateTableKey(const bfrt::BfRtInfo* bfrt_info_, int table_id) {
   bool is_active;
   RETURN_IF_BFRT_ERROR(table_data_->isActive(field_id, &is_active));
   if (!is_active) {
-    RETURN_ERROR(ERR_ENTRY_NOT_FOUND).without_logging()
-        << "Field $ACTION_MEMBER_ID is not active.";
+    return MAKE_ERROR(ERR_ENTRY_NOT_FOUND).without_logging()
+           << "Field $ACTION_MEMBER_ID is not active.";
   }
   RETURN_IF_BFRT_ERROR(table_data_->getValue(field_id, action_member_id));
 
@@ -827,8 +827,8 @@ TableKey::CreateTableKey(const bfrt::BfRtInfo* bfrt_info_, int table_id) {
   bool is_active;
   RETURN_IF_BFRT_ERROR(table_data_->isActive(field_id, &is_active));
   if (!is_active) {
-    RETURN_ERROR(ERR_ENTRY_NOT_FOUND).without_logging()
-        << "Field $SELECTOR_GROUP_ID is not active.";
+    return MAKE_ERROR(ERR_ENTRY_NOT_FOUND).without_logging()
+           << "Field $SELECTOR_GROUP_ID is not active.";
   }
   RETURN_IF_BFRT_ERROR(table_data_->getValue(field_id, selector_group_id));
 
@@ -988,7 +988,7 @@ bf_status_t sde_port_status_callback(bf_dev_id_t device, bf_dev_port_t dev_port,
     case kHundredGigBps:
       return BF_SPEED_100G;
     default:
-      RETURN_ERROR(ERR_INVALID_PARAM) << "Unsupported port speed.";
+      return MAKE_ERROR(ERR_INVALID_PARAM) << "Unsupported port speed.";
   }
 }
 
@@ -1001,7 +1001,7 @@ bf_status_t sde_port_status_callback(bf_dev_id_t device, bf_dev_port_t dev_port,
     case TRI_STATE_FALSE:
       return 2;
     default:
-      RETURN_ERROR(ERR_INVALID_PARAM) << "Invalid autoneg state.";
+      return MAKE_ERROR(ERR_INVALID_PARAM) << "Invalid autoneg state.";
   }
 }
 
@@ -1013,7 +1013,8 @@ bf_status_t sde_port_status_callback(bf_dev_id_t device, bf_dev_port_t dev_port,
     // we have to "guess" the FEC type to use based on the port speed.
     switch (speed_bps) {
       case kOneGigBps:
-        RETURN_ERROR(ERR_INVALID_PARAM) << "Invalid FEC mode for 1Gbps mode.";
+        return MAKE_ERROR(ERR_INVALID_PARAM)
+               << "Invalid FEC mode for 1Gbps mode.";
       case kTenGigBps:
       case kFortyGigBps:
         return BF_FEC_TYP_FIRECODE;
@@ -1024,10 +1025,10 @@ bf_status_t sde_port_status_callback(bf_dev_id_t device, bf_dev_port_t dev_port,
       case kFourHundredGigBps:
         return BF_FEC_TYP_REED_SOLOMON;
       default:
-        RETURN_ERROR(ERR_INVALID_PARAM) << "Unsupported port speed.";
+        return MAKE_ERROR(ERR_INVALID_PARAM) << "Unsupported port speed.";
     }
   }
-  RETURN_ERROR(ERR_INVALID_PARAM) << "Invalid FEC mode.";
+  return MAKE_ERROR(ERR_INVALID_PARAM) << "Invalid FEC mode.";
 }
 
 ::util::StatusOr<bf_loopback_mode_e> LoopbackModeToBf(
@@ -1038,9 +1039,9 @@ bf_status_t sde_port_status_callback(bf_dev_id_t device, bf_dev_port_t dev_port,
     case LOOPBACK_STATE_MAC:
       return BF_LPBK_MAC_NEAR;
     default:
-      RETURN_ERROR(ERR_INVALID_PARAM)
-          << "Unsupported loopback mode: " << LoopbackState_Name(loopback_mode)
-          << ".";
+      return MAKE_ERROR(ERR_INVALID_PARAM)
+             << "Unsupported loopback mode: "
+             << LoopbackState_Name(loopback_mode) << ".";
   }
 }
 
@@ -1182,7 +1183,7 @@ BfSdeWrapper::BfSdeWrapper() : port_status_event_writer_(nullptr) {}
 
 ::util::Status BfSdeWrapper::SetPortMtu(int device, int port, int32 mtu) {
   if (mtu < 0) {
-    RETURN_ERROR(ERR_INVALID_PARAM) << "Invalid MTU value.";
+    return MAKE_ERROR(ERR_INVALID_PARAM) << "Invalid MTU value.";
   }
   if (mtu == 0) mtu = kBfDefaultMtu;
   RETURN_IF_BFRT_ERROR(bf_pal_port_mtu_set(
@@ -1797,7 +1798,7 @@ namespace {
     }
   }
 
-  RETURN_ERROR(ERR_TABLE_FULL) << "Could not find free multicast node id.";
+  return MAKE_ERROR(ERR_TABLE_FULL) << "Could not find free multicast node id.";
 }
 
 ::util::StatusOr<uint32> BfSdeWrapper::CreateMulticastNode(
@@ -2379,7 +2380,7 @@ namespace {
     }
   }
 
-  RETURN_ERROR(ERR_INTERNAL) << "Could not find register data field id.";
+  return MAKE_ERROR(ERR_INTERNAL) << "Could not find register data field id.";
 }
 }  // namespace
 
@@ -2503,9 +2504,10 @@ namespace {
         break;
       }
       default:
-        RETURN_ERROR(ERR_INVALID_PARAM)
-            << "Unsupported register data type " << static_cast<int>(data_type)
-            << " for register in table " << table_id;
+        return MAKE_ERROR(ERR_INVALID_PARAM)
+               << "Unsupported register data type "
+               << static_cast<int>(data_type) << " for register in table "
+               << table_id;
     }
   }
 
@@ -2670,9 +2672,9 @@ namespace {
         RETURN_IF_BFRT_ERROR(table_data->getValue(field_id, &pburst));
         pbursts->push_back(pburst);
       } else {
-        RETURN_ERROR(ERR_INVALID_PARAM)
-            << "Unknown meter field " << field_name << " in meter with id "
-            << table_id << ".";
+        return MAKE_ERROR(ERR_INVALID_PARAM)
+               << "Unknown meter field " << field_name << " in meter with id "
+               << table_id << ".";
       }
     }
   }

--- a/stratum/hal/lib/barefoot/bfrt_action_profile_manager.cc
+++ b/stratum/hal/lib/barefoot/bfrt_action_profile_manager.cc
@@ -61,8 +61,8 @@ BfrtActionProfileManager::CreateInstance(BfSdeInterface* bf_sde_interface,
                                        act_prof_group);
     }
     default:
-      RETURN_ERROR(ERR_INVALID_PARAM)
-          << "Unsupported extern type " << entry.extern_type_id() << ".";
+      return MAKE_ERROR(ERR_INVALID_PARAM)
+             << "Unsupported extern type " << entry.extern_type_id() << ".";
   }
 }
 
@@ -94,8 +94,8 @@ BfrtActionProfileManager::CreateInstance(BfSdeInterface* bf_sde_interface,
       break;
     }
     default:
-      RETURN_ERROR(ERR_OPER_NOT_SUPPORTED)
-          << "Unsupported extern type " << entry.extern_type_id() << ".";
+      return MAKE_ERROR(ERR_OPER_NOT_SUPPORTED)
+             << "Unsupported extern type " << entry.extern_type_id() << ".";
   }
 
   return ::util::OkStatus();
@@ -191,7 +191,8 @@ BfrtActionProfileManager::CreateInstance(BfSdeInterface* bf_sde_interface,
       break;
     }
     default:
-      RETURN_ERROR(ERR_INVALID_PARAM) << "Unsupported update type: " << type;
+      return MAKE_ERROR(ERR_INVALID_PARAM)
+             << "Unsupported update type: " << type;
   }
 
   return ::util::OkStatus();
@@ -243,7 +244,7 @@ BfrtActionProfileManager::CreateInstance(BfSdeInterface* bf_sde_interface,
   }
 
   if (!writer->Write(resp)) {
-    RETURN_ERROR(ERR_INTERNAL) << "Write to stream channel failed.";
+    return MAKE_ERROR(ERR_INTERNAL) << "Write to stream channel failed.";
   }
 
   return ::util::OkStatus();
@@ -282,7 +283,8 @@ BfrtActionProfileManager::CreateInstance(BfSdeInterface* bf_sde_interface,
       break;
     }
     default:
-      RETURN_ERROR(ERR_INVALID_PARAM) << "Unsupported update type: " << type;
+      return MAKE_ERROR(ERR_INVALID_PARAM)
+             << "Unsupported update type: " << type;
   }
 
   return ::util::OkStatus();

--- a/stratum/hal/lib/barefoot/bfrt_node.cc
+++ b/stratum/hal/lib/barefoot/bfrt_node.cc
@@ -411,8 +411,9 @@ std::unique_ptr<BfrtNode> BfrtNode::CreateInstance(
       return bfrt_packetio_manager_->TransmitPacket(req.packet());
     }
     default:
-      RETURN_ERROR(ERR_UNIMPLEMENTED) << "Unsupported StreamMessageRequest "
-                                      << req.ShortDebugString() << ".";
+      return MAKE_ERROR(ERR_UNIMPLEMENTED)
+             << "Unsupported StreamMessageRequest " << req.ShortDebugString()
+             << ".";
   }
 }
 
@@ -425,8 +426,8 @@ std::unique_ptr<BfrtNode> BfrtNode::CreateInstance(
       return bfrt_action_profile_manager_->WriteActionProfileEntry(session,
                                                                    type, entry);
     default:
-      RETURN_ERROR() << "Unsupported extern entry: " << entry.ShortDebugString()
-                     << ".";
+      return MAKE_ERROR() << "Unsupported extern entry: "
+                          << entry.ShortDebugString() << ".";
   }
 }
 
@@ -440,8 +441,8 @@ std::unique_ptr<BfrtNode> BfrtNode::CreateInstance(
       return bfrt_action_profile_manager_->ReadActionProfileEntry(
           session, entry, writer);
     default:
-      RETURN_ERROR(ERR_OPER_NOT_SUPPORTED)
-          << "Unsupported extern entry: " << entry.ShortDebugString() << ".";
+      return MAKE_ERROR(ERR_OPER_NOT_SUPPORTED)
+             << "Unsupported extern entry: " << entry.ShortDebugString() << ".";
   }
 }
 

--- a/stratum/hal/lib/barefoot/bfrt_packetio_manager.cc
+++ b/stratum/hal/lib/barefoot/bfrt_packetio_manager.cc
@@ -65,9 +65,9 @@ std::unique_ptr<BfrtPacketioManager> BfrtPacketioManager::CreateInstance(
         int ret = pthread_create(&sde_rx_thread_id_, nullptr,
                                  &BfrtPacketioManager::SdeRxThreadFunc, this);
         if (ret != 0) {
-          RETURN_ERROR(ERR_INTERNAL)
-              << "Failed to spawn RX thread for SDE wrapper for device with ID "
-              << device_ << ". Err: " << ret << ".";
+          return MAKE_ERROR(ERR_INTERNAL) << "Failed to spawn RX thread for "
+                                             "SDE wrapper for device with ID "
+                                          << device_ << ". Err: " << ret << ".";
         }
       }
       RETURN_IF_ERROR(bf_sde_interface_->RegisterPacketReceiveWriter(
@@ -281,7 +281,8 @@ class BitBuffer {
     const ::p4::v1::PacketOut& packet) {
   {
     absl::ReaderMutexLock l(&data_lock_);
-    if (!initialized_) RETURN_ERROR(ERR_NOT_INITIALIZED) << "Not initialized.";
+    if (!initialized_)
+      return MAKE_ERROR(ERR_NOT_INITIALIZED) << "Not initialized.";
   }
   std::string buf;
   RETURN_IF_ERROR(DeparsePacketOut(packet, &buf));
@@ -296,7 +297,8 @@ class BitBuffer {
   std::unique_ptr<ChannelReader<std::string>> reader;
   {
     absl::ReaderMutexLock l(&data_lock_);
-    if (!initialized_) RETURN_ERROR(ERR_NOT_INITIALIZED) << "Not initialized.";
+    if (!initialized_)
+      return MAKE_ERROR(ERR_NOT_INITIALIZED) << "Not initialized.";
     reader = ChannelReader<std::string>::Create(packet_receive_channel_);
   }
 

--- a/stratum/hal/lib/barefoot/bfrt_pre_manager.cc
+++ b/stratum/hal/lib/barefoot/bfrt_pre_manager.cc
@@ -37,8 +37,8 @@ BfrtPreManager::BfrtPreManager(BfSdeInterface* bf_sde_interface, int device)
     case PreEntry::kCloneSessionEntry:
       return WriteCloneSessionEntry(session, type, entry.clone_session_entry());
     default:
-      RETURN_ERROR(ERR_UNIMPLEMENTED)
-          << "Unsupported PRE entry: " << entry.ShortDebugString();
+      return MAKE_ERROR(ERR_UNIMPLEMENTED)
+             << "Unsupported PRE entry: " << entry.ShortDebugString();
   }
 }
 
@@ -58,8 +58,8 @@ BfrtPreManager::BfrtPreManager(BfSdeInterface* bf_sde_interface, int device)
       break;
     }
     default:
-      RETURN_ERROR(ERR_UNIMPLEMENTED)
-          << "Unsupported PRE entry: " << entry.ShortDebugString();
+      return MAKE_ERROR(ERR_UNIMPLEMENTED)
+             << "Unsupported PRE entry: " << entry.ShortDebugString();
   }
 
   return ::util::OkStatus();
@@ -154,7 +154,8 @@ std::unique_ptr<BfrtPreManager> BfrtPreManager::CreateInstance(
       break;
     }
     default:
-      RETURN_ERROR(ERR_UNIMPLEMENTED) << "Unsupported update type: " << type;
+      return MAKE_ERROR(ERR_UNIMPLEMENTED)
+             << "Unsupported update type: " << type;
   }
   return ::util::OkStatus();
 }
@@ -271,9 +272,9 @@ std::unique_ptr<BfrtPreManager> BfrtPreManager::CreateInstance(
       break;
     }
     default:
-      RETURN_ERROR(ERR_UNIMPLEMENTED)
-          << "Unsupported update type: " << type << " on CloneSessionEntry "
-          << entry.ShortDebugString() << ".";
+      return MAKE_ERROR(ERR_UNIMPLEMENTED)
+             << "Unsupported update type: " << type << " on CloneSessionEntry "
+             << entry.ShortDebugString() << ".";
   }
 
   return ::util::OkStatus();

--- a/stratum/hal/lib/barefoot/bfrt_table_manager.cc
+++ b/stratum/hal/lib/barefoot/bfrt_table_manager.cc
@@ -101,8 +101,8 @@ std::unique_ptr<BfrtTableManager> BfrtTableManager::CreateInstance(
   auto last = std::unique(intervals_ms.begin(), intervals_ms.end());
   intervals_ms.erase(last, intervals_ms.end());
   if (intervals_ms.size() != 1) {
-    RETURN_ERROR(ERR_INVALID_PARAM)
-        << "Inconsistent register reset intervals are not supported.";
+    return MAKE_ERROR(ERR_INVALID_PARAM)
+           << "Inconsistent register reset intervals are not supported.";
   }
 
   TimerDaemon::DescriptorPtr handle;
@@ -216,8 +216,9 @@ std::unique_ptr<BfrtTableManager> BfrtTableManager::CreateInstance(
           CHECK_RETURN_IF_FALSE(!IsDontCareMatch(mk.optional()));
           ABSL_FALLTHROUGH_INTENDED;
         default:
-          RETURN_ERROR(ERR_INVALID_PARAM)
-              << "Invalid or unsupported match key: " << mk.ShortDebugString();
+          return MAKE_ERROR(ERR_INVALID_PARAM)
+                 << "Invalid or unsupported match key: "
+                 << mk.ShortDebugString();
       }
     } else {
       switch (expected_match_field.match_type()) {
@@ -234,21 +235,22 @@ std::unique_ptr<BfrtTableManager> BfrtTableManager::CreateInstance(
           break;
         }
         default:
-          RETURN_ERROR(ERR_INVALID_PARAM)
-              << "Invalid field match type "
-              << ::p4::config::v1::MatchField_MatchType_Name(
-                     expected_match_field.match_type())
-              << ".";
+          return MAKE_ERROR(ERR_INVALID_PARAM)
+                 << "Invalid field match type "
+                 << ::p4::config::v1::MatchField_MatchType_Name(
+                        expected_match_field.match_type())
+                 << ".";
       }
     }
   }
 
   // Priority handling.
   if (!needs_priority && table_entry.priority()) {
-    RETURN_ERROR(ERR_INVALID_PARAM) << "Non-zero priority for exact/LPM match.";
+    return MAKE_ERROR(ERR_INVALID_PARAM)
+           << "Non-zero priority for exact/LPM match.";
   } else if (needs_priority && table_entry.priority() == 0) {
-    RETURN_ERROR(ERR_INVALID_PARAM)
-        << "Zero priority for ternary/range/optional match.";
+    return MAKE_ERROR(ERR_INVALID_PARAM)
+           << "Zero priority for ternary/range/optional match.";
   } else if (needs_priority) {
     ASSIGN_OR_RETURN(uint64 priority,
                      ConvertPriorityFromP4rtToBfrt(table_entry.priority()));
@@ -286,8 +288,8 @@ std::unique_ptr<BfrtTableManager> BfrtTableManager::CreateInstance(
       break;
     case ::p4::v1::TableAction::kActionProfileActionSet:
     default:
-      RETURN_ERROR(ERR_UNIMPLEMENTED)
-          << "Unsupported action type: " << table_entry.action().type_case();
+      return MAKE_ERROR(ERR_UNIMPLEMENTED)
+             << "Unsupported action type: " << table_entry.action().type_case();
   }
 
   if (table_entry.has_counter_data()) {
@@ -314,9 +316,9 @@ std::unique_ptr<BfrtTableManager> BfrtTableManager::CreateInstance(
 
   if (!table_entry.is_default_action()) {
     if (table.is_const_table()) {
-      RETURN_ERROR(ERR_PERMISSION_DENIED)
-          << "Can't write to table " << table.preamble().name()
-          << " because it has const entries.";
+      return MAKE_ERROR(ERR_PERMISSION_DENIED)
+             << "Can't write to table " << table.preamble().name()
+             << " because it has const entries.";
     }
     ASSIGN_OR_RETURN(auto table_key,
                      bf_sde_interface_->CreateTableKey(table_id));
@@ -343,9 +345,9 @@ std::unique_ptr<BfrtTableManager> BfrtTableManager::CreateInstance(
             device_, session, table_id, table_key.get()));
         break;
       default:
-        RETURN_ERROR(ERR_INTERNAL)
-            << "Unsupported update type: " << type << " in table entry "
-            << table_entry.ShortDebugString() << ".";
+        return MAKE_ERROR(ERR_INTERNAL)
+               << "Unsupported update type: " << type << " in table entry "
+               << table_entry.ShortDebugString() << ".";
     }
   } else {
     CHECK_RETURN_IF_FALSE(type == ::p4::v1::Update::MODIFY)
@@ -435,11 +437,11 @@ std::unique_ptr<BfrtTableManager> BfrtTableManager::CreateInstance(
         break;
       }
       default:
-        RETURN_ERROR(ERR_INVALID_PARAM)
-            << "Invalid field match type "
-            << ::p4::config::v1::MatchField_MatchType_Name(
-                   expected_match_field.match_type())
-            << ".";
+        return MAKE_ERROR(ERR_INVALID_PARAM)
+               << "Invalid field match type "
+               << ::p4::config::v1::MatchField_MatchType_Name(
+                      expected_match_field.match_type())
+               << ".";
     }
   }
 
@@ -849,8 +851,9 @@ BfrtTableManager::ReadDirectCounterEntry(
         meter_units_in_bits = false;
         break;
       default:
-        RETURN_ERROR(ERR_INVALID_PARAM) << "Unsupported meter spec on meter "
-                                        << meter.ShortDebugString() << ".";
+        return MAKE_ERROR(ERR_INVALID_PARAM)
+               << "Unsupported meter spec on meter " << meter.ShortDebugString()
+               << ".";
     }
   }
   // Index 0 is a valid value and not a wildcard.
@@ -914,8 +917,9 @@ BfrtTableManager::ReadDirectCounterEntry(
         meter_units_in_packets = true;
         break;
       default:
-        RETURN_ERROR(ERR_INVALID_PARAM) << "Unsupported meter spec on meter "
-                                        << meter.ShortDebugString() << ".";
+        return MAKE_ERROR(ERR_INVALID_PARAM)
+               << "Unsupported meter spec on meter " << meter.ShortDebugString()
+               << ".";
     }
   }
 

--- a/stratum/hal/lib/bcm/bcm_node.cc
+++ b/stratum/hal/lib/bcm/bcm_node.cc
@@ -357,7 +357,7 @@ BcmNode::~BcmNode() {}
           GoogleConfig::BCM_KNET_INTF_PURPOSE_CONTROLLER, req.packet());
     }
     default:
-      RETURN_ERROR(ERR_UNIMPLEMENTED) << "Unsupported StreamMessageRequest "
+      return MAKE_ERROR(ERR_UNIMPLEMENTED) << "Unsupported StreamMessageRequest "
                                       << req.ShortDebugString() << ".";
   }
 }

--- a/stratum/hal/lib/bcm/sdk/bcm_sdk_wrapper.cc
+++ b/stratum/hal/lib/bcm/sdk/bcm_sdk_wrapper.cc
@@ -3073,7 +3073,7 @@ bcm_field_qualify_t HalAclFieldToBcm(BcmAclStage stage, BcmField::Type field) {
   // Set pipeline stage for table.
   bcm_field_qualify_t bcm_stage = HalAclStageToBcm(table.stage());
   if (bcm_stage == bcmFieldQualifyCount) {
-    RETURN_ERROR(ERR_INVALID_PARAM)
+    return MAKE_ERROR(ERR_INVALID_PARAM)
         << "Attempted to create ACL table with invalid pipeline stage: "
         << BcmAclStage_Name(table.stage()) << ".";
   }
@@ -3089,7 +3089,7 @@ bcm_field_qualify_t HalAclFieldToBcm(BcmAclStage stage, BcmField::Type field) {
     bcm_field_qualify_t bcm_field =
         HalAclFieldToBcm(table.stage(), field.type());
     if (bcm_field == bcmFieldQualifyCount) {
-      RETURN_ERROR(ERR_INVALID_PARAM)
+      return MAKE_ERROR(ERR_INVALID_PARAM)
           << "Attempted to create ACL table with invalid predefined qualifier: "
           << field.ShortDebugString() << ".";
     }
@@ -3184,7 +3184,7 @@ const std::string& ExactMatchMaskBytes(BcmField::Type field) {
                                   const BcmField& field) {
   if ((field.type() != BcmField::ETH_DST) &&
       (field.type() != BcmField::ETH_SRC)) {
-    RETURN_ERROR()
+    return MAKE_ERROR()
         << "Attempted to add MAC address qualifier with wrong field type: "
         << BcmField::Type_Name(field.type()) << ".";
   }
@@ -3219,7 +3219,7 @@ const std::string& ExactMatchMaskBytes(BcmField::Type field) {
         (field.type() != BcmField::IPV6_DST) ||
         (field.type() != BcmField::IPV6_SRC_UPPER_64) ||
         (field.type() != BcmField::IPV6_DST_UPPER_64))) {
-    RETURN_ERROR()
+    return MAKE_ERROR()
         << "Attempted to add IPv6 address qualifier with wrong field type: "
         << BcmField::Type_Name(field.type()) << ".";
   }
@@ -3252,7 +3252,7 @@ const std::string& ExactMatchMaskBytes(BcmField::Type field) {
           bcm_field_qualify_DstIp6High(unit, entry, value, mask));
       break;
     default:
-      RETURN_ERROR() << "Control flow is broken.";
+      return MAKE_ERROR() << "Control flow is broken.";
   }
   return ::util::OkStatus();
 }
@@ -3440,7 +3440,7 @@ inline int bcm_add_field_u32(F func, int unit, int flow_id,
           bcm_field_qualify_IcmpTypeCode, unit, entry, field));
       break;
     default:
-      RETURN_ERROR() << "Attempted to translate unsupported BcmField::Type: "
+      return MAKE_ERROR() << "Attempted to translate unsupported BcmField::Type: "
                      << BcmField::Type_Name(field.type()) << ".";
   }
   return ::util::OkStatus();
@@ -3894,7 +3894,7 @@ inline uint64 ntohll(uint64 n) { return ntohl(1) == 1 ? n : bswap_64(n); }
       retval = bcm_field_qualify_SrcMac_get(unit, entry, &value, &mask);
       break;
     default:
-      RETURN_ERROR()
+      return MAKE_ERROR()
           << "Attempted to get MAC address qualifier with wrong field type: "
           << BcmField::Type_Name(field->type()) << ".";
   }
@@ -3942,7 +3942,7 @@ inline uint64 ntohll(uint64 n) { return ntohl(1) == 1 ? n : bswap_64(n); }
       retval = bcm_field_qualify_DstIp6High_get(unit, entry, &value, &mask);
       break;
     default:
-      RETURN_ERROR()
+      return MAKE_ERROR()
           << "Attempted to get IPv6 address qualifier with wrong field type: "
           << BcmField::Type_Name(field->type()) << ".";
   }
@@ -4537,7 +4537,7 @@ inline ::util::StatusOr<bool> GetAclActionOneParam(
               hw_field.mask().b() == ExactMatchMaskBytes(field.type());
           break;
         default:
-          RETURN_ERROR() << "Invalid mask type: " << hw_field.mask().data_case()
+          return MAKE_ERROR() << "Invalid mask type: " << hw_field.mask().data_case()
                          << " for retrieved qualifier of type "
                          << BcmField::Type_Name(hw_field.type()) << ".";
       }
@@ -4605,7 +4605,7 @@ inline ::util::StatusOr<bool> GetAclActionOneParam(
   RETURN_IF_BCM_ERROR(
       bcm_field_entry_multi_get(unit, table_id, 0, nullptr, &num_entries));
   if (num_entries < 0) {
-    RETURN_ERROR()
+    return MAKE_ERROR()
         << "bcm_field_entry_multi_get() returned negative flow count for table "
         << table_id << " on unit " << unit << ".";
   } else if (!num_entries) {
@@ -4617,7 +4617,7 @@ inline ::util::StatusOr<bool> GetAclActionOneParam(
   RETURN_IF_BCM_ERROR(bcm_field_entry_multi_get(
       unit, table_id, num_entries, flow_ids->data(), &num_entries));
   if (num_entries != static_cast<int>(flow_ids->size())) {
-    RETURN_ERROR() << "Consecutive bcm_field_entry_multi_get() for table "
+    return MAKE_ERROR() << "Consecutive bcm_field_entry_multi_get() for table "
                    << table_id << " on unit " << unit
                    << " return different flow counts.";
   }
@@ -4640,7 +4640,7 @@ inline ::util::StatusOr<bool> GetAclActionOneParam(
         unit, table_id, kUncoloredStatCount, stat_entry, &stat_id));
   }
   if (stat_id < 0) {
-    RETURN_ERROR(ERR_INTERNAL)
+    return MAKE_ERROR(ERR_INTERNAL)
         << "Received invalid stat_id " << stat_id << " for new stats object for"
         << " flow " << flow_id << ".";
   }
@@ -4713,7 +4713,7 @@ inline util::Status GetAclStatCounters(int unit, int stat_id,
     green->set_packets(counter_data[kGreenCounterIndex]);
     green->set_bytes(counter_data[kGreenCounterIndex + 1]);
   } else {
-    RETURN_ERROR() << "Invalid stat count for stat id " << stat_id
+    return MAKE_ERROR() << "Invalid stat count for stat id " << stat_id
                    << " on unit " << unit << ".";
   }
   return ::util::OkStatus();

--- a/stratum/hal/lib/bmv2/bmv2_chassis_manager.cc
+++ b/stratum/hal/lib/bmv2/bmv2_chassis_manager.cc
@@ -68,7 +68,7 @@ namespace {
   auto bm_status = dev_mgr->port_add(
       iface_name, static_cast<bm::PortMonitorIface::port_t>(port_id), {});
   if (bm_status != bm::DevMgrIface::ReturnCode::SUCCESS) {
-    RETURN_ERROR(ERR_INTERNAL)
+    return MAKE_ERROR(ERR_INTERNAL)
         << "Error when binding port " << port_id << " to interface "
         << iface_name << " in node " << node_id << ".";
   }
@@ -82,7 +82,7 @@ namespace {
   auto bm_status =
       dev_mgr->port_remove(static_cast<bm::PortMonitorIface::port_t>(port_id));
   if (bm_status != bm::DevMgrIface::ReturnCode::SUCCESS) {
-    RETURN_ERROR(ERR_INTERNAL) << "Error when removing port " << port_id
+    return MAKE_ERROR(ERR_INTERNAL) << "Error when removing port " << port_id
                                << " from node " << node_id << ".";
   }
   return ::util::OkStatus();
@@ -312,7 +312,7 @@ namespace {
       break;
     }
     default:
-      RETURN_ERROR(ERR_INTERNAL) << "Not supported yet";
+      return MAKE_ERROR(ERR_INTERNAL) << "Not supported yet";
   }
   return resp;
 }

--- a/stratum/hal/lib/common/admin_utils.cc
+++ b/stratum/hal/lib/common/admin_utils.cc
@@ -353,8 +353,8 @@ std::string FileSystemHelper::GetHashSum(
   // Return failure if reboot was not successful
   if (reboot_return_val != 0) {
     LOG(ERROR) << "Failed to reboot the system: " << strerror(errno);
-    RETURN_ERROR(ERR_INTERNAL)
-        << "Failed to reboot the system: " << strerror(errno);
+    return MAKE_ERROR(ERR_INTERNAL)
+           << "Failed to reboot the system: " << strerror(errno);
   }
   return ::util::OkStatus();
 }

--- a/stratum/hal/lib/common/openconfig_converter.cc
+++ b/stratum/hal/lib/common/openconfig_converter.cc
@@ -327,8 +327,8 @@ SingletonPortToInterfaces(const SingletonPort& in) {
           OPENCONFIGIFETHERNETETHERNETSPEED_SPEED_100GB);
       break;
     default:
-      RETURN_ERROR(ERR_INVALID_PARAM)
-          << "unknown 'speed_bps' " << in.ShortDebugString();
+      return MAKE_ERROR(ERR_INVALID_PARAM)
+             << "unknown 'speed_bps' " << in.ShortDebugString();
   }
 
   // SingletonPort.config_params.admin_state
@@ -403,7 +403,8 @@ TrunkPortToInterfaces(const ChassisConfig& root, const TrunkPort& in) {
           OPENCONFIGIFAGGREGATEAGGREGATIONTYPE_STATIC);
       break;
     default:
-      RETURN_ERROR(ERR_INVALID_PARAM) << "unknown trunk type " << in.type();
+      return MAKE_ERROR(ERR_INVALID_PARAM)
+             << "unknown trunk type " << in.type();
   }
 
   std::map<int64, std::string> id_to_name;
@@ -414,8 +415,8 @@ TrunkPortToInterfaces(const ChassisConfig& root, const TrunkPort& in) {
   for (int64 member_id : in.members()) {
     std::string* name = gtl::FindOrNull(id_to_name, member_id);
     if (name == nullptr) {
-      RETURN_ERROR(ERR_INVALID_PARAM)
-          << "unknown 'members' " << in.ShortDebugString();
+      return MAKE_ERROR(ERR_INVALID_PARAM)
+             << "unknown 'members' " << in.ShortDebugString();
     }
 
     auto member = trunk->mutable_aggregation()->add_member();
@@ -689,8 +690,8 @@ TrunkPortToInterfaces(const ChassisConfig& root, const TrunkPort& in) {
   }
 
   if (!if_component_key.has_component()) {
-    RETURN_ERROR(ERR_INVALID_PARAM)
-        << "Cannot find component for interface " << interface_key.name();
+    return MAKE_ERROR(ERR_INVALID_PARAM)
+           << "Cannot find component for interface " << interface_key.name();
   }
 
   const auto& if_component = if_component_key.component();
@@ -725,8 +726,8 @@ TrunkPortToInterfaces(const ChassisConfig& root, const TrunkPort& in) {
       to.set_speed_bps(kHundredGigBps);
       break;
     default:
-      RETURN_ERROR(ERR_INVALID_PARAM)
-          << "Invalid interface speed " << interface.ethernet().port_speed();
+      return MAKE_ERROR(ERR_INVALID_PARAM)
+             << "Invalid interface speed " << interface.ethernet().port_speed();
   }
 
   auto config_params = to.mutable_config_params();

--- a/stratum/hal/lib/common/utils.cc
+++ b/stratum/hal/lib/common/utils.cc
@@ -454,8 +454,8 @@ uint64 ConvertMHzToHz(const uint64& val) { return val * 1000000; }
     logging_config->first = "0";
     logging_config->second = "2";
   } else {
-    RETURN_ERROR(ERR_INVALID_PARAM)
-        << "Invalid severity string \"" << severity_string << "\".";
+    return MAKE_ERROR(ERR_INVALID_PARAM)
+           << "Invalid severity string \"" << severity_string << "\".";
   }
 
   return ::util::OkStatus();

--- a/stratum/hal/lib/np4intel/np4_chassis_manager.cc
+++ b/stratum/hal/lib/np4intel/np4_chassis_manager.cc
@@ -269,7 +269,7 @@ namespace {
       resp.mutable_sdn_port_id()->set_port_id(request.sdn_port_id().port_id());
       break;
     default:
-      RETURN_ERROR(ERR_INTERNAL) << "Not supported yet";
+      return MAKE_ERROR(ERR_INTERNAL) << "Not supported yet";
   }
   return resp;
 }

--- a/stratum/hal/lib/p4/p4_action_mapper.cc
+++ b/stratum/hal/lib/p4/p4_action_mapper.cc
@@ -8,29 +8,26 @@
 
 #include <memory>
 
-#include "stratum/hal/lib/p4/utils.h"
-#include "stratum/lib/macros.h"
 #include "absl/memory/memory.h"
 #include "stratum/glue/gtl/map_util.h"
 #include "stratum/glue/gtl/stl_util.h"
+#include "stratum/hal/lib/p4/utils.h"
+#include "stratum/lib/macros.h"
 
 namespace stratum {
 namespace hal {
 
 P4ActionMapper::P4ActionMapper(const P4PipelineConfig& p4_pipeline_config)
-    : p4_pipeline_config_(p4_pipeline_config) {
-}
+    : p4_pipeline_config_(p4_pipeline_config) {}
 
-P4ActionMapper::~P4ActionMapper() {
-  gtl::STLDeleteValues(&action_map_);
-}
+P4ActionMapper::~P4ActionMapper() { gtl::STLDeleteValues(&action_map_); }
 
 ::util::Status P4ActionMapper::AddP4Actions(
     const P4InfoManager& p4_info_manager) {
   if (!action_map_.empty()) {
     return MAKE_ERROR(ERR_INTERNAL)
-        << __PRETTY_FUNCTION__
-        << " has already processed this P4PipelineConfig";
+           << __PRETTY_FUNCTION__
+           << " has already processed this P4PipelineConfig";
   }
 
   // This loop finds the p4_pipeline_config_ action descriptor for each
@@ -61,9 +58,9 @@ P4ActionMapper::~P4ActionMapper() {
           auto status = AddAction(internal_action, new_map_entry.get());
           APPEND_STATUS_IF_ERROR(action_add_status, status);
         } else {
-          auto status = AddAppliedTableAction(
-              p4_info_manager, internal_link,
-              internal_action, new_map_entry.get());
+          auto status =
+              AddAppliedTableAction(p4_info_manager, internal_link,
+                                    internal_action, new_map_entry.get());
           APPEND_STATUS_IF_ERROR(action_add_status, status);
         }
       }
@@ -76,8 +73,7 @@ P4ActionMapper::~P4ActionMapper() {
 }
 
 ::util::StatusOr<const P4ActionDescriptor*>
-P4ActionMapper::MapActionIDAndTableID(
-    uint32 action_id, uint32 table_id) const {
+P4ActionMapper::MapActionIDAndTableID(uint32 action_id, uint32 table_id) const {
   return nullptr;  // TODO(teverman): Add implementation.
 }
 
@@ -93,8 +89,8 @@ P4ActionMapper::MapActionIDAndTableID(
     const P4ActionDescriptor& internal_action, ActionMapEntry* map_entry) {
   if (map_entry->internal_action != nullptr) {
     return MAKE_ERROR(ERR_INTERNAL)
-        << "Unexpected multiple links to internal actions - discarding "
-        << internal_action.ShortDebugString();
+           << "Unexpected multiple links to internal actions - discarding "
+           << internal_action.ShortDebugString();
   }
   map_entry->internal_action = &internal_action;
 
@@ -117,8 +113,8 @@ P4ActionMapper::MapActionIDAndTableID(
                                  table_status.ValueOrDie().preamble().id(),
                                  &internal_action)) {
       ::util::Status error = MAKE_ERROR(ERR_INTERNAL)
-          << "Unexpected duplicate appearance of table " << table_name
-          << " in internal action links";
+                             << "Unexpected duplicate appearance of table "
+                             << table_name << " in internal action links";
       APPEND_STATUS_IF_ERROR(table_action_status, error);
     }
   }

--- a/stratum/hal/lib/p4/p4_action_mapper.h
+++ b/stratum/hal/lib/p4/p4_action_mapper.h
@@ -13,14 +13,14 @@
 #ifndef STRATUM_HAL_LIB_P4_P4_ACTION_MAPPER_H_
 #define STRATUM_HAL_LIB_P4_P4_ACTION_MAPPER_H_
 
-#include "stratum/hal/lib/p4/p4_info_manager.h"
-#include "stratum/hal/lib/p4/p4_pipeline_config.pb.h"
-#include "stratum/hal/lib/p4/p4_table_map.pb.h"
 #include "absl/container/flat_hash_map.h"
 #include "p4/config/v1/p4info.pb.h"
 #include "stratum/glue/integral_types.h"
 #include "stratum/glue/status/status.h"
 #include "stratum/glue/status/statusor.h"
+#include "stratum/hal/lib/p4/p4_info_manager.h"
+#include "stratum/hal/lib/p4/p4_pipeline_config.pb.h"
+#include "stratum/hal/lib/p4/p4_table_map.pb.h"
 
 namespace stratum {
 namespace hal {
@@ -95,8 +95,7 @@ class P4ActionMapper {
   // P4PipelineConfig; hence they are not owned by this class.
   struct ActionMapEntry {
     explicit ActionMapEntry(const P4ActionDescriptor* action)
-        : original_action(action),
-          internal_action(nullptr) {}
+        : original_action(action), internal_action(nullptr) {}
 
     const P4ActionDescriptor* original_action;
     const P4ActionDescriptor* internal_action;
@@ -108,8 +107,8 @@ class P4ActionMapper {
   // complex case where internal_action is only used by the applied_tables
   // in internal_link.  Both methods update map_entry with data about when
   // internal_action replaces the original_action.
-  ::util::Status AddAction(
-      const P4ActionDescriptor& internal_action, ActionMapEntry* map_entry);
+  ::util::Status AddAction(const P4ActionDescriptor& internal_action,
+                           ActionMapEntry* map_entry);
   ::util::Status AddAppliedTableAction(
       const P4InfoManager& p4_info_manager,
       const P4ActionDescriptor::P4InternalActionLink& internal_link,

--- a/stratum/hal/lib/p4/p4_action_mapper_test.cc
+++ b/stratum/hal/lib/p4/p4_action_mapper_test.cc
@@ -9,18 +9,18 @@
 #include <memory>
 #include <string>
 
+#include "absl/memory/memory.h"
+#include "absl/strings/substitute.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "p4/config/v1/p4info.pb.h"
+#include "stratum/glue/gtl/map_util.h"
+#include "stratum/glue/status/status_test_util.h"
 #include "stratum/hal/lib/p4/p4_info_manager_mock.h"
 #include "stratum/hal/lib/p4/p4_pipeline_config.pb.h"
 #include "stratum/hal/lib/p4/p4_table_map.pb.h"
 #include "stratum/lib/test_utils/matchers.h"
 #include "stratum/lib/utils.h"
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
-#include "absl/memory/memory.h"
-#include "absl/strings/substitute.h"
-#include "p4/config/v1/p4info.pb.h"
-#include "stratum/glue/gtl/map_util.h"
-#include "stratum/glue/status/status_test_util.h"
 
 namespace stratum {
 namespace hal {
@@ -63,15 +63,16 @@ class P4ActionMapperTest : public testing::TestWithParam<std::string> {
     test_action_mapper_ =
         absl::make_unique<P4ActionMapper>(test_pipeline_config_);
     EXPECT_CALL(mock_p4info_manager_, p4_info())
-        .Times(AnyNumber()).WillRepeatedly(ReturnRef(test_p4_info_));
+        .Times(AnyNumber())
+        .WillRepeatedly(ReturnRef(test_p4_info_));
   }
 
   // Reads file_name with proto buffer text into test_pipeline_config_.
   void ReadP4PipelineConfig(const std::string& file_name) {
     const std::string test_pipeline_file =
         "stratum/hal/lib/p4/testdata/" + file_name;
-    ASSERT_OK(ReadProtoFromTextFile(
-        test_pipeline_file, &test_pipeline_config_));
+    ASSERT_OK(
+        ReadProtoFromTextFile(test_pipeline_file, &test_pipeline_config_));
   }
 
   // Creates a P4Info actions() entry in test_p4_info_.
@@ -161,8 +162,7 @@ class P4ActionMapperTest : public testing::TestWithParam<std::string> {
   int CountInternalActions() {
     int count = 0;
     for (const auto& table_map_entry : test_pipeline_config_.table_map()) {
-      if (table_map_entry.second.has_internal_action())
-        ++count;
+      if (table_map_entry.second.has_internal_action()) ++count;
     }
     return count;
   }
@@ -241,7 +241,7 @@ TEST_F(P4ActionMapperTest, TestMissingP4InfoTable) {
   constexpr uint32 kTestActionId = 1;
   SetUpP4InfoAction(kActionAppliedTable, kTestActionId);
   const ::util::Status table_error = MAKE_ERROR(ERR_INTERNAL)
-      << "Table not found";
+                                     << "Table not found";
   EXPECT_CALL(mock_p4info_manager_, FindTableByName(kAppliedTable))
       .WillOnce(Return(table_error));
   ::util::Status status =
@@ -258,7 +258,8 @@ TEST_F(P4ActionMapperTest, TestDuplicateAppliedTable) {
   ::p4::config::v1::Table applied_table_info;
   applied_table_info.mutable_preamble()->set_id(200);
   EXPECT_CALL(mock_p4info_manager_, FindTableByName(kDuplicateAppliedTable))
-      .Times(2).WillRepeatedly(Return(applied_table_info));
+      .Times(2)
+      .WillRepeatedly(Return(applied_table_info));
   ::util::Status status =
       test_action_mapper_->AddP4Actions(mock_p4info_manager_);
   EXPECT_FALSE(status.ok());
@@ -274,7 +275,8 @@ TEST_F(P4ActionMapperTest, TestDuplicateAppliedTableMultiLink) {
   ::p4::config::v1::Table applied_table_info;
   applied_table_info.mutable_preamble()->set_id(200);
   EXPECT_CALL(mock_p4info_manager_, FindTableByName(kDuplicateAppliedTable))
-      .Times(2).WillRepeatedly(Return(applied_table_info));
+      .Times(2)
+      .WillRepeatedly(Return(applied_table_info));
   ::util::Status status =
       test_action_mapper_->AddP4Actions(mock_p4info_manager_);
   EXPECT_FALSE(status.ok());
@@ -359,28 +361,13 @@ TEST_P(P4ActionMapperInvalidSequenceTest, TestInvalidSequences3) {
 // qualifier, and a 'U' indicates an unqualified internal action.  The
 // parameter string length is bounded by the number of internal actions
 // in the pipeline config test file.
-INSTANTIATE_TEST_CASE_P(
-  ValidAppliedTablesSequence,
-  P4ActionMapperTest,
-  ::testing::Values(
-    "Q",
-    "QQ",
-    "QQQ",
-    "QQU",
-    "U",
-    "UQ",
-    "UQQ",
-    "QU",
-    "QUQ"));
+INSTANTIATE_TEST_CASE_P(ValidAppliedTablesSequence, P4ActionMapperTest,
+                        ::testing::Values("Q", "QQ", "QQQ", "QQU", "U", "UQ",
+                                          "UQQ", "QU", "QUQ"));
 
-INSTANTIATE_TEST_CASE_P(
-  InvalidAppliedTablesSequence,
-  P4ActionMapperInvalidSequenceTest,
-  ::testing::Values(
-    "UU",
-    "UQU",
-    "UUQ",
-    "QUU"));
+INSTANTIATE_TEST_CASE_P(InvalidAppliedTablesSequence,
+                        P4ActionMapperInvalidSequenceTest,
+                        ::testing::Values("UU", "UQU", "UUQ", "QUU"));
 
 }  // namespace hal
 }  // namespace stratum

--- a/stratum/hal/lib/p4/p4_config_verifier.h
+++ b/stratum/hal/lib/p4/p4_config_verifier.h
@@ -2,7 +2,6 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 // P4ConfigVerifier verifies consistency among various P4 objects in the P4Info
 // and the P4PipelineConfig.  It helps P4TableMapper verify forwarding
 // pipeline config pushes.  It also has a role in some unit tests that verify
@@ -15,12 +14,12 @@
 #include <memory>
 #include <string>
 
+#include "p4/config/v1/p4info.pb.h"
 #include "stratum/glue/status/status.h"
 #include "stratum/glue/status/statusor.h"
 #include "stratum/hal/lib/p4/p4_pipeline_config.pb.h"
 #include "stratum/hal/lib/p4/p4_table_map.pb.h"
 #include "stratum/public/proto/p4_table_defs.pb.h"
-#include "p4/config/v1/p4info.pb.h"
 
 namespace stratum {
 namespace hal {
@@ -113,9 +112,9 @@ class P4ConfigVerifier {
 
   // These two methods verify assignments within P4 action bodies.
   ::util::Status VerifyHeaderAssignment();
-  ::util::Status VerifyFieldAssignment(
-      const std::string& destination_field,
-      const P4AssignSourceValue& source_value, const std::string& action_name);
+  ::util::Status VerifyFieldAssignment(const std::string& destination_field,
+                                       const P4AssignSourceValue& source_value,
+                                       const std::string& action_name);
 
   // Verifies that the input P4FieldDescriptor contains a known field type.
   bool VerifyKnownFieldType(const P4FieldDescriptor& descriptor);

--- a/stratum/hal/lib/p4/p4_config_verifier_test.cc
+++ b/stratum/hal/lib/p4/p4_config_verifier_test.cc
@@ -2,7 +2,6 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 // This file contains unit tests for P4ConfigVerifier.
 
 #include "stratum/hal/lib/p4/p4_config_verifier.h"
@@ -11,17 +10,17 @@
 #include <string>
 #include <vector>
 
+#include "absl/memory/memory.h"
 #include "gflags/gflags.h"
-#include "stratum/glue/status/status_test_util.h"
-#include "stratum/hal/lib/p4/p4_info_manager.h"
-#include "stratum/lib/utils.h"
-#include "stratum/lib/test_utils/matchers.h"
-#include "stratum/public/lib/error.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
-#include "absl/memory/memory.h"
 #include "p4/v1/p4runtime.pb.h"
 #include "stratum/glue/gtl/map_util.h"
+#include "stratum/glue/status/status_test_util.h"
+#include "stratum/hal/lib/p4/p4_info_manager.h"
+#include "stratum/lib/test_utils/matchers.h"
+#include "stratum/lib/utils.h"
+#include "stratum/public/lib/error.h"
 
 // P4ConfigVerifier flags to override for some tests.
 DECLARE_string(match_field_error_level);
@@ -30,8 +29,8 @@ DECLARE_string(action_field_error_level);
 namespace stratum {
 namespace hal {
 
-using ::testing::HasSubstr;
 using ::gflags::FlagSaver;
+using ::testing::HasSubstr;
 
 // This class is the P4ConfigVerifier test fixture.
 class P4ConfigVerifierTest : public testing::Test {
@@ -43,8 +42,8 @@ class P4ConfigVerifierTest : public testing::Test {
     const std::string kTestP4PipelineConfigFile =
         "stratum/hal/lib/p4/testdata/"
         "test_p4_pipeline_config.pb.txt";
-    ASSERT_OK(ReadProtoFromTextFile(
-        kTestP4PipelineConfigFile, &test_p4_pipeline_config_));
+    ASSERT_OK(ReadProtoFromTextFile(kTestP4PipelineConfigFile,
+                                    &test_p4_pipeline_config_));
 
     // P4ConfigVerifier assumes P4InfoManager pre-validation of P4Info.
     p4_info_manager_ = absl::make_unique<P4InfoManager>(test_p4_info_);
@@ -135,23 +134,23 @@ class P4ConfigVerifierTest : public testing::Test {
 
 TEST_F(P4ConfigVerifierTest, TestValidP4Config) {
   SetUpP4ConfigFromFiles();
-  p4_verifier_ = P4ConfigVerifier::CreateInstance(
-      test_p4_info_, test_p4_pipeline_config_);
+  p4_verifier_ =
+      P4ConfigVerifier::CreateInstance(test_p4_info_, test_p4_pipeline_config_);
   EXPECT_OK(p4_verifier_->Verify());
 }
 
 TEST_F(P4ConfigVerifierTest, TestValidP4ConfigFirstCompare) {
   SetUpP4ConfigFromFiles();
-  p4_verifier_ = P4ConfigVerifier::CreateInstance(
-      test_p4_info_, test_p4_pipeline_config_);
+  p4_verifier_ =
+      P4ConfigVerifier::CreateInstance(test_p4_info_, test_p4_pipeline_config_);
   ::p4::config::v1::P4Info empty_p4_info;
   P4PipelineConfig empty_p4_pipeline;
   EXPECT_OK(p4_verifier_->VerifyAndCompare(empty_p4_info, empty_p4_pipeline));
 }
 
 TEST_F(P4ConfigVerifierTest, TestEmptyPipelineConfig) {
-  p4_verifier_ = P4ConfigVerifier::CreateInstance(
-      test_p4_info_, test_p4_pipeline_config_);
+  p4_verifier_ =
+      P4ConfigVerifier::CreateInstance(test_p4_info_, test_p4_pipeline_config_);
   ::util::Status status = p4_verifier_->Verify();
   EXPECT_EQ(ERR_INTERNAL, status.error_code());
   EXPECT_THAT(status.ToString(), HasSubstr("missing object mapping"));
@@ -415,8 +414,8 @@ TEST_F(P4ConfigVerifierTest, TestMissingActionSourceFieldDescriptor) {
   P4ActionDescriptor::P4ActionInstructions* bad_assignment =
       bad_descriptor.mutable_action_descriptor()->add_assignments();
   const std::string kMissingFieldName = "unknown-header-field";
-  bad_assignment->mutable_assigned_value()->
-      set_source_field_name(kMissingFieldName);
+  bad_assignment->mutable_assigned_value()->set_source_field_name(
+      kMissingFieldName);
   const std::string kTestDestField = "test-header-field-32";
   bad_assignment->set_destination_field_name(kTestDestField);
   (*test_p4_pipeline_config_.mutable_table_map())[first_action_name] =
@@ -449,8 +448,8 @@ TEST_F(P4ConfigVerifierTest, TestMissingActionSourceFieldDescriptorOld) {
   P4ActionDescriptor::P4ActionInstructions* bad_assignment =
       bad_descriptor.mutable_action_descriptor()->add_assignments();
   const std::string kMissingFieldName = "unknown-header-field";
-  bad_assignment->mutable_assigned_value()->
-      set_source_field_name(kMissingFieldName);
+  bad_assignment->mutable_assigned_value()->set_source_field_name(
+      kMissingFieldName);
   const std::string kTestDestField = "test-header-field-32";
   bad_assignment->add_destination_field_names(kTestDestField);
   (*test_p4_pipeline_config_.mutable_table_map())[first_action_name] =
@@ -571,11 +570,12 @@ TEST_F(P4ConfigVerifierTest, TestActionInternalLink) {
 
   // This test creates a link from the first action descriptor to an
   // internal action.
-  P4TableMapValue link_descriptor = gtl::FindOrDie(
-      test_p4_pipeline_config_.table_map(), first_action_name);
+  P4TableMapValue link_descriptor =
+      gtl::FindOrDie(test_p4_pipeline_config_.table_map(), first_action_name);
   P4ActionDescriptor::P4InternalActionLink* internal_link =
-      link_descriptor.mutable_action_descriptor()->
-      add_action_redirects()->add_internal_links();
+      link_descriptor.mutable_action_descriptor()
+          ->add_action_redirects()
+          ->add_internal_links();
   const std::string kInternalAction = "internal-action";
   internal_link->set_internal_action_name(kInternalAction);
   gtl::InsertOrUpdate(test_p4_pipeline_config_.mutable_table_map(),
@@ -598,11 +598,12 @@ TEST_F(P4ConfigVerifierTest, TestActionBadInternalLink) {
 
   // This test creates a link from the first action descriptor to an
   // internal action that does not exist.
-  P4TableMapValue link_descriptor = gtl::FindOrDie(
-      test_p4_pipeline_config_.table_map(), first_action_name);
+  P4TableMapValue link_descriptor =
+      gtl::FindOrDie(test_p4_pipeline_config_.table_map(), first_action_name);
   P4ActionDescriptor::P4InternalActionLink* internal_link =
-      link_descriptor.mutable_action_descriptor()->
-      add_action_redirects()->add_internal_links();
+      link_descriptor.mutable_action_descriptor()
+          ->add_action_redirects()
+          ->add_internal_links();
   const std::string kInternalAction = "unknown-internal-action";
   internal_link->set_internal_action_name(kInternalAction);
   gtl::InsertOrUpdate(test_p4_pipeline_config_.mutable_table_map(),
@@ -626,11 +627,12 @@ TEST_F(P4ConfigVerifierTest, TestInternalActionWithRedirects) {
   // This test creates a link from the first action descriptor to an
   // internal action, then populates the internal action with another
   // level of indirection.
-  P4TableMapValue link_descriptor = gtl::FindOrDie(
-      test_p4_pipeline_config_.table_map(), first_action_name);
+  P4TableMapValue link_descriptor =
+      gtl::FindOrDie(test_p4_pipeline_config_.table_map(), first_action_name);
   P4ActionDescriptor::P4InternalActionLink* internal_link =
-      link_descriptor.mutable_action_descriptor()->
-      add_action_redirects()->add_internal_links();
+      link_descriptor.mutable_action_descriptor()
+          ->add_action_redirects()
+          ->add_internal_links();
   const std::string kInternalAction = "internal-action";
   internal_link->set_internal_action_name(kInternalAction);
   gtl::InsertOrUpdate(test_p4_pipeline_config_.mutable_table_map(),
@@ -660,11 +662,12 @@ TEST_F(P4ConfigVerifierTest, TestInternalActionWithBadAssignment) {
   // This test creates a link from the first action descriptor to an
   // internal action, then populates the internal action with invalid
   // assignment instructions.
-  P4TableMapValue link_descriptor = gtl::FindOrDie(
-      test_p4_pipeline_config_.table_map(), first_action_name);
+  P4TableMapValue link_descriptor =
+      gtl::FindOrDie(test_p4_pipeline_config_.table_map(), first_action_name);
   P4ActionDescriptor::P4InternalActionLink* internal_link =
-      link_descriptor.mutable_action_descriptor()->
-      add_action_redirects()->add_internal_links();
+      link_descriptor.mutable_action_descriptor()
+          ->add_action_redirects()
+          ->add_internal_links();
   const std::string kInternalAction = "internal-action";
   internal_link->set_internal_action_name(kInternalAction);
   gtl::InsertOrUpdate(test_p4_pipeline_config_.mutable_table_map(),
@@ -693,11 +696,12 @@ TEST_F(P4ConfigVerifierTest, TestActionInternalLinkWithAppliedTables) {
 
   // This test creates a link from the first action descriptor to an
   // internal action.  The link is constrained to the first P4 table.
-  P4TableMapValue link_descriptor = gtl::FindOrDie(
-      test_p4_pipeline_config_.table_map(), first_action_name);
+  P4TableMapValue link_descriptor =
+      gtl::FindOrDie(test_p4_pipeline_config_.table_map(), first_action_name);
   P4ActionDescriptor::P4InternalActionLink* internal_link =
-      link_descriptor.mutable_action_descriptor()->
-      add_action_redirects()->add_internal_links();
+      link_descriptor.mutable_action_descriptor()
+          ->add_action_redirects()
+          ->add_internal_links();
   const std::string kInternalAction = "internal-action";
   internal_link->set_internal_action_name(kInternalAction);
   ASSERT_TRUE(FirstTableHasDescriptor());
@@ -722,11 +726,12 @@ TEST_F(P4ConfigVerifierTest, TestActionInternalLinkWithUnknownAppliedTables) {
 
   // This test creates a link from the first action descriptor to an
   // internal action.  The link is constrained to a P4 table that doesn't exist.
-  P4TableMapValue link_descriptor = gtl::FindOrDie(
-      test_p4_pipeline_config_.table_map(), first_action_name);
+  P4TableMapValue link_descriptor =
+      gtl::FindOrDie(test_p4_pipeline_config_.table_map(), first_action_name);
   P4ActionDescriptor::P4InternalActionLink* internal_link =
-      link_descriptor.mutable_action_descriptor()->
-      add_action_redirects()->add_internal_links();
+      link_descriptor.mutable_action_descriptor()
+          ->add_action_redirects()
+          ->add_internal_links();
   const std::string kInternalAction = "internal-action";
   internal_link->set_internal_action_name(kInternalAction);
   internal_link->add_applied_tables("unknown-applied-table");
@@ -753,8 +758,8 @@ TEST_F(P4ConfigVerifierTest, TestActionInternalLinkWithUnknownAppliedTables) {
 TEST_F(P4ConfigVerifierTest, TestValidStaticTableEntry) {
   SetUpP4ConfigFromFiles();
   SetUpStaticTableEntry();
-  p4_verifier_ = P4ConfigVerifier::CreateInstance(
-      test_p4_info_, test_p4_pipeline_config_);
+  p4_verifier_ =
+      P4ConfigVerifier::CreateInstance(test_p4_info_, test_p4_pipeline_config_);
   EXPECT_OK(p4_verifier_->Verify());
 }
 
@@ -765,8 +770,8 @@ TEST_F(P4ConfigVerifierTest, TestStaticTableEntryBadUpdateType) {
       test_p4_pipeline_config_.mutable_static_table_entries()->mutable_updates(
           0);
   test_update->set_type(::p4::v1::Update::DELETE);  // DELETE is unexpected.
-  p4_verifier_ = P4ConfigVerifier::CreateInstance(
-      test_p4_info_, test_p4_pipeline_config_);
+  p4_verifier_ =
+      P4ConfigVerifier::CreateInstance(test_p4_info_, test_p4_pipeline_config_);
   ::util::Status status = p4_verifier_->Verify();
   EXPECT_EQ(ERR_INTERNAL, status.error_code());
   EXPECT_THAT(status.ToString(), HasSubstr("unexpected type"));
@@ -781,8 +786,8 @@ TEST_F(P4ConfigVerifierTest, TestStaticTableEntryNotTableEntry) {
           ->mutable_updates(0)
           ->mutable_entity();
   test_entity->clear_table_entry();  // Clears the expected table_entry.
-  p4_verifier_ = P4ConfigVerifier::CreateInstance(
-      test_p4_info_, test_p4_pipeline_config_);
+  p4_verifier_ =
+      P4ConfigVerifier::CreateInstance(test_p4_info_, test_p4_pipeline_config_);
   ::util::Status status = p4_verifier_->Verify();
   EXPECT_EQ(ERR_INTERNAL, status.error_code());
   EXPECT_THAT(status.ToString(), HasSubstr("no TableEntry"));
@@ -796,8 +801,8 @@ TEST_F(P4ConfigVerifierTest, TestStaticTableEntryBadTableID) {
           ->mutable_updates(0)
           ->mutable_entity();
   test_entity->mutable_table_entry()->set_table_id(0xf123f);
-  p4_verifier_ = P4ConfigVerifier::CreateInstance(
-      test_p4_info_, test_p4_pipeline_config_);
+  p4_verifier_ =
+      P4ConfigVerifier::CreateInstance(test_p4_info_, test_p4_pipeline_config_);
   ::util::Status status = p4_verifier_->Verify();
   EXPECT_EQ(ERR_INTERNAL, status.error_code());
   EXPECT_THAT(status.ToString(), HasSubstr("table_id is not in P4Info"));
@@ -811,8 +816,8 @@ TEST_F(P4ConfigVerifierTest, TestStaticTableEntryNoFieldMatches) {
           ->mutable_updates(0)
           ->mutable_entity();
   test_entity->mutable_table_entry()->clear_match();  // Clears expected match.
-  p4_verifier_ = P4ConfigVerifier::CreateInstance(
-      test_p4_info_, test_p4_pipeline_config_);
+  p4_verifier_ =
+      P4ConfigVerifier::CreateInstance(test_p4_info_, test_p4_pipeline_config_);
   ::util::Status status = p4_verifier_->Verify();
   EXPECT_EQ(ERR_INTERNAL, status.error_code());
   EXPECT_THAT(status.ToString(), HasSubstr("0 match fields"));
@@ -823,8 +828,8 @@ TEST_F(P4ConfigVerifierTest, TestStaticTableEntryCompareNoChange) {
   SetUpP4ConfigFromFiles();
   SetUpStaticTableEntry();
   P4PipelineConfig old_p4_pipeline = test_p4_pipeline_config_;
-  p4_verifier_ = P4ConfigVerifier::CreateInstance(
-      test_p4_info_, test_p4_pipeline_config_);
+  p4_verifier_ =
+      P4ConfigVerifier::CreateInstance(test_p4_info_, test_p4_pipeline_config_);
   EXPECT_OK(p4_verifier_->VerifyAndCompare(test_p4_info_, old_p4_pipeline));
 }
 
@@ -833,8 +838,8 @@ TEST_F(P4ConfigVerifierTest, TestStaticTableEntryCompareAddition) {
   SetUpStaticTableEntry();
   P4PipelineConfig old_p4_pipeline = test_p4_pipeline_config_;
   old_p4_pipeline.clear_static_table_entries();
-  p4_verifier_ = P4ConfigVerifier::CreateInstance(
-      test_p4_info_, test_p4_pipeline_config_);
+  p4_verifier_ =
+      P4ConfigVerifier::CreateInstance(test_p4_info_, test_p4_pipeline_config_);
   EXPECT_OK(p4_verifier_->VerifyAndCompare(test_p4_info_, old_p4_pipeline));
 }
 
@@ -843,8 +848,8 @@ TEST_F(P4ConfigVerifierTest, TestStaticTableEntryCompareDeletion) {
   SetUpStaticTableEntry();
   P4PipelineConfig old_p4_pipeline = test_p4_pipeline_config_;
   test_p4_pipeline_config_.clear_static_table_entries();
-  p4_verifier_ = P4ConfigVerifier::CreateInstance(
-      test_p4_info_, test_p4_pipeline_config_);
+  p4_verifier_ =
+      P4ConfigVerifier::CreateInstance(test_p4_info_, test_p4_pipeline_config_);
   ::util::Status status =
       p4_verifier_->VerifyAndCompare(test_p4_info_, old_p4_pipeline);
   EXPECT_EQ(ERR_REBOOT_REQUIRED, status.error_code());
@@ -857,10 +862,13 @@ TEST_F(P4ConfigVerifierTest, TestStaticTableEntryCompareModification) {
   P4PipelineConfig old_p4_pipeline = test_p4_pipeline_config_;
   auto update =
       old_p4_pipeline.mutable_static_table_entries()->mutable_updates(0);
-  update->mutable_entity()->mutable_table_entry()->mutable_action()->
-      mutable_action()->set_action_id(1);
-  p4_verifier_ = P4ConfigVerifier::CreateInstance(
-      test_p4_info_, test_p4_pipeline_config_);
+  update->mutable_entity()
+      ->mutable_table_entry()
+      ->mutable_action()
+      ->mutable_action()
+      ->set_action_id(1);
+  p4_verifier_ =
+      P4ConfigVerifier::CreateInstance(test_p4_info_, test_p4_pipeline_config_);
   ::util::Status status =
       p4_verifier_->VerifyAndCompare(test_p4_info_, old_p4_pipeline);
   EXPECT_EQ(ERR_REBOOT_REQUIRED, status.error_code());
@@ -878,19 +886,23 @@ TEST_F(P4ConfigVerifierTest, TestStaticTableEntryModifyAndDelete) {
   // SetUpStaticTableEntry puts the same ID in all entries.
   SetUpStaticTableEntry();
   auto deleted_table_entry =
-      test_p4_pipeline_config_.mutable_static_table_entries()->
-      mutable_updates(1)->mutable_entity()->mutable_table_entry();
+      test_p4_pipeline_config_.mutable_static_table_entries()
+          ->mutable_updates(1)
+          ->mutable_entity()
+          ->mutable_table_entry();
   ASSERT_LE(2, test_p4_info_.tables_size());
   deleted_table_entry->set_table_id(test_p4_info_.tables(1).preamble().id());
   auto modified_table_entry =
-      test_p4_pipeline_config_.mutable_static_table_entries()->
-      mutable_updates(0)->mutable_entity()->mutable_table_entry();
+      test_p4_pipeline_config_.mutable_static_table_entries()
+          ->mutable_updates(0)
+          ->mutable_entity()
+          ->mutable_table_entry();
   modified_table_entry->set_priority(100);
 
   // The error string from the ERR_REBOOT_REQUIRED status should report both
   // a modify and a delete.
-  p4_verifier_ = P4ConfigVerifier::CreateInstance(
-      test_p4_info_, p4_pipeline_one_static);
+  p4_verifier_ =
+      P4ConfigVerifier::CreateInstance(test_p4_info_, p4_pipeline_one_static);
   ::util::Status status =
       p4_verifier_->VerifyAndCompare(test_p4_info_, test_p4_pipeline_config_);
   EXPECT_EQ(ERR_REBOOT_REQUIRED, status.error_code());
@@ -912,8 +924,8 @@ TEST_F(P4ConfigVerifierTest, TestStaticTableEntryVerifyVsRebootPrecedence) {
   // The old_p4_pipeline adjustment simulates a reboot-required deletion.
   P4PipelineConfig old_p4_pipeline = test_p4_pipeline_config_;
   test_p4_pipeline_config_.clear_static_table_entries();
-  p4_verifier_ = P4ConfigVerifier::CreateInstance(
-      test_p4_info_, test_p4_pipeline_config_);
+  p4_verifier_ =
+      P4ConfigVerifier::CreateInstance(test_p4_info_, test_p4_pipeline_config_);
   ::util::Status status =
       p4_verifier_->VerifyAndCompare(test_p4_info_, old_p4_pipeline);
 
@@ -937,15 +949,15 @@ TEST_F(P4ConfigVerifierTest, TestNonErrorLevels) {
   ASSERT_TRUE(value != nullptr);
   value->mutable_field_descriptor()->clear_type();
   const std::vector<std::string> error_test_levels = {
-    "warn",
-    "vlog",
-    "xxxxxx"
+      "warn",
+      "vlog",
+      "xxxxxx",
   };
 
   for (const auto& level : error_test_levels) {
     FLAGS_action_field_error_level = level;
-    p4_verifier_ = P4ConfigVerifier::CreateInstance(
-        test_p4_info_, test_p4_pipeline_config_);
+    p4_verifier_ = P4ConfigVerifier::CreateInstance(test_p4_info_,
+                                                    test_p4_pipeline_config_);
     EXPECT_OK(p4_verifier_->Verify());
   }
 }

--- a/stratum/hal/lib/p4/p4_info_manager.cc
+++ b/stratum/hal/lib/p4/p4_info_manager.cc
@@ -180,8 +180,8 @@ P4InfoManager::FindRegisterByName(const std::string& register_name) const {
   return register_map_.FindByName(register_name);
 }
 
-::util::StatusOr<const std::string>
-P4InfoManager::FindResourceTypeByID(uint32 id_key) const {
+::util::StatusOr<const std::string> P4InfoManager::FindResourceTypeByID(
+    uint32 id_key) const {
   auto iter = id_to_resource_type_map_.find(id_key);
   if (iter == id_to_resource_type_map_.end()) {
     return MAKE_ERROR(ERR_INVALID_P4_INFO)
@@ -266,7 +266,7 @@ P4InfoManager::FindResourceTypeByID(uint32 id_key) const {
           bit_width = type_spec.bitstring().varbit().max_bitwidth();
           break;
         default:
-          RETURN_ERROR(ERR_UNIMPLEMENTED) << "Not implemented.";
+          return MAKE_ERROR(ERR_UNIMPLEMENTED) << "Not implemented.";
       }
       CHECK_RETURN_IF_FALSE(data.bitstring().size() * 8 <= bit_width);
       break;
@@ -284,9 +284,9 @@ P4InfoManager::FindResourceTypeByID(uint32 id_key) const {
       break;
     }
     default:
-      RETURN_ERROR(ERR_UNIMPLEMENTED)
-          << "P4data type " << data.data_case() << " in P4Data "
-          << data.ShortDebugString() << " is not supported.";
+      return MAKE_ERROR(ERR_UNIMPLEMENTED)
+             << "P4data type " << data.data_case() << " in P4Data "
+             << data.ShortDebugString() << " is not supported.";
   }
 
   return ::util::OkStatus();

--- a/stratum/hal/lib/p4/p4_static_entry_mapper.cc
+++ b/stratum/hal/lib/p4/p4_static_entry_mapper.cc
@@ -2,7 +2,6 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 // This file contains the implementation of P4StaticEntryMapper.
 
 #include "stratum/hal/lib/p4/p4_static_entry_mapper.h"
@@ -22,7 +21,8 @@
 // actions from its const entries into the actions for the first table.
 // When the flag is false, the switch stack treats const entries in hidden
 // tables like any other const entry.
-DEFINE_bool(remap_hidden_table_const_entries, true, "Enables/disables "
+DEFINE_bool(remap_hidden_table_const_entries, true,
+            "Enables/disables "
             "remapping of hidden table const entries.  When enabled, the "
             "hidden const entry actions are integrated into the actions of "
             "related physical tables.");
@@ -49,10 +49,10 @@ P4StaticEntryMapper::P4StaticEntryMapper() : p4_table_mapper_(nullptr) {}
   // modifications are not applicable during the pre-push step.
   ::p4::v1::WriteRequest physical_deletes;
   ::p4::v1::WriteRequest physical_unchanged;
-  P4WriteRequestDiffer physical_differ(
-      physical_static_entries_, physical_request);
-  RETURN_IF_ERROR(physical_differ.Compare(
-      &physical_deletes, nullptr, nullptr, &physical_unchanged));
+  P4WriteRequestDiffer physical_differ(physical_static_entries_,
+                                       physical_request);
+  RETURN_IF_ERROR(physical_differ.Compare(&physical_deletes, nullptr, nullptr,
+                                          &physical_unchanged));
 
   // Hidden static entries that have been deleted relative to the current
   // pipeline config are identified here.  Static entry additions and
@@ -60,8 +60,8 @@ P4StaticEntryMapper::P4StaticEntryMapper() : p4_table_mapper_(nullptr) {}
   ::p4::v1::WriteRequest hidden_deletes;
   ::p4::v1::WriteRequest hidden_unchanged;
   P4WriteRequestDiffer hidden_differ(hidden_static_entries_, hidden_request);
-  RETURN_IF_ERROR(hidden_differ.Compare(
-      &hidden_deletes, nullptr, nullptr, &hidden_unchanged));
+  RETURN_IF_ERROR(hidden_differ.Compare(&hidden_deletes, nullptr, nullptr,
+                                        &hidden_unchanged));
 
   // TODO(unknown): Finish implementation - hidden_deletes need to be saved
   // with internal hidden tables.
@@ -87,10 +87,10 @@ P4StaticEntryMapper::P4StaticEntryMapper() : p4_table_mapper_(nullptr) {}
   ::p4::v1::WriteRequest physical_deletes;
   ::p4::v1::WriteRequest physical_adds;
   ::p4::v1::WriteRequest physical_mods;
-  P4WriteRequestDiffer physical_differ(
-      physical_static_entries_, physical_request);
-  RETURN_IF_ERROR(physical_differ.Compare(
-      &physical_deletes, &physical_adds, &physical_mods, nullptr));
+  P4WriteRequestDiffer physical_differ(physical_static_entries_,
+                                       physical_request);
+  RETURN_IF_ERROR(physical_differ.Compare(&physical_deletes, &physical_adds,
+                                          &physical_mods, nullptr));
   CHECK_RETURN_IF_FALSE(physical_deletes.updates_size() == 0)
       << "Unexpected physical static table entry deletions - possible "
       << "P4StaticEntryMapper API misuse: "
@@ -103,8 +103,8 @@ P4StaticEntryMapper::P4StaticEntryMapper() : p4_table_mapper_(nullptr) {}
   ::p4::v1::WriteRequest hidden_adds;
   ::p4::v1::WriteRequest hidden_mods;
   P4WriteRequestDiffer hidden_differ(hidden_static_entries_, hidden_request);
-  RETURN_IF_ERROR(hidden_differ.Compare(
-      &hidden_deletes, &hidden_adds, &hidden_mods, nullptr));
+  RETURN_IF_ERROR(hidden_differ.Compare(&hidden_deletes, &hidden_adds,
+                                        &hidden_mods, nullptr));
   CHECK_RETURN_IF_FALSE(hidden_deletes.updates_size() == 0)
       << "Unexpected hidden static table entry deletions - possible "
       << "P4StaticEntryMapper API misuse: "
@@ -140,7 +140,7 @@ P4StaticEntryMapper::P4StaticEntryMapper() : p4_table_mapper_(nullptr) {}
       // post-push for adding new entries.
       continue;
     } else if (hidden_status == TRI_STATE_TRUE &&
-        FLAGS_remap_hidden_table_const_entries) {
+               FLAGS_remap_hidden_table_const_entries) {
       out_update = hidden_request->add_updates();
     } else {
       out_update = physical_request->add_updates();

--- a/stratum/hal/lib/p4/p4_static_entry_mapper.h
+++ b/stratum/hal/lib/p4/p4_static_entry_mapper.h
@@ -2,7 +2,6 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 // P4StaticEntryMapper is a P4TableMapper helper class.  Similar to
 // P4TableMapper, one instance exists per configured P4 device ID.
 // P4StaticEntryMapper manages the static table entries, i.e. those defined
@@ -23,9 +22,9 @@
 #ifndef STRATUM_HAL_LIB_P4_P4_STATIC_ENTRY_MAPPER_H_
 #define STRATUM_HAL_LIB_P4_P4_STATIC_ENTRY_MAPPER_H_
 
+#include "p4/v1/p4runtime.pb.h"
 #include "stratum/glue/status/status.h"
 #include "stratum/hal/lib/p4/p4_pipeline_config.pb.h"
-#include "p4/v1/p4runtime.pb.h"
 
 namespace stratum {
 namespace hal {

--- a/stratum/hal/lib/p4/p4_static_entry_mapper_mock.h
+++ b/stratum/hal/lib/p4/p4_static_entry_mapper_mock.h
@@ -2,14 +2,13 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 // This is a mock implementation of P4StaticEntryMapper.
 
 #ifndef STRATUM_HAL_LIB_P4_P4_STATIC_ENTRY_MAPPER_MOCK_H_
 #define STRATUM_HAL_LIB_P4_P4_STATIC_ENTRY_MAPPER_MOCK_H_
 
-#include "stratum/hal/lib/p4/p4_static_entry_mapper.h"
 #include "gmock/gmock.h"
+#include "stratum/hal/lib/p4/p4_static_entry_mapper.h"
 
 namespace stratum {
 namespace hal {

--- a/stratum/hal/lib/p4/p4_static_entry_mapper_test.cc
+++ b/stratum/hal/lib/p4/p4_static_entry_mapper_test.cc
@@ -2,7 +2,6 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 // This file contains unit tests for P4StaticEntryMapper.
 
 #include "stratum/hal/lib/p4/p4_static_entry_mapper.h"
@@ -10,15 +9,15 @@
 #include <memory>
 #include <vector>
 
+#include "absl/memory/memory.h"
 #include "gflags/gflags.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "p4/v1/p4runtime.pb.h"
 #include "stratum/glue/status/status_test_util.h"
 #include "stratum/hal/lib/p4/p4_table_mapper_mock.h"
 #include "stratum/lib/test_utils/matchers.h"
 #include "stratum/lib/utils.h"
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
-#include "absl/memory/memory.h"
-#include "p4/v1/p4runtime.pb.h"
 
 DECLARE_bool(remap_hidden_table_const_entries);
 
@@ -109,8 +108,8 @@ void P4StaticEntryMapperTest::SetUpTestRequest(
   pipeline_static_entries_.Clear();
   for (auto update_text : updates_text) {
     ::p4::v1::Update update;
-    ASSERT_OK(ParseProtoFromString(
-        update_text, pipeline_static_entries_.add_updates()));
+    ASSERT_OK(ParseProtoFromString(update_text,
+                                   pipeline_static_entries_.add_updates()));
   }
 }
 
@@ -135,18 +134,18 @@ void P4StaticEntryMapperTest::SetUpFirstPipelinePush(
     const std::vector<const char*>& updates_text) {
   SetUpTestRequest(updates_text);
   SetUpHiddenTableExpectations();
-  ASSERT_OK(test_mapper_->HandlePrePushChanges(
-      pipeline_static_entries_, &test_request_out_));
-  ASSERT_OK(test_mapper_->HandlePostPushChanges(
-      pipeline_static_entries_, &test_request_out_));
+  ASSERT_OK(test_mapper_->HandlePrePushChanges(pipeline_static_entries_,
+                                               &test_request_out_));
+  ASSERT_OK(test_mapper_->HandlePostPushChanges(pipeline_static_entries_,
+                                                &test_request_out_));
 }
 
 // Verifies that the output P4 WriteRequest is cleared when no static
 // entry deletions are needed.
 TEST_F(P4StaticEntryMapperTest, TestClearDelete) {
   test_request_out_.add_updates();
-  EXPECT_OK(test_mapper_->HandlePrePushChanges(
-      pipeline_static_entries_, &test_request_out_));
+  EXPECT_OK(test_mapper_->HandlePrePushChanges(pipeline_static_entries_,
+                                               &test_request_out_));
   EXPECT_EQ(0, test_request_out_.updates_size());
 }
 
@@ -154,8 +153,8 @@ TEST_F(P4StaticEntryMapperTest, TestClearDelete) {
 // entry additions are needed.
 TEST_F(P4StaticEntryMapperTest, TestClearAdd) {
   test_request_out_.add_updates();
-  EXPECT_OK(test_mapper_->HandlePostPushChanges(
-      pipeline_static_entries_, &test_request_out_));
+  EXPECT_OK(test_mapper_->HandlePostPushChanges(pipeline_static_entries_,
+                                                &test_request_out_));
   EXPECT_EQ(0, test_request_out_.updates_size());
 }
 
@@ -170,15 +169,15 @@ TEST_F(P4StaticEntryMapperTest, TestFirstPipelinePush) {
   EXPECT_CALL(mock_p4_table_mapper_, IsTableStageHidden(_))
       .Times(AnyNumber())
       .WillRepeatedly(Return(TRI_STATE_UNKNOWN));
-  EXPECT_OK(test_mapper_->HandlePrePushChanges(
-      pipeline_static_entries_, &test_request_out_));
+  EXPECT_OK(test_mapper_->HandlePrePushChanges(pipeline_static_entries_,
+                                               &test_request_out_));
   EXPECT_EQ(0, test_request_out_.updates_size());
 
   // According to the standard pipeline push sequence, the table mapper should
   // now be ready, so set normal expectations.
   SetUpHiddenTableExpectations();
-  EXPECT_OK(test_mapper_->HandlePostPushChanges(
-      pipeline_static_entries_, &test_request_out_));
+  EXPECT_OK(test_mapper_->HandlePostPushChanges(pipeline_static_entries_,
+                                                &test_request_out_));
   EXPECT_EQ(2, test_request_out_.updates_size());
 }
 
@@ -186,11 +185,11 @@ TEST_F(P4StaticEntryMapperTest, TestFirstPipelinePush) {
 // empty write requests.
 TEST_F(P4StaticEntryMapperTest, TestUnchangedPipelinePush) {
   SetUpFirstPipelinePush({kTestUpdatePhysical1, kTestUpdateHidden1});
-  EXPECT_OK(test_mapper_->HandlePrePushChanges(
-      pipeline_static_entries_, &test_request_out_));
+  EXPECT_OK(test_mapper_->HandlePrePushChanges(pipeline_static_entries_,
+                                               &test_request_out_));
   EXPECT_EQ(0, test_request_out_.updates_size());
-  EXPECT_OK(test_mapper_->HandlePostPushChanges(
-      pipeline_static_entries_, &test_request_out_));
+  EXPECT_OK(test_mapper_->HandlePostPushChanges(pipeline_static_entries_,
+                                                &test_request_out_));
   EXPECT_EQ(0, test_request_out_.updates_size());
 }
 
@@ -201,11 +200,11 @@ TEST_F(P4StaticEntryMapperTest, TestPipelinePushPhysicalAddition) {
 
   SetUpTestRequest(  // Adds kTestUpdatePhysical1.
       {kTestUpdatePhysical1, kTestUpdatePhysical2, kTestUpdateHidden1});
-  EXPECT_OK(test_mapper_->HandlePrePushChanges(
-      pipeline_static_entries_, &test_request_out_));
+  EXPECT_OK(test_mapper_->HandlePrePushChanges(pipeline_static_entries_,
+                                               &test_request_out_));
   EXPECT_EQ(0, test_request_out_.updates_size());
-  EXPECT_OK(test_mapper_->HandlePostPushChanges(
-      pipeline_static_entries_, &test_request_out_));
+  EXPECT_OK(test_mapper_->HandlePostPushChanges(pipeline_static_entries_,
+                                                &test_request_out_));
   EXPECT_EQ(1, test_request_out_.updates_size());
 }
 
@@ -216,11 +215,11 @@ TEST_F(P4StaticEntryMapperTest, TestPipelinePushHiddenAddition) {
 
   SetUpTestRequest(  // Adds kTestUpdateHidden1.
       {kTestUpdatePhysical1, kTestUpdateHidden1, kTestUpdateHidden2});
-  EXPECT_OK(test_mapper_->HandlePrePushChanges(
-      pipeline_static_entries_, &test_request_out_));
+  EXPECT_OK(test_mapper_->HandlePrePushChanges(pipeline_static_entries_,
+                                               &test_request_out_));
   EXPECT_EQ(0, test_request_out_.updates_size());
-  EXPECT_OK(test_mapper_->HandlePostPushChanges(
-      pipeline_static_entries_, &test_request_out_));
+  EXPECT_OK(test_mapper_->HandlePostPushChanges(pipeline_static_entries_,
+                                                &test_request_out_));
   EXPECT_EQ(0, test_request_out_.updates_size());
 }
 
@@ -232,11 +231,11 @@ TEST_F(P4StaticEntryMapperTest, TestPipelinePushPhysicalDeletion) {
 
   // Deletes kTestUpdatePhysical2.
   SetUpTestRequest({kTestUpdatePhysical1, kTestUpdateHidden1});
-  EXPECT_OK(test_mapper_->HandlePrePushChanges(
-      pipeline_static_entries_, &test_request_out_));
+  EXPECT_OK(test_mapper_->HandlePrePushChanges(pipeline_static_entries_,
+                                               &test_request_out_));
   EXPECT_EQ(1, test_request_out_.updates_size());
-  EXPECT_OK(test_mapper_->HandlePostPushChanges(
-      pipeline_static_entries_, &test_request_out_));
+  EXPECT_OK(test_mapper_->HandlePostPushChanges(pipeline_static_entries_,
+                                                &test_request_out_));
   EXPECT_EQ(0, test_request_out_.updates_size());
 }
 
@@ -248,11 +247,11 @@ TEST_F(P4StaticEntryMapperTest, TestPipelinePushHiddenDeletion) {
 
   // Deletes kTestUpdateHidden2.
   SetUpTestRequest({kTestUpdatePhysical1, kTestUpdateHidden1});
-  EXPECT_OK(test_mapper_->HandlePrePushChanges(
-      pipeline_static_entries_, &test_request_out_));
+  EXPECT_OK(test_mapper_->HandlePrePushChanges(pipeline_static_entries_,
+                                               &test_request_out_));
   EXPECT_EQ(0, test_request_out_.updates_size());
-  EXPECT_OK(test_mapper_->HandlePostPushChanges(
-      pipeline_static_entries_, &test_request_out_));
+  EXPECT_OK(test_mapper_->HandlePostPushChanges(pipeline_static_entries_,
+                                                &test_request_out_));
   EXPECT_EQ(0, test_request_out_.updates_size());
 }
 
@@ -308,11 +307,11 @@ TEST_F(P4StaticEntryMapperTest, TestNoHiddenRemap) {
 
   // Adds kTestUpdateHidden2.
   SetUpTestRequest({kTestUpdatePhysical1, kTestUpdateHidden2});
-  EXPECT_OK(test_mapper_->HandlePrePushChanges(
-      pipeline_static_entries_, &test_request_out_));
+  EXPECT_OK(test_mapper_->HandlePrePushChanges(pipeline_static_entries_,
+                                               &test_request_out_));
   EXPECT_EQ(0, test_request_out_.updates_size());
-  EXPECT_OK(test_mapper_->HandlePostPushChanges(
-      pipeline_static_entries_, &test_request_out_));
+  EXPECT_OK(test_mapper_->HandlePostPushChanges(pipeline_static_entries_,
+                                                &test_request_out_));
   EXPECT_EQ(1, test_request_out_.updates_size());
 }
 

--- a/stratum/hal/lib/p4/p4_table_mapper.cc
+++ b/stratum/hal/lib/p4/p4_table_mapper.cc
@@ -692,10 +692,10 @@ std::string P4TableMapper::GetMapperNameKey(
   auto convert_iter = field_convert_by_table_.find(key);
   if (convert_iter == field_convert_by_table_.end()) {
     // No way to decode fields that don't go with the table.
-    RETURN_ERROR(ERR_OPER_NOT_SUPPORTED)
-        << "P4 TableEntry match field ID "
-        << PrintP4ObjectID(match_field.field_id())
-        << " is not recognized in table " << table_p4_info.preamble().name();
+    return MAKE_ERROR(ERR_OPER_NOT_SUPPORTED)
+           << "P4 TableEntry match field ID "
+           << PrintP4ObjectID(match_field.field_id())
+           << " is not recognized in table " << table_p4_info.preamble().name();
   }
 
   const auto& conversion_value = convert_iter->second;

--- a/stratum/hal/lib/p4/p4_table_mapper.h
+++ b/stratum/hal/lib/p4/p4_table_mapper.h
@@ -2,7 +2,6 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 #ifndef STRATUM_HAL_LIB_P4_P4_TABLE_MAPPER_H_
 #define STRATUM_HAL_LIB_P4_P4_TABLE_MAPPER_H_
 
@@ -11,10 +10,11 @@
 #include <memory>
 #include <set>
 #include <string>
-#include <vector>
 #include <utility>
+#include <vector>
 
 #include "absl/container/flat_hash_map.h"
+#include "p4/config/v1/p4info.pb.h"
 #include "stratum/glue/status/status.h"
 #include "stratum/hal/lib/common/common.pb.h"
 #include "stratum/hal/lib/p4/common_flow_entry.pb.h"
@@ -24,7 +24,6 @@
 #include "stratum/hal/lib/p4/p4_table_map.pb.h"
 #include "stratum/lib/utils.h"
 #include "stratum/public/proto/p4_table_defs.pb.h"
-#include "p4/config/v1/p4info.pb.h"
 
 namespace stratum {
 namespace hal {

--- a/stratum/hal/lib/p4/p4_table_mapper_mock.h
+++ b/stratum/hal/lib/p4/p4_table_mapper_mock.h
@@ -2,14 +2,13 @@
 // Copyright 2018-present Open Networking Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-
 // This is a mock implementation of P4TableMapper.
 
 #ifndef STRATUM_HAL_LIB_P4_P4_TABLE_MAPPER_MOCK_H_
 #define STRATUM_HAL_LIB_P4_P4_TABLE_MAPPER_MOCK_H_
 
-#include "stratum/hal/lib/p4/p4_table_mapper.h"
 #include "gmock/gmock.h"
+#include "stratum/hal/lib/p4/p4_table_mapper.h"
 
 namespace stratum {
 namespace hal {

--- a/stratum/hal/lib/p4/p4_write_request_differ.cc
+++ b/stratum/hal/lib/p4/p4_write_request_differ.cc
@@ -7,8 +7,8 @@
 
 #include "stratum/hal/lib/p4/p4_write_request_differ.h"
 
-#include "stratum/glue/logging.h"
 #include "google/protobuf/generated_message_reflection.h"
+#include "stratum/glue/logging.h"
 #include "stratum/glue/status/status_macros.h"
 #include "stratum/lib/macros.h"
 #include "stratum/public/lib/error.h"
@@ -156,8 +156,9 @@ void P4WriteRequestReporter::ReportMatched(
 bool P4WriteRequestComparator::IsMatch(
     const google::protobuf::Message& message1,
     const google::protobuf::Message& message2,  // NOLINTNEXTLINE
-    const std::vector<google::protobuf::util::MessageDifferencer::SpecificField>&
-    parent_fields) const {
+    const std::vector<
+        google::protobuf::util::MessageDifferencer::SpecificField>&
+        parent_fields) const {
   const ::p4::v1::Update& update1 =
       *google::protobuf::DynamicCastToGenerated<const ::p4::v1::Update>(
           &message1);

--- a/stratum/hal/lib/phal/datasource.cc
+++ b/stratum/hal/lib/phal/datasource.cc
@@ -74,7 +74,7 @@ void FetchOnce::CacheUpdated() { should_update_ = false; }
         return new NoCache();
 
     default:
-        RETURN_ERROR(ERR_INVALID_PARAM) << "invalid cache type";
+        return MAKE_ERROR(ERR_INVALID_PARAM) << "invalid cache type";
     }
 }
 

--- a/stratum/hal/lib/phal/onlp/onlp_fan_datasource.cc
+++ b/stratum/hal/lib/phal/onlp/onlp_fan_datasource.cc
@@ -109,7 +109,7 @@ OnlpFanDataSource::OnlpFanDataSource(int fan_id,
   // to squeeze a double into an 'int', with an error if
   // it doesn't fit.
   if (val > SHRT_MAX) {
-    RETURN_ERROR() << "Set Fan RPM bigger than an integer";
+    return MAKE_ERROR() << "Set Fan RPM bigger than an integer";
   }
   int onlp_val = static_cast<int>(val);
   return onlp_stub_->SetFanRpm(fan_oid_, onlp_val);

--- a/stratum/hal/lib/phal/onlp/onlp_sfp_configurator.cc
+++ b/stratum/hal/lib/phal/onlp/onlp_sfp_configurator.cc
@@ -66,7 +66,7 @@ OnlpSfpConfigurator::Make(std::shared_ptr<OnlpSfpDataSource> datasource,
       break;
 
     default:
-      RETURN_ERROR() << "Unknown SFP event state " << state << ".";
+      return MAKE_ERROR() << "Unknown SFP event state " << state << ".";
   }
 
   return ::util::OkStatus();

--- a/stratum/hal/lib/phal/optics_adapter.cc
+++ b/stratum/hal/lib/phal/optics_adapter.cc
@@ -23,7 +23,7 @@ OpticsAdapter::OpticsAdapter(AttributeDatabaseInterface* attribute_db_interface)
     int module, int network_interface,
     OpticalTransceiverInfo* ot_info) {
   if (module <= 0 || network_interface <= 0) {
-    RETURN_ERROR(ERR_INVALID_PARAM) << "Invalid Slot/Port value. ";
+    return MAKE_ERROR(ERR_INVALID_PARAM) << "Invalid Slot/Port value. ";
   }
 
   std::vector<Path> paths = {
@@ -59,7 +59,7 @@ OpticsAdapter::OpticsAdapter(AttributeDatabaseInterface* attribute_db_interface)
     int module, int network_interface,
     const OpticalTransceiverInfo& ot_info) {
   if (module <= 0 || network_interface <= 0) {
-    RETURN_ERROR(ERR_INVALID_PARAM) << "Invalid Slot/Port value. ";
+    return MAKE_ERROR(ERR_INVALID_PARAM) << "Invalid Slot/Port value. ";
   }
 
   AttributeValueMap attrs;

--- a/stratum/hal/lib/phal/phaldb_service.cc
+++ b/stratum/hal/lib/phal/phaldb_service.cc
@@ -63,7 +63,7 @@ namespace {
 ::util::StatusOr<Path> ToPhalDBPath(PathQuery req_path) {
   // If no path entries return error
   if (req_path.entries_size() == 0) {
-    RETURN_ERROR(ERR_INVALID_PARAM) << "No Path";
+    return MAKE_ERROR(ERR_INVALID_PARAM) << "No Path";
   }
 
   // Create Attribute DB Path

--- a/stratum/hal/lib/phal/sfp_adapter.cc
+++ b/stratum/hal/lib/phal/sfp_adapter.cc
@@ -32,7 +32,7 @@ SfpAdapter::~SfpAdapter() {
 ::util::Status SfpAdapter::GetFrontPanelPortInfo(
     int card_id, int port_id, FrontPanelPortInfo* fp_port_info) {
   if (card_id <= 0 || port_id <= 0) {
-    RETURN_ERROR(ERR_INVALID_PARAM) << "Invalid Slot/Port value. ";
+    return MAKE_ERROR(ERR_INVALID_PARAM) << "Invalid Slot/Port value. ";
   }
 
   std::vector<Path> paths = {
@@ -59,7 +59,7 @@ SfpAdapter::~SfpAdapter() {
 
   // Get the SFP (transceiver)
   if (!phal_port.has_transceiver()) {
-    RETURN_ERROR() << "cards[" << card_id << "]/ports[" << port_id
+    return MAKE_ERROR() << "cards[" << card_id << "]/ports[" << port_id
                    << "] has no transceiver";
   }
   auto sfp = phal_port.transceiver();
@@ -83,7 +83,7 @@ SfpAdapter::~SfpAdapter() {
       actual_val = PHYSICAL_PORT_TYPE_QSFP_CAGE;
       break;
     default:
-      RETURN_ERROR(ERR_INVALID_PARAM) << "Invalid sfptype. ";
+      return MAKE_ERROR(ERR_INVALID_PARAM) << "Invalid sfptype. ";
   }
   fp_port_info->set_physical_port_type(actual_val);
 

--- a/stratum/hal/lib/pi/pi_node.cc
+++ b/stratum/hal/lib/pi/pi_node.cc
@@ -148,7 +148,7 @@ std::unique_ptr<PINode> PINode::CreateInstance(
     const ::p4::v1::WriteRequest& req, std::vector<::util::Status>* results) {
   absl::ReaderMutexLock l(&lock_);
   if (!pipeline_initialized_) {
-    RETURN_ERROR(ERR_INTERNAL) << "Pipeline not initialized";
+    return MAKE_ERROR(ERR_INTERNAL) << "Pipeline not initialized";
   }
   if (!req.updates_size()) return ::util::OkStatus();  // nothing to do.
   CHECK_RETURN_IF_FALSE(results != nullptr)
@@ -164,7 +164,7 @@ std::unique_ptr<PINode> PINode::CreateInstance(
     std::vector<::util::Status>* details) {
   absl::ReaderMutexLock l(&lock_);
   if (!pipeline_initialized_) {
-    RETURN_ERROR(ERR_INTERNAL) << "Pipeline not initialized";
+    return MAKE_ERROR(ERR_INTERNAL) << "Pipeline not initialized";
   }
   CHECK_RETURN_IF_FALSE(writer) << "Channel writer must be non-null.";
   CHECK_RETURN_IF_FALSE(details) << "Details pointer must be non-null.";
@@ -196,7 +196,7 @@ std::unique_ptr<PINode> PINode::CreateInstance(
     const ::p4::v1::StreamMessageRequest& request) {
   absl::ReaderMutexLock l(&lock_);
   if (!pipeline_initialized_) {
-    RETURN_ERROR(ERR_INTERNAL) << "Pipeline not initialized";
+    return MAKE_ERROR(ERR_INTERNAL) << "Pipeline not initialized";
   }
   return toUtilStatus(device_mgr_->stream_message_request_handle(request));
 }

--- a/stratum/hal/lib/tdi/dpdk/dpdk_sde_target.cc
+++ b/stratum/hal/lib/tdi/dpdk/dpdk_sde_target.cc
@@ -200,7 +200,8 @@ std::string TdiSdeWrapper::GetSdeVersion() const {
     int dev_id, std::shared_ptr<TdiSdeInterface::SessionInterface> session,
     const std::string& table_name, notification_table_callback_t callback,
     void* cookie) const LOCKS_EXCLUDED(data_lock_) {
-  RETURN_ERROR(ERR_OPER_NOT_SUPPORTED) << "Notification Table not supported";
+  return MAKE_ERROR(ERR_OPER_NOT_SUPPORTED)
+         << "Notification Table not supported";
 }
 
 }  // namespace tdi

--- a/stratum/hal/lib/tdi/es2k/es2k_chassis_manager.cc
+++ b/stratum/hal/lib/tdi/es2k/es2k_chassis_manager.cc
@@ -83,14 +83,14 @@ Es2kChassisManager::~Es2kChassisManager() = default;
 
   const auto& config_params = singleton_port.config_params();
   if (config_params.admin_state() == ADMIN_STATE_UNKNOWN) {
-    RETURN_ERROR(ERR_INVALID_PARAM)
-        << "Invalid admin state for port " << port_id << " in node " << node_id
-        << " (SDK Port " << sdk_port_id << ").";
+    return MAKE_ERROR(ERR_INVALID_PARAM)
+           << "Invalid admin state for port " << port_id << " in node "
+           << node_id << " (SDK Port " << sdk_port_id << ").";
   }
   if (config_params.admin_state() == ADMIN_STATE_DIAG) {
-    RETURN_ERROR(ERR_UNIMPLEMENTED)
-        << "Unsupported 'diags' admin state for port " << port_id << " in node "
-        << node_id << " (SDK Port " << sdk_port_id << ").";
+    return MAKE_ERROR(ERR_UNIMPLEMENTED)
+           << "Unsupported 'diags' admin state for port " << port_id
+           << " in node " << node_id << " (SDK Port " << sdk_port_id << ").";
   }
 
   LOG(INFO) << "Adding port " << port_id << " in node " << node_id
@@ -147,9 +147,9 @@ Es2kChassisManager::~Es2kChassisManager() = default;
     config->admin_state = ADMIN_STATE_UNKNOWN;
     config->speed_bps.reset();
     config->fec_mode.reset();
-    RETURN_ERROR(ERR_INTERNAL)
-        << "Port " << port_id << " in node " << node_id << " is not valid"
-        << " (SDK Port " << sdk_port_id << ").";
+    return MAKE_ERROR(ERR_INTERNAL)
+           << "Port " << port_id << " in node " << node_id << " is not valid"
+           << " (SDK Port " << sdk_port_id << ").";
   }
 
   const auto& config_params = singleton_port.config_params();
@@ -176,29 +176,29 @@ Es2kChassisManager::~Es2kChassisManager() = default;
       if (config_old.fec_mode)
         port_old.mutable_config_params()->set_fec_mode(*config_old.fec_mode);
       AddPortHelper(node_id, unit, sdk_port_id, port_old, config);
-      RETURN_ERROR(ERR_INVALID_PARAM)
-          << "Could not add port " << port_id << " with new speed "
-          << singleton_port.speed_bps() << " to BF SDE"
-          << " (SDK Port " << sdk_port_id << ").";
+      return MAKE_ERROR(ERR_INVALID_PARAM)
+             << "Could not add port " << port_id << " with new speed "
+             << singleton_port.speed_bps() << " to BF SDE"
+             << " (SDK Port " << sdk_port_id << ").";
     }
   }
   // same for FEC mode
   if (config_params.fec_mode() != config_old.fec_mode) {
-    RETURN_ERROR(ERR_UNIMPLEMENTED)
-        << "The FEC mode for port " << port_id << " in node " << node_id
-        << " has changed; you need to delete the port and add it again"
-        << " (SDK Port " << sdk_port_id << ").";
+    return MAKE_ERROR(ERR_UNIMPLEMENTED)
+           << "The FEC mode for port " << port_id << " in node " << node_id
+           << " has changed; you need to delete the port and add it again"
+           << " (SDK Port " << sdk_port_id << ").";
   }
 
   if (config_params.admin_state() == ADMIN_STATE_UNKNOWN) {
-    RETURN_ERROR(ERR_INVALID_PARAM)
-        << "Invalid admin state for port " << port_id << " in node " << node_id
-        << " (SDK Port " << sdk_port_id << ").";
+    return MAKE_ERROR(ERR_INVALID_PARAM)
+           << "Invalid admin state for port " << port_id << " in node "
+           << node_id << " (SDK Port " << sdk_port_id << ").";
   }
   if (config_params.admin_state() == ADMIN_STATE_DIAG) {
-    RETURN_ERROR(ERR_UNIMPLEMENTED)
-        << "Unsupported 'diags' admin state for port " << port_id << " in node "
-        << node_id << " (SDK Port " << sdk_port_id << ").";
+    return MAKE_ERROR(ERR_UNIMPLEMENTED)
+           << "Unsupported 'diags' admin state for port " << port_id
+           << " in node " << node_id << " (SDK Port " << sdk_port_id << ").";
   }
 
   bool config_changed = false;
@@ -296,9 +296,9 @@ Es2kChassisManager::~Es2kChassisManager() = default;
 
     auto* unit = gtl::FindOrNull(node_id_to_unit, node_id);
     if (unit == nullptr) {
-      RETURN_ERROR(ERR_INVALID_PARAM)
-          << "Invalid ChassisConfig, unknown node id " << node_id
-          << " for port " << port_id << ".";
+      return MAKE_ERROR(ERR_INVALID_PARAM)
+             << "Invalid ChassisConfig, unknown node id " << node_id
+             << " for port " << port_id << ".";
     }
     node_id_to_port_id_to_port_state[node_id][port_id] = PORT_STATE_UNKNOWN;
     node_id_to_port_id_to_time_last_changed[node_id][port_id] =
@@ -361,9 +361,9 @@ Es2kChassisManager::~Es2kChassisManager() = default;
       // sanity-check: if admin_state is not ADMIN_STATE_UNKNOWN, then the port
       // was added and the speed_bps was set.
       if (!config_old->speed_bps) {
-        RETURN_ERROR(ERR_INTERNAL)
-            << "Invalid internal state in Es2kChassisManager, "
-            << "speed_bps field should contain a value";
+        return MAKE_ERROR(ERR_INTERNAL)
+               << "Invalid internal state in Es2kChassisManager, "
+               << "speed_bps field should contain a value";
       }
 
       // if anything fails, config.admin_state will be set to
@@ -524,17 +524,17 @@ Es2kChassisManager::~Es2kChassisManager() = default;
   if (initialized_) {
     if (node_id_to_port_id_to_singleton_port_key !=
         node_id_to_port_id_to_singleton_port_key_) {
-      RETURN_ERROR(ERR_REBOOT_REQUIRED)
-          << "The switch is already initialized, but we detected the newly "
-          << "pushed config requires a change in the port layout. The stack "
-          << "needs to be rebooted to finish config push.";
+      return MAKE_ERROR(ERR_REBOOT_REQUIRED)
+             << "The switch is already initialized, but we detected the newly "
+             << "pushed config requires a change in the port layout. The stack "
+             << "needs to be rebooted to finish config push.";
     }
 
     if (node_id_to_unit != node_id_to_unit_) {
-      RETURN_ERROR(ERR_REBOOT_REQUIRED)
-          << "The switch is already initialized, but we detected the newly "
-          << "pushed config requires a change in node_id_to_unit. The stack "
-          << "needs to be rebooted to finish config push.";
+      return MAKE_ERROR(ERR_REBOOT_REQUIRED)
+             << "The switch is already initialized, but we detected the newly "
+             << "pushed config requires a change in node_id_to_unit. The stack "
+             << "needs to be rebooted to finish config push.";
     }
   }
 
@@ -707,12 +707,12 @@ Es2kChassisManager::GetPortConfig(uint64 node_id, uint32 port_id) const {
       break;
     }
     default:
-      RETURN_ERROR(ERR_UNIMPLEMENTED)
-          << "DataRequest field "
-          << request.descriptor()
-                 ->FindFieldByNumber(request.request_case())
-                 ->name()
-          << " is not supported yet!";
+      return MAKE_ERROR(ERR_UNIMPLEMENTED)
+             << "DataRequest field "
+             << request.descriptor()
+                    ->FindFieldByNumber(request.request_case())
+                    ->name()
+             << " is not supported yet!";
   }
   return resp;
 }
@@ -809,14 +809,14 @@ Es2kChassisManager::GetPortConfig(uint64 node_id, uint32 port_id) const {
     }
 
     if (!config.speed_bps) {
-      RETURN_ERROR(ERR_INTERNAL)
-          << "Invalid internal state in Es2kChassisManager, "
-          << "speed_bps field should contain a value";
+      return MAKE_ERROR(ERR_INTERNAL)
+             << "Invalid internal state in Es2kChassisManager, "
+             << "speed_bps field should contain a value";
     }
     if (!config.fec_mode) {
-      RETURN_ERROR(ERR_INTERNAL)
-          << "Invalid internal state in Es2kChassisManager, "
-          << "fec_mode field should contain a value";
+      return MAKE_ERROR(ERR_INTERNAL)
+             << "Invalid internal state in Es2kChassisManager, "
+             << "fec_mode field should contain a value";
     }
 
     ASSIGN_OR_RETURN(auto sdk_port_id, GetSdkPortId(node_id, port_id));

--- a/stratum/hal/lib/tdi/es2k/es2k_port_manager.cc
+++ b/stratum/hal/lib/tdi/es2k/es2k_port_manager.cc
@@ -57,7 +57,7 @@ namespace {
     case TRI_STATE_FALSE:
       return 2;
     default:
-      RETURN_ERROR(ERR_INVALID_PARAM) << "Invalid autoneg state.";
+      return MAKE_ERROR(ERR_INVALID_PARAM) << "Invalid autoneg state.";
   }
 }
 

--- a/stratum/hal/lib/tdi/es2k/es2k_sde_target.cc
+++ b/stratum/hal/lib/tdi/es2k/es2k_sde_target.cc
@@ -212,8 +212,8 @@ std::string TdiSdeWrapper::GetChipType(int device) const {
                            char* ipsec_sa_dest_address, bool ipv4, void* cke),
     void* cookie) const {
   if (!tdi_info_) {
-    RETURN_ERROR(ERR_INTERNAL)
-        << "Unable to initialize notification table due to TDI internal error";
+    return MAKE_ERROR(ERR_INTERNAL) << "Unable to initialize notification "
+                                       "table due to TDI internal error";
   }
 
   auto real_session = std::dynamic_pointer_cast<Session>(session);

--- a/stratum/hal/lib/tdi/tdi_action_profile_manager.cc
+++ b/stratum/hal/lib/tdi/tdi_action_profile_manager.cc
@@ -62,8 +62,8 @@ TdiActionProfileManager::CreateInstance(TdiSdeInterface* tdi_sde_interface,
                                        act_prof_group);
     }
     default:
-      RETURN_ERROR(ERR_INVALID_PARAM)
-          << "Unsupported extern type " << entry.extern_type_id() << ".";
+      return MAKE_ERROR(ERR_INVALID_PARAM)
+             << "Unsupported extern type " << entry.extern_type_id() << ".";
   }
 }
 
@@ -95,8 +95,8 @@ TdiActionProfileManager::CreateInstance(TdiSdeInterface* tdi_sde_interface,
       break;
     }
     default:
-      RETURN_ERROR(ERR_OPER_NOT_SUPPORTED)
-          << "Unsupported extern type " << entry.extern_type_id() << ".";
+      return MAKE_ERROR(ERR_OPER_NOT_SUPPORTED)
+             << "Unsupported extern type " << entry.extern_type_id() << ".";
   }
 
   return ::util::OkStatus();
@@ -192,7 +192,8 @@ TdiActionProfileManager::CreateInstance(TdiSdeInterface* tdi_sde_interface,
       break;
     }
     default:
-      RETURN_ERROR(ERR_INVALID_PARAM) << "Unsupported update type: " << type;
+      return MAKE_ERROR(ERR_INVALID_PARAM)
+             << "Unsupported update type: " << type;
   }
 
   return ::util::OkStatus();
@@ -245,7 +246,7 @@ TdiActionProfileManager::CreateInstance(TdiSdeInterface* tdi_sde_interface,
   }
 
   if (!writer->Write(resp)) {
-    RETURN_ERROR(ERR_INTERNAL) << "Write to stream channel failed.";
+    return MAKE_ERROR(ERR_INTERNAL) << "Write to stream channel failed.";
   }
 
   return ::util::OkStatus();
@@ -284,7 +285,8 @@ TdiActionProfileManager::CreateInstance(TdiSdeInterface* tdi_sde_interface,
       break;
     }
     default:
-      RETURN_ERROR(ERR_INVALID_PARAM) << "Unsupported update type: " << type;
+      return MAKE_ERROR(ERR_INVALID_PARAM)
+             << "Unsupported update type: " << type;
   }
 
   return ::util::OkStatus();

--- a/stratum/hal/lib/tdi/tdi_fixed_function_manager.cc
+++ b/stratum/hal/lib/tdi/tdi_fixed_function_manager.cc
@@ -96,8 +96,8 @@ TdiFixedFunctionManager::CreateInstance(OperationMode mode,
           device_, session, table_id, table_key.get()));
       break;
     default:
-      RETURN_ERROR(ERR_INTERNAL)
-          << "Unsupported update type: " << op_type << " for IPSEC SADB table.";
+      return MAKE_ERROR(ERR_INTERNAL) << "Unsupported update type: " << op_type
+                                      << " for IPSEC SADB table.";
   }
   return ::util::OkStatus();
 }

--- a/stratum/hal/lib/tdi/tdi_node.cc
+++ b/stratum/hal/lib/tdi/tdi_node.cc
@@ -430,8 +430,9 @@ std::unique_ptr<TdiNode> TdiNode::CreateInstance(
       return tdi_packetio_manager_->TransmitPacket(req.packet());
     }
     default:
-      RETURN_ERROR(ERR_UNIMPLEMENTED) << "Unsupported StreamMessageRequest "
-                                      << req.ShortDebugString() << ".";
+      return MAKE_ERROR(ERR_UNIMPLEMENTED)
+             << "Unsupported StreamMessageRequest " << req.ShortDebugString()
+             << ".";
   }
 }
 

--- a/stratum/hal/lib/tdi/tdi_packetio_manager.cc
+++ b/stratum/hal/lib/tdi/tdi_packetio_manager.cc
@@ -65,9 +65,9 @@ std::unique_ptr<TdiPacketioManager> TdiPacketioManager::CreateInstance(
         int ret = pthread_create(&sde_rx_thread_id_, nullptr,
                                  &TdiPacketioManager::SdeRxThreadFunc, this);
         if (ret != 0) {
-          RETURN_ERROR(ERR_INTERNAL)
-              << "Failed to spawn RX thread for SDE wrapper for device with ID "
-              << device_ << ". Err: " << ret << ".";
+          return MAKE_ERROR(ERR_INTERNAL) << "Failed to spawn RX thread for "
+                                             "SDE wrapper for device with ID "
+                                          << device_ << ". Err: " << ret << ".";
         }
       }
       RETURN_IF_ERROR(tdi_sde_interface_->RegisterPacketReceiveWriter(
@@ -281,7 +281,8 @@ class BitBuffer {
     const ::p4::v1::PacketOut& packet) {
   {
     absl::ReaderMutexLock l(&data_lock_);
-    if (!initialized_) RETURN_ERROR(ERR_NOT_INITIALIZED) << "Not initialized.";
+    if (!initialized_)
+      return MAKE_ERROR(ERR_NOT_INITIALIZED) << "Not initialized.";
   }
   std::string buf;
   RETURN_IF_ERROR(DeparsePacketOut(packet, &buf));
@@ -296,7 +297,8 @@ class BitBuffer {
   std::unique_ptr<ChannelReader<std::string>> reader;
   {
     absl::ReaderMutexLock l(&data_lock_);
-    if (!initialized_) RETURN_ERROR(ERR_NOT_INITIALIZED) << "Not initialized.";
+    if (!initialized_)
+      return MAKE_ERROR(ERR_NOT_INITIALIZED) << "Not initialized.";
     reader = ChannelReader<std::string>::Create(packet_receive_channel_);
   }
 

--- a/stratum/hal/lib/tdi/tdi_pipeline_utils.cc
+++ b/stratum/hal/lib/tdi/tdi_pipeline_utils.cc
@@ -41,7 +41,8 @@ std::string Uint32ToLeByteStream(uint32 val) {
     return util::OkStatus();
   }
 
-  RETURN_ERROR(ERR_INVALID_PARAM) << "Unknown format for p4_device_config.";
+  return MAKE_ERROR(ERR_INVALID_PARAM)
+         << "Unknown format for p4_device_config.";
 }
 
 ::util::Status BfPipelineConfigToPiConfig(const BfPipelineConfig& bf_config,

--- a/stratum/hal/lib/tdi/tdi_pre_manager.cc
+++ b/stratum/hal/lib/tdi/tdi_pre_manager.cc
@@ -39,8 +39,8 @@ TdiPreManager::TdiPreManager(TdiSdeInterface* tdi_sde_interface, int device)
     case PreEntry::kCloneSessionEntry:
       return WriteCloneSessionEntry(session, type, entry.clone_session_entry());
     default:
-      RETURN_ERROR(ERR_UNIMPLEMENTED)
-          << "Unsupported PRE entry: " << entry.ShortDebugString();
+      return MAKE_ERROR(ERR_UNIMPLEMENTED)
+             << "Unsupported PRE entry: " << entry.ShortDebugString();
   }
 }
 
@@ -60,8 +60,8 @@ TdiPreManager::TdiPreManager(TdiSdeInterface* tdi_sde_interface, int device)
       break;
     }
     default:
-      RETURN_ERROR(ERR_UNIMPLEMENTED)
-          << "Unsupported PRE entry: " << entry.ShortDebugString();
+      return MAKE_ERROR(ERR_UNIMPLEMENTED)
+             << "Unsupported PRE entry: " << entry.ShortDebugString();
   }
 
   return ::util::OkStatus();
@@ -156,7 +156,8 @@ std::unique_ptr<TdiPreManager> TdiPreManager::CreateInstance(
       break;
     }
     default:
-      RETURN_ERROR(ERR_UNIMPLEMENTED) << "Unsupported update type: " << type;
+      return MAKE_ERROR(ERR_UNIMPLEMENTED)
+             << "Unsupported update type: " << type;
   }
   return ::util::OkStatus();
 }
@@ -273,9 +274,9 @@ std::unique_ptr<TdiPreManager> TdiPreManager::CreateInstance(
       break;
     }
     default:
-      RETURN_ERROR(ERR_UNIMPLEMENTED)
-          << "Unsupported update type: " << type << " on CloneSessionEntry "
-          << entry.ShortDebugString() << ".";
+      return MAKE_ERROR(ERR_UNIMPLEMENTED)
+             << "Unsupported update type: " << type << " on CloneSessionEntry "
+             << entry.ShortDebugString() << ".";
   }
 
   return ::util::OkStatus();

--- a/stratum/hal/lib/tdi/tdi_sde_helpers.cc
+++ b/stratum/hal/lib/tdi/tdi_sde_helpers.cc
@@ -106,8 +106,8 @@ namespace helpers {
         break;
       }
       default:
-        RETURN_ERROR(ERR_INTERNAL)
-            << "Unknown key_type: " << static_cast<int>(key_type) << ".";
+        return MAKE_ERROR(ERR_INTERNAL)
+               << "Unknown key_type: " << static_cast<int>(key_type) << ".";
     }
 
     absl::StrAppend(&s, field_name, " { field_id: ", field_id,
@@ -180,8 +180,8 @@ namespace helpers {
         break;
       }
       default:
-        RETURN_ERROR(ERR_INTERNAL)
-            << "Unknown data_type: " << static_cast<int>(data_type) << ".";
+        return MAKE_ERROR(ERR_INTERNAL)
+               << "Unknown data_type: " << static_cast<int>(data_type) << ".";
     }
 
     absl::StrAppend(&s, field_name, " { field_id: ", field_id,

--- a/stratum/hal/lib/tdi/tdi_sde_meter.cc
+++ b/stratum/hal/lib/tdi/tdi_sde_meter.cc
@@ -194,9 +194,9 @@ using namespace stratum::hal::tdi::helpers;
         RETURN_IF_TDI_ERROR(table_data->getValue(field_id, &pburst));
         pbursts->push_back(pburst);
       } else {
-        RETURN_ERROR(ERR_INVALID_PARAM)
-            << "Unknown meter field " << field_name << " in meter with id "
-            << table_id << ".";
+        return MAKE_ERROR(ERR_INVALID_PARAM)
+               << "Unknown meter field " << field_name << " in meter with id "
+               << table_id << ".";
       }
     }
   }

--- a/stratum/hal/lib/tdi/tdi_sde_multicast.cc
+++ b/stratum/hal/lib/tdi/tdi_sde_multicast.cc
@@ -169,7 +169,7 @@ namespace {
     }
   }
 
-  RETURN_ERROR(ERR_TABLE_FULL) << "Could not find free multicast node id.";
+  return MAKE_ERROR(ERR_TABLE_FULL) << "Could not find free multicast node id.";
 }
 
 ::util::StatusOr<uint32> TdiSdeWrapper::CreateMulticastNode(

--- a/stratum/hal/lib/tdi/tdi_sde_register.cc
+++ b/stratum/hal/lib/tdi/tdi_sde_register.cc
@@ -59,7 +59,7 @@ namespace {
     }
   }
 
-  RETURN_ERROR(ERR_INTERNAL) << "Could not find register data field id.";
+  return MAKE_ERROR(ERR_INTERNAL) << "Could not find register data field id.";
 }
 
 }  // namespace
@@ -195,9 +195,10 @@ namespace {
         break;
       }
       default:
-        RETURN_ERROR(ERR_INVALID_PARAM)
-            << "Unsupported register data type " << static_cast<int>(data_type)
-            << " for register in table " << table_id;
+        return MAKE_ERROR(ERR_INVALID_PARAM)
+               << "Unsupported register data type "
+               << static_cast<int>(data_type) << " for register in table "
+               << table_id;
     }
   }
 

--- a/stratum/hal/lib/tdi/tdi_sde_wrapper.cc
+++ b/stratum/hal/lib/tdi/tdi_sde_wrapper.cc
@@ -119,7 +119,7 @@ TdiSdeWrapper* TdiSdeWrapper::GetSingleton() {
     return (table->tableInfoGet()->idGet());
   }
 
-  RETURN_ERROR(ERR_INTERNAL) << "Error retreiving information from TDI";
+  return MAKE_ERROR(ERR_INTERNAL) << "Error retreiving information from TDI";
 }
 
 }  // namespace tdi

--- a/stratum/hal/lib/tdi/tofino/tofino_chassis_manager.cc
+++ b/stratum/hal/lib/tdi/tofino/tofino_chassis_manager.cc
@@ -96,14 +96,14 @@ TofinoChassisManager::~TofinoChassisManager() = default;
 
   const auto& config_params = singleton_port.config_params();
   if (config_params.admin_state() == ADMIN_STATE_UNKNOWN) {
-    RETURN_ERROR(ERR_INVALID_PARAM)
-        << "Invalid admin state for port " << port_id << " in node " << node_id
-        << " (SDK Port " << sdk_port_id << ").";
+    return MAKE_ERROR(ERR_INVALID_PARAM)
+           << "Invalid admin state for port " << port_id << " in node "
+           << node_id << " (SDK Port " << sdk_port_id << ").";
   }
   if (config_params.admin_state() == ADMIN_STATE_DIAG) {
-    RETURN_ERROR(ERR_UNIMPLEMENTED)
-        << "Unsupported 'diags' admin state for port " << port_id << " in node "
-        << node_id << " (SDK Port " << sdk_port_id << ").";
+    return MAKE_ERROR(ERR_UNIMPLEMENTED)
+           << "Unsupported 'diags' admin state for port " << port_id
+           << " in node " << node_id << " (SDK Port " << sdk_port_id << ").";
   }
 
   LOG(INFO) << "Adding port " << port_id << " in node " << node_id
@@ -160,9 +160,9 @@ TofinoChassisManager::~TofinoChassisManager() = default;
     config->admin_state = ADMIN_STATE_UNKNOWN;
     config->speed_bps.reset();
     config->fec_mode.reset();
-    RETURN_ERROR(ERR_INTERNAL)
-        << "Port " << port_id << " in node " << node_id << " is not valid"
-        << " (SDK Port " << sdk_port_id << ").";
+    return MAKE_ERROR(ERR_INTERNAL)
+           << "Port " << port_id << " in node " << node_id << " is not valid"
+           << " (SDK Port " << sdk_port_id << ").";
   }
 
   const auto& config_params = singleton_port.config_params();
@@ -189,29 +189,29 @@ TofinoChassisManager::~TofinoChassisManager() = default;
       if (config_old.fec_mode)
         port_old.mutable_config_params()->set_fec_mode(*config_old.fec_mode);
       AddPortHelper(node_id, unit, sdk_port_id, port_old, config);
-      RETURN_ERROR(ERR_INVALID_PARAM)
-          << "Could not add port " << port_id << " with new speed "
-          << singleton_port.speed_bps() << " to BF SDE"
-          << " (SDK Port " << sdk_port_id << ").";
+      return MAKE_ERROR(ERR_INVALID_PARAM)
+             << "Could not add port " << port_id << " with new speed "
+             << singleton_port.speed_bps() << " to BF SDE"
+             << " (SDK Port " << sdk_port_id << ").";
     }
   }
   // same for FEC mode
   if (config_params.fec_mode() != config_old.fec_mode) {
-    RETURN_ERROR(ERR_UNIMPLEMENTED)
-        << "The FEC mode for port " << port_id << " in node " << node_id
-        << " has changed; you need to delete the port and add it again"
-        << " (SDK Port " << sdk_port_id << ").";
+    return MAKE_ERROR(ERR_UNIMPLEMENTED)
+           << "The FEC mode for port " << port_id << " in node " << node_id
+           << " has changed; you need to delete the port and add it again"
+           << " (SDK Port " << sdk_port_id << ").";
   }
 
   if (config_params.admin_state() == ADMIN_STATE_UNKNOWN) {
-    RETURN_ERROR(ERR_INVALID_PARAM)
-        << "Invalid admin state for port " << port_id << " in node " << node_id
-        << " (SDK Port " << sdk_port_id << ").";
+    return MAKE_ERROR(ERR_INVALID_PARAM)
+           << "Invalid admin state for port " << port_id << " in node "
+           << node_id << " (SDK Port " << sdk_port_id << ").";
   }
   if (config_params.admin_state() == ADMIN_STATE_DIAG) {
-    RETURN_ERROR(ERR_UNIMPLEMENTED)
-        << "Unsupported 'diags' admin state for port " << port_id << " in node "
-        << node_id << " (SDK Port " << sdk_port_id << ").";
+    return MAKE_ERROR(ERR_UNIMPLEMENTED)
+           << "Unsupported 'diags' admin state for port " << port_id
+           << " in node " << node_id << " (SDK Port " << sdk_port_id << ").";
   }
 
   bool config_changed = false;
@@ -320,9 +320,9 @@ TofinoChassisManager::~TofinoChassisManager() = default;
 
     auto* unit = gtl::FindOrNull(node_id_to_unit, node_id);
     if (unit == nullptr) {
-      RETURN_ERROR(ERR_INVALID_PARAM)
-          << "Invalid ChassisConfig, unknown node id " << node_id
-          << " for port " << port_id << ".";
+      return MAKE_ERROR(ERR_INVALID_PARAM)
+             << "Invalid ChassisConfig, unknown node id " << node_id
+             << " for port " << port_id << ".";
     }
     node_id_to_port_id_to_port_state[node_id][port_id] = PORT_STATE_UNKNOWN;
     node_id_to_port_id_to_time_last_changed[node_id][port_id] =
@@ -386,9 +386,9 @@ TofinoChassisManager::~TofinoChassisManager() = default;
       // sanity-check: if admin_state is not ADMIN_STATE_UNKNOWN, then the port
       // was added and the speed_bps was set.
       if (!config_old->speed_bps) {
-        RETURN_ERROR(ERR_INTERNAL)
-            << "Invalid internal state in TofinoChassisManager, "
-            << "speed_bps field should contain a value";
+        return MAKE_ERROR(ERR_INTERNAL)
+               << "Invalid internal state in TofinoChassisManager, "
+               << "speed_bps field should contain a value";
       }
 
       // if anything fails, config.admin_state will be set to
@@ -452,9 +452,9 @@ TofinoChassisManager::~TofinoChassisManager() = default;
             break;
           }
           default:
-            RETURN_ERROR(ERR_INVALID_PARAM)
-                << "Unsupported port type in DropTarget "
-                << drop_target.ShortDebugString();
+            return MAKE_ERROR(ERR_INVALID_PARAM)
+                   << "Unsupported port type in DropTarget "
+                   << drop_target.ShortDebugString();
         }
         RETURN_IF_ERROR(tofino_port_manager_->SetDeflectOnDropDestination(
             unit, sdk_port_id, drop_target.queue()));
@@ -522,9 +522,9 @@ TofinoChassisManager::~TofinoChassisManager() = default;
           shaping_config.byte_shaping().max_rate_bps()));
       break;
     default:
-      RETURN_ERROR(ERR_INVALID_PARAM)
-          << "Invalid port shaping config " << shaping_config.ShortDebugString()
-          << ".";
+      return MAKE_ERROR(ERR_INVALID_PARAM)
+             << "Invalid port shaping config "
+             << shaping_config.ShortDebugString() << ".";
   }
   RETURN_IF_ERROR(tofino_port_manager_->EnablePortShaping(unit, sdk_port_id,
                                                           TRI_STATE_TRUE));
@@ -650,17 +650,17 @@ TofinoChassisManager::~TofinoChassisManager() = default;
   if (initialized_) {
     if (node_id_to_port_id_to_singleton_port_key !=
         node_id_to_port_id_to_singleton_port_key_) {
-      RETURN_ERROR(ERR_REBOOT_REQUIRED)
-          << "The switch is already initialized, but we detected the newly "
-          << "pushed config requires a change in the port layout. The stack "
-          << "needs to be rebooted to finish config push.";
+      return MAKE_ERROR(ERR_REBOOT_REQUIRED)
+             << "The switch is already initialized, but we detected the newly "
+             << "pushed config requires a change in the port layout. The stack "
+             << "needs to be rebooted to finish config push.";
     }
 
     if (node_id_to_unit != node_id_to_unit_) {
-      RETURN_ERROR(ERR_REBOOT_REQUIRED)
-          << "The switch is already initialized, but we detected the newly "
-          << "pushed config requires a change in node_id_to_unit. The stack "
-          << "needs to be rebooted to finish config push.";
+      return MAKE_ERROR(ERR_REBOOT_REQUIRED)
+             << "The switch is already initialized, but we detected the newly "
+             << "pushed config requires a change in node_id_to_unit. The stack "
+             << "needs to be rebooted to finish config push.";
     }
   }
 
@@ -839,12 +839,12 @@ TofinoChassisManager::GetPortConfig(uint64 node_id, uint32 port_id) const {
       break;
     }
     default:
-      RETURN_ERROR(ERR_UNIMPLEMENTED)
-          << "DataRequest field "
-          << request.descriptor()
-                 ->FindFieldByNumber(request.request_case())
-                 ->name()
-          << " is not supported yet!";
+      return MAKE_ERROR(ERR_UNIMPLEMENTED)
+             << "DataRequest field "
+             << request.descriptor()
+                    ->FindFieldByNumber(request.request_case())
+                    ->name()
+             << " is not supported yet!";
   }
   return resp;
 }
@@ -939,14 +939,14 @@ TofinoChassisManager::GetNodeIdToUnitMap() const {
     }
 
     if (!config.speed_bps) {
-      RETURN_ERROR(ERR_INTERNAL)
-          << "Invalid internal state in TofinoChassisManager, "
-          << "speed_bps field should contain a value";
+      return MAKE_ERROR(ERR_INTERNAL)
+             << "Invalid internal state in TofinoChassisManager, "
+             << "speed_bps field should contain a value";
     }
     if (!config.fec_mode) {
-      RETURN_ERROR(ERR_INTERNAL)
-          << "Invalid internal state in TofinoChassisManager, "
-          << "fec_mode field should contain a value";
+      return MAKE_ERROR(ERR_INTERNAL)
+             << "Invalid internal state in TofinoChassisManager, "
+             << "fec_mode field should contain a value";
     }
 
     ASSIGN_OR_RETURN(auto sdk_port_id, GetSdkPortId(node_id, port_id));
@@ -1012,9 +1012,9 @@ TofinoChassisManager::GetNodeIdToUnitMap() const {
         break;
       }
       default:
-        RETURN_ERROR(ERR_INVALID_PARAM)
-            << "Unsupported port type in DropTarget "
-            << drop_target.ShortDebugString();
+        return MAKE_ERROR(ERR_INVALID_PARAM)
+               << "Unsupported port type in DropTarget "
+               << drop_target.ShortDebugString();
     }
 
     RETURN_IF_ERROR(tofino_port_manager_->SetDeflectOnDropDestination(

--- a/stratum/hal/lib/tdi/tofino/tofino_port_manager.cc
+++ b/stratum/hal/lib/tdi/tofino/tofino_port_manager.cc
@@ -66,7 +66,7 @@ namespace {
     case kHundredGigBps:
       return BF_SPEED_100G;
     default:
-      RETURN_ERROR(ERR_INVALID_PARAM) << "Unsupported port speed.";
+      return MAKE_ERROR(ERR_INVALID_PARAM) << "Unsupported port speed.";
   }
 }
 
@@ -79,7 +79,7 @@ namespace {
     case TRI_STATE_FALSE:
       return 2;
     default:
-      RETURN_ERROR(ERR_INVALID_PARAM) << "Invalid autoneg state.";
+      return MAKE_ERROR(ERR_INVALID_PARAM) << "Invalid autoneg state.";
   }
 }
 
@@ -91,7 +91,8 @@ namespace {
     // we have to "guess" the FEC type to use based on the port speed.
     switch (speed_bps) {
       case kOneGigBps:
-        RETURN_ERROR(ERR_INVALID_PARAM) << "Invalid FEC mode for 1Gbps mode.";
+        return MAKE_ERROR(ERR_INVALID_PARAM)
+               << "Invalid FEC mode for 1Gbps mode.";
       case kTenGigBps:
       case kFortyGigBps:
         return BF_FEC_TYP_FIRECODE;
@@ -102,10 +103,10 @@ namespace {
       case kFourHundredGigBps:
         return BF_FEC_TYP_REED_SOLOMON;
       default:
-        RETURN_ERROR(ERR_INVALID_PARAM) << "Unsupported port speed.";
+        return MAKE_ERROR(ERR_INVALID_PARAM) << "Unsupported port speed.";
     }
   }
-  RETURN_ERROR(ERR_INVALID_PARAM) << "Invalid FEC mode.";
+  return MAKE_ERROR(ERR_INVALID_PARAM) << "Invalid FEC mode.";
 }
 
 ::util::StatusOr<bf_loopback_mode_e> LoopbackModeToBf(
@@ -116,9 +117,9 @@ namespace {
     case LOOPBACK_STATE_MAC:
       return BF_LPBK_MAC_NEAR;
     default:
-      RETURN_ERROR(ERR_INVALID_PARAM)
-          << "Unsupported loopback mode: " << LoopbackState_Name(loopback_mode)
-          << ".";
+      return MAKE_ERROR(ERR_INVALID_PARAM)
+             << "Unsupported loopback mode: "
+             << LoopbackState_Name(loopback_mode) << ".";
   }
 }
 
@@ -295,7 +296,7 @@ TofinoPortManager* TofinoPortManager::GetSingleton() {
 
 ::util::Status TofinoPortManager::SetPortMtu(int device, int port, int32 mtu) {
   if (mtu < 0) {
-    RETURN_ERROR(ERR_INVALID_PARAM) << "Invalid MTU value.";
+    return MAKE_ERROR(ERR_INVALID_PARAM) << "Invalid MTU value.";
   }
   if (mtu == 0) mtu = kBfDefaultMtu;
   RETURN_IF_TDI_ERROR(bf_pal_port_mtu_set(

--- a/stratum/hal/lib/tdi/tofino/tofino_sde_target.cc
+++ b/stratum/hal/lib/tdi/tofino/tofino_sde_target.cc
@@ -338,7 +338,8 @@ bf_status_t TdiSdeWrapper::BfPktRxNotifyCallback(bf_dev_id_t device,
     int dev_id, std::shared_ptr<TdiSdeInterface::SessionInterface> session,
     const std::string& table_name, notification_table_callback_t callback,
     void* cookie) const LOCKS_EXCLUDED(data_lock_) {
-  RETURN_ERROR(ERR_OPER_NOT_SUPPORTED) << "Notification Table not supported";
+  return MAKE_ERROR(ERR_OPER_NOT_SUPPORTED)
+         << "Notification Table not supported";
 }
 
 }  // namespace tdi

--- a/stratum/hal/stub/embedded/main.cc
+++ b/stratum/hal/stub/embedded/main.cc
@@ -724,7 +724,7 @@ ABSL_CONST_INIT absl::Mutex HalServiceClient::lock_(absl::kConstInit);
   } else if (FLAGS_start_gnmi_subscription_session) {
     client.StartGnmiSubscriptionSession();
   } else {
-    RETURN_ERROR(ERR_INVALID_PARAM) << "Invalid command.";
+    return MAKE_ERROR(ERR_INVALID_PARAM) << "Invalid command.";
   }
 
   return ::util::OkStatus();

--- a/stratum/tools/stratum_replay/stratum_replay.cc
+++ b/stratum/tools/stratum_replay/stratum_replay.cc
@@ -59,7 +59,7 @@ using ClientStreamChannelReaderWriter =
 ::util::Status Main(int argc, char** argv) {
   if (argc < 2) {
     LOG(INFO) << kUsage;
-    RETURN_ERROR(ERR_INVALID_PARAM).without_logging() << "";
+    return MAKE_ERROR(ERR_INVALID_PARAM).without_logging() << "";
   }
 
   // Initialize the gRPC channel and P4Runtime service stub
@@ -112,7 +112,7 @@ using ClientStreamChannelReaderWriter =
   std::unique_ptr<ClientStreamChannelReaderWriter> stream =
       stub->StreamChannel(&context);
   if (!stream->Write(stream_req)) {
-    RETURN_ERROR(ERR_INTERNAL)
+    return MAKE_ERROR(ERR_INTERNAL)
         << "Failed to send request '" << stream_req.ShortDebugString()
         << "' to switch.";
   }


### PR DESCRIPTION
- Replace all occurrences of `RETURN_ERROR()` with `return MAKE_ERROR()` and remove the definition of `RETURN_ERROR()`, to align Stratum source with upstream version.

- Remove vestigial definition of `RETURN_OK()`, for the same reason.

- Use clang-format to canonicalize modified files. Also format files in stratum/hal/lib/p4.