### PR TITLE
[sync] Rename `unit` to `device` in TDI code

### DIFF
--- a/stratum/hal/lib/tdi/dpdk/dpdk_chassis_manager.h
+++ b/stratum/hal/lib/tdi/dpdk/dpdk_chassis_manager.h
@@ -63,10 +63,10 @@ class DpdkChassisManager {
   virtual ::util::Status ReplayPortsConfig(uint64 node_id)
       EXCLUSIVE_LOCKS_REQUIRED(chassis_lock);
 
-  virtual ::util::StatusOr<std::map<uint64, int>> GetNodeIdToUnitMap() const
+  virtual ::util::StatusOr<std::map<uint64, int>> GetNodeIdToDeviceMap() const
       SHARED_LOCKS_REQUIRED(chassis_lock);
 
-  virtual ::util::StatusOr<int> GetUnitFromNodeId(uint64 node_id) const
+  virtual ::util::StatusOr<int> GetDeviceFromNodeId(uint64 node_id) const
       SHARED_LOCKS_REQUIRED(chassis_lock);
 
   // Factory function for creating the instance of the class.
@@ -138,17 +138,17 @@ class DpdkChassisManager {
   void CleanupInternalState() EXCLUSIVE_LOCKS_REQUIRED(chassis_lock);
 
   // helper to add / configure / enable a port with DpdkPortManager
-  ::util::Status AddPortHelper(uint64 node_id, int unit, uint32 port_id,
+  ::util::Status AddPortHelper(uint64 node_id, int device, uint32 port_id,
                                const SingletonPort& singleton_port,
                                DpdkPortConfig* config);
 
   // helper to hotplug add / delete a port with DpdkPortManager
-  ::util::Status HotplugPortHelper(uint64 node_id, int unit, uint32 port_id,
+  ::util::Status HotplugPortHelper(uint64 node_id, int device, uint32 port_id,
                                    const SingletonPort& singleton_port,
                                    DpdkPortConfig* config);
 
   // helper to update port configuration with DpdkPortManager
-  ::util::Status UpdatePortHelper(uint64 node_id, int unit, uint32 port_id,
+  ::util::Status UpdatePortHelper(uint64 node_id, int device, uint32 port_id,
                                   const SingletonPort& singleton_port,
                                   const DpdkPortConfig& config_old,
                                   DpdkPortConfig* config);
@@ -170,11 +170,11 @@ class DpdkChassisManager {
   std::shared_ptr<WriterInterface<GnmiEventPtr>> gnmi_event_writer_
       GUARDED_BY(gnmi_event_lock_);
 
-  // Map from unit number to the node ID as specified by the config.
-  std::map<int, uint64> unit_to_node_id_ GUARDED_BY(chassis_lock);
+  // Map from device number to the node ID as specified by the config.
+  std::map<int, uint64> device_to_node_id_ GUARDED_BY(chassis_lock);
 
-  // Map from node ID to unit number.
-  std::map<uint64, int> node_id_to_unit_ GUARDED_BY(chassis_lock);
+  // Map from node ID to device number.
+  std::map<uint64, int> node_id_to_device_ GUARDED_BY(chassis_lock);
 
   // Map from node ID to another map from port ID to PortState representing
   // the state of the singleton port uniquely identified by (node ID, port ID).

--- a/stratum/hal/lib/tdi/dpdk/dpdk_chassis_manager_mock.h
+++ b/stratum/hal/lib/tdi/dpdk/dpdk_chassis_manager_mock.h
@@ -38,9 +38,10 @@ class DpdkChassisManagerMock : public DpdkChassisManager {
   //  MOCK_METHOD3(GetFrontPanelPortInfo,
   //               ::util::Status(uint64 node_id, uint32 port_id,
   //                              FrontPanelPortInfo* fp_port_info));
-  MOCK_CONST_METHOD0(GetNodeIdToUnitMap,
+  MOCK_CONST_METHOD0(GetNodeIdToDeviceMap,
                      ::util::StatusOr<std::map<uint64, int>>());
-  MOCK_CONST_METHOD1(GetUnitFromNodeId, ::util::StatusOr<int>(uint64 node_id));
+  MOCK_CONST_METHOD1(GetDeviceFromNodeId,
+                     ::util::StatusOr<int>(uint64 node_id));
 };
 
 }  // namespace tdi

--- a/stratum/hal/lib/tdi/dpdk/dpdk_hal_test.cc
+++ b/stratum/hal/lib/tdi/dpdk/dpdk_hal_test.cc
@@ -1,6 +1,6 @@
 // Copyright 2018 Google LLC
 // Copyright 2018-present Open Networking Foundation
-// Copyright 2022 Intel Corporation
+// Copyright 2022-2023 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 // adapted from common/hal_test.cc
@@ -78,7 +78,7 @@ class DpdkHalTest : public ::testing::Test {
 
   void FillTestChassisConfigAndSave(ChassisConfig* chassis_config) {
     const std::string& chassis_config_text = absl::Substitute(
-        kChassisConfigTemplate, kNodeId1, kUnit1 + 1, kNodeId2, kUnit2 + 1);
+        kChassisConfigTemplate, kNodeId1, kDevice1 + 1, kNodeId2, kDevice2 + 1);
     ASSERT_OK(ParseProtoFromString(chassis_config_text, chassis_config));
     ASSERT_OK(
         WriteStringToFile(chassis_config_text, FLAGS_chassis_config_file));
@@ -140,8 +140,8 @@ class DpdkHalTest : public ::testing::Test {
   static constexpr char kErrorMsg[] = "Some error";
   static constexpr uint64 kNodeId1 = 123123123;
   static constexpr uint64 kNodeId2 = 456456456;
-  static constexpr int kUnit1 = 0;
-  static constexpr int kUnit2 = 1;
+  static constexpr int kDevice1 = 0;
+  static constexpr int kDevice2 = 1;
   static constexpr OperationMode kMode = OPERATION_MODE_STANDALONE;
 
   static ::testing::StrictMock<SwitchMock>* switch_mock_;
@@ -155,8 +155,8 @@ constexpr char DpdkHalTest::kForwardingPipelineConfigsTemplate[];
 constexpr char DpdkHalTest::kErrorMsg[];
 constexpr uint64 DpdkHalTest::kNodeId1;
 constexpr uint64 DpdkHalTest::kNodeId2;
-constexpr int DpdkHalTest::kUnit1;
-constexpr int DpdkHalTest::kUnit2;
+constexpr int DpdkHalTest::kDevice1;
+constexpr int DpdkHalTest::kDevice2;
 constexpr OperationMode DpdkHalTest::kMode;
 
 ::testing::StrictMock<SwitchMock>* DpdkHalTest::switch_mock_ = nullptr;

--- a/stratum/hal/lib/tdi/dpdk/dpdk_switch.cc
+++ b/stratum/hal/lib/tdi/dpdk/dpdk_switch.cc
@@ -1,5 +1,5 @@
 // Copyright 2020-present Open Networking Foundation
-// Copyright 2022 Intel Corporation
+// Copyright 2022-2023 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 #include "stratum/hal/lib/tdi/dpdk/dpdk_switch.h"
@@ -44,7 +44,7 @@ DpdkSwitch::~DpdkSwitch() {}
   absl::WriterMutexLock l(&chassis_lock);
   RETURN_IF_ERROR(chassis_manager_->PushChassisConfig(config));
   ASSIGN_OR_RETURN(const auto& node_id_to_device_id,
-                   chassis_manager_->GetNodeIdToUnitMap());
+                   chassis_manager_->GetNodeIdToDeviceMap());
   node_id_to_tdi_node_.clear();
   for (const auto& entry : node_id_to_device_id) {
     uint64 node_id = entry.first;
@@ -185,7 +185,7 @@ DpdkSwitch::~DpdkSwitch() {}
       // Node information request
       case DataRequest::Request::kNodeInfo: {
         auto device_id =
-            chassis_manager_->GetUnitFromNodeId(req.node_info().node_id());
+            chassis_manager_->GetDeviceFromNodeId(req.node_info().node_id());
         if (!device_id.ok()) {
           status.Update(device_id.status());
         } else {
@@ -270,7 +270,7 @@ std::unique_ptr<DpdkSwitch> DpdkSwitch::CreateInstance(
   TdiNode* tdi_node = gtl::FindPtrOrNull(device_id_to_tdi_node_, device_id);
   if (tdi_node == nullptr) {
     return MAKE_ERROR(ERR_INVALID_PARAM)
-           << "Unit " << device_id << " is unknown.";
+           << "Device " << device_id << " is unknown.";
   }
   return tdi_node;
 }

--- a/stratum/hal/lib/tdi/dpdk/dpdk_switch_test.cc
+++ b/stratum/hal/lib/tdi/dpdk/dpdk_switch_test.cc
@@ -1,6 +1,6 @@
 // Copyright 2018 Google LLC
 // Copyright 2018-present Open Networking Foundation
-// Copyright 2022 Intel Corporation
+// Copyright 2022-2023 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 // adapted from bcm_switch_test
@@ -61,12 +61,12 @@ MATCHER_P(DerivedFromStatus, status, "") {
 }
 
 constexpr uint64 kNodeId = 13579;
-constexpr int kUnit = 2;
+constexpr int kDevice = 2;
 constexpr char kErrorMsg[] = "Test error message";
 constexpr uint32 kPortId = 2468;
 
-const std::map<uint64, int>& NodeIdToUnitMap() {
-  static auto* map = new std::map<uint64, int>({{kNodeId, kUnit}});
+const std::map<uint64, int>& NodeIdToDeviceMap() {
+  static auto* map = new std::map<uint64, int>({{kNodeId, kDevice}});
   return *map;
 }
 
@@ -78,19 +78,19 @@ class DpdkSwitchTest : public ::testing::Test {
     chassis_manager_mock_ =
         absl::make_unique<NiceMock<DpdkChassisManagerMock>>();
     node_mock_ = absl::make_unique<NiceMock<TdiNodeMock>>();
-    unit_to_tdi_node_mock_[kUnit] = node_mock_.get();
+    device_to_tdi_node_mock_[kDevice] = node_mock_.get();
     switch_ = DpdkSwitch::CreateInstance(
-        chassis_manager_mock_.get(), sde_mock_.get(), unit_to_tdi_node_mock_);
+        chassis_manager_mock_.get(), sde_mock_.get(), device_to_tdi_node_mock_);
 #if 0
     // no 'shutdown'
     shutdown = false;  // global variable initialization
 #endif
 
-    ON_CALL(*chassis_manager_mock_, GetNodeIdToUnitMap())
-        .WillByDefault(Return(NodeIdToUnitMap()));
+    ON_CALL(*chassis_manager_mock_, GetNodeIdToDeviceMap())
+        .WillByDefault(Return(NodeIdToDeviceMap()));
   }
 
-  void TearDown() override { unit_to_tdi_node_mock_.clear(); }
+  void TearDown() override { device_to_tdi_node_mock_.clear(); }
 
   // This operation should always succeed.
   // We use it to set up a number of test cases.
@@ -109,7 +109,7 @@ class DpdkSwitchTest : public ::testing::Test {
   std::unique_ptr<TdiSdeMock> sde_mock_;
   std::unique_ptr<DpdkChassisManagerMock> chassis_manager_mock_;
   std::unique_ptr<TdiNodeMock> node_mock_;
-  std::map<int, TdiNode*> unit_to_tdi_node_mock_;
+  std::map<int, TdiNode*> device_to_tdi_node_mock_;
   std::unique_ptr<DpdkSwitch> switch_;
 };
 

--- a/stratum/hal/lib/tdi/es2k/es2k_chassis_manager.cc
+++ b/stratum/hal/lib/tdi/es2k/es2k_chassis_manager.cc
@@ -44,8 +44,8 @@ Es2kChassisManager::Es2kChassisManager(OperationMode mode,
       initialized_(false),
       port_status_event_channel_(nullptr),
       gnmi_event_writer_(nullptr),
-      unit_to_node_id_(),
-      node_id_to_unit_(),
+      device_to_node_id_(),
+      node_id_to_device_(),
       node_id_to_port_id_to_port_state_(),
       node_id_to_port_id_to_time_last_changed_(),
       node_id_to_port_id_to_port_config_(),
@@ -60,8 +60,8 @@ Es2kChassisManager::Es2kChassisManager()
       initialized_(false),
       port_status_event_channel_(nullptr),
       gnmi_event_writer_(nullptr),
-      unit_to_node_id_(),
-      node_id_to_unit_(),
+      device_to_node_id_(),
+      node_id_to_device_(),
       node_id_to_port_id_to_port_state_(),
       node_id_to_port_id_to_time_last_changed_(),
       node_id_to_port_id_to_port_config_(),
@@ -74,7 +74,7 @@ Es2kChassisManager::Es2kChassisManager()
 Es2kChassisManager::~Es2kChassisManager() = default;
 
 ::util::Status Es2kChassisManager::AddPortHelper(
-    uint64 node_id, int unit, uint32 sdk_port_id,
+    uint64 node_id, int device, uint32 sdk_port_id,
     const SingletonPort& singleton_port /* desired config */,
     /* out */ PortConfig* config /* new config */) {
   config->admin_state = ADMIN_STATE_UNKNOWN;
@@ -95,20 +95,21 @@ Es2kChassisManager::~Es2kChassisManager() = default;
 
   LOG(INFO) << "Adding port " << port_id << " in node " << node_id
             << " (SDK Port " << sdk_port_id << ").";
-  RETURN_IF_ERROR(es2k_port_manager_->AddPort(
-      unit, sdk_port_id, singleton_port.speed_bps(), config_params.fec_mode()));
+  RETURN_IF_ERROR(es2k_port_manager_->AddPort(device, sdk_port_id,
+                                              singleton_port.speed_bps(),
+                                              config_params.fec_mode()));
   config->speed_bps = singleton_port.speed_bps();
   config->admin_state = ADMIN_STATE_DISABLED;
   config->fec_mode = config_params.fec_mode();
 
   if (config_params.mtu() != 0) {
-    RETURN_IF_ERROR(
-        es2k_port_manager_->SetPortMtu(unit, sdk_port_id, config_params.mtu()));
+    RETURN_IF_ERROR(es2k_port_manager_->SetPortMtu(device, sdk_port_id,
+                                                   config_params.mtu()));
   }
   config->mtu = config_params.mtu();
   if (config_params.autoneg() != TRI_STATE_UNKNOWN) {
     RETURN_IF_ERROR(es2k_port_manager_->SetPortAutonegPolicy(
-        unit, sdk_port_id, config_params.autoneg()));
+        device, sdk_port_id, config_params.autoneg()));
   }
   config->autoneg = config_params.autoneg();
 
@@ -117,25 +118,25 @@ Es2kChassisManager::~Es2kChassisManager() = default;
               << config_params.loopback_mode() << " (SDK Port " << sdk_port_id
               << ").";
     RETURN_IF_ERROR(es2k_port_manager_->SetPortLoopbackMode(
-        unit, sdk_port_id, config_params.loopback_mode()));
+        device, sdk_port_id, config_params.loopback_mode()));
   }
   config->loopback_mode = config_params.loopback_mode();
 
   if (config_params.admin_state() == ADMIN_STATE_ENABLED) {
     LOG(INFO) << "Enabling port " << port_id << " in node " << node_id
               << " (SDK Port " << sdk_port_id << ").";
-    RETURN_IF_ERROR(es2k_port_manager_->EnablePort(unit, sdk_port_id));
+    RETURN_IF_ERROR(es2k_port_manager_->EnablePort(device, sdk_port_id));
     config->admin_state = ADMIN_STATE_ENABLED;
   }
 
-  RETURN_IF_ERROR(es2k_port_manager_->EnablePortShaping(unit, sdk_port_id,
+  RETURN_IF_ERROR(es2k_port_manager_->EnablePortShaping(device, sdk_port_id,
                                                         TRI_STATE_FALSE));
 
   return ::util::OkStatus();
 }
 
 ::util::Status Es2kChassisManager::UpdatePortHelper(
-    uint64 node_id, int unit, uint32 sdk_port_id,
+    uint64 node_id, int device, uint32 sdk_port_id,
     const SingletonPort& singleton_port /* desired config */,
     const PortConfig& config_old /* current config */,
     /* out */ PortConfig* config /* new config */) {
@@ -143,7 +144,7 @@ Es2kChassisManager::~Es2kChassisManager() = default;
   // SingletonPort ID is the SDN/Stratum port ID
   uint32 port_id = singleton_port.id();
 
-  if (!es2k_port_manager_->IsValidPort(unit, sdk_port_id)) {
+  if (!es2k_port_manager_->IsValidPort(device, sdk_port_id)) {
     config->admin_state = ADMIN_STATE_UNKNOWN;
     config->speed_bps.reset();
     config->fec_mode.reset();
@@ -154,11 +155,11 @@ Es2kChassisManager::~Es2kChassisManager() = default;
 
   const auto& config_params = singleton_port.config_params();
   if (singleton_port.speed_bps() != config_old.speed_bps) {
-    RETURN_IF_ERROR(es2k_port_manager_->DisablePort(unit, sdk_port_id));
-    RETURN_IF_ERROR(es2k_port_manager_->DeletePort(unit, sdk_port_id));
+    RETURN_IF_ERROR(es2k_port_manager_->DisablePort(device, sdk_port_id));
+    RETURN_IF_ERROR(es2k_port_manager_->DeletePort(device, sdk_port_id));
 
     ::util::Status status =
-        AddPortHelper(node_id, unit, sdk_port_id, singleton_port, config);
+        AddPortHelper(node_id, device, sdk_port_id, singleton_port, config);
     if (status.ok()) {
       return ::util::OkStatus();
     } else {
@@ -175,7 +176,7 @@ Es2kChassisManager::~Es2kChassisManager() = default;
         port_old.mutable_config_params()->set_mtu(*config_old.mtu);
       if (config_old.fec_mode)
         port_old.mutable_config_params()->set_fec_mode(*config_old.fec_mode);
-      AddPortHelper(node_id, unit, sdk_port_id, port_old, config);
+      AddPortHelper(node_id, device, sdk_port_id, port_old, config);
       return MAKE_ERROR(ERR_INVALID_PARAM)
              << "Could not add port " << port_id << " with new speed "
              << singleton_port.speed_bps() << " to BF SDE"
@@ -208,8 +209,8 @@ Es2kChassisManager::~Es2kChassisManager() = default;
             << " changed"
             << " (SDK Port " << sdk_port_id << ").";
     config->mtu.reset();
-    RETURN_IF_ERROR(
-        es2k_port_manager_->SetPortMtu(unit, sdk_port_id, config_params.mtu()));
+    RETURN_IF_ERROR(es2k_port_manager_->SetPortMtu(device, sdk_port_id,
+                                                   config_params.mtu()));
     config->mtu = config_params.mtu();
     config_changed = true;
   }
@@ -219,14 +220,14 @@ Es2kChassisManager::~Es2kChassisManager() = default;
             << " (SDK Port " << sdk_port_id << ").";
     config->autoneg.reset();
     RETURN_IF_ERROR(es2k_port_manager_->SetPortAutonegPolicy(
-        unit, sdk_port_id, config_params.autoneg()));
+        device, sdk_port_id, config_params.autoneg()));
     config->autoneg = config_params.autoneg();
     config_changed = true;
   }
   if (config_params.loopback_mode() != config_old.loopback_mode) {
     config->loopback_mode.reset();
     RETURN_IF_ERROR(es2k_port_manager_->SetPortLoopbackMode(
-        unit, sdk_port_id, config_params.loopback_mode()));
+        device, sdk_port_id, config_params.loopback_mode()));
     config->loopback_mode = config_params.loopback_mode();
     config_changed = true;
   }
@@ -251,13 +252,13 @@ Es2kChassisManager::~Es2kChassisManager() = default;
   if (need_disable) {
     LOG(INFO) << "Disabling port " << port_id << " in node " << node_id
               << " (SDK Port " << sdk_port_id << ").";
-    RETURN_IF_ERROR(es2k_port_manager_->DisablePort(unit, sdk_port_id));
+    RETURN_IF_ERROR(es2k_port_manager_->DisablePort(device, sdk_port_id));
     config->admin_state = ADMIN_STATE_DISABLED;
   }
   if (need_enable) {
     LOG(INFO) << "Enabling port " << port_id << " in node " << node_id
               << " (SDK Port " << sdk_port_id << ").";
-    RETURN_IF_ERROR(es2k_port_manager_->EnablePort(unit, sdk_port_id));
+    RETURN_IF_ERROR(es2k_port_manager_->EnablePort(device, sdk_port_id));
     config->admin_state = ADMIN_STATE_ENABLED;
   }
 
@@ -267,8 +268,8 @@ Es2kChassisManager::~Es2kChassisManager() = default;
 ::util::Status Es2kChassisManager::PushChassisConfig(
     const ChassisConfig& config) {
   // new maps
-  std::map<int, uint64> unit_to_node_id;
-  std::map<uint64, int> node_id_to_unit;
+  std::map<int, uint64> device_to_node_id;
+  std::map<uint64, int> node_id_to_device;
   std::map<uint64, std::map<uint32, PortState>>
       node_id_to_port_id_to_port_state;
   std::map<uint64, std::map<uint32, absl::Time>>
@@ -282,11 +283,11 @@ Es2kChassisManager::~Es2kChassisManager() = default;
   std::map<PortKey, HwState> xcvr_port_key_to_xcvr_state;
 
   {
-    int unit = 0;
+    int device = 0;
     for (const auto& node : config.nodes()) {
-      unit_to_node_id[unit] = node.id();
-      node_id_to_unit[node.id()] = unit;
-      unit++;
+      device_to_node_id[device] = node.id();
+      node_id_to_device[node.id()] = device;
+      device++;
     }
   }
 
@@ -294,8 +295,8 @@ Es2kChassisManager::~Es2kChassisManager() = default;
     uint32 port_id = singleton_port.id();
     uint64 node_id = singleton_port.node();
 
-    auto* unit = gtl::FindOrNull(node_id_to_unit, node_id);
-    if (unit == nullptr) {
+    auto* device = gtl::FindOrNull(node_id_to_device, node_id);
+    if (device == nullptr) {
       return MAKE_ERROR(ERR_INVALID_PARAM)
              << "Invalid ChassisConfig, unknown node id " << node_id
              << " for port " << port_id << ".";
@@ -311,7 +312,7 @@ Es2kChassisManager::~Es2kChassisManager() = default;
 
     // Translate the logical SDN port to SDK port (BF device port ID)
     ASSIGN_OR_RETURN(uint32 sdk_port, es2k_port_manager_->GetPortIdFromPortKey(
-                                          *unit, singleton_port_key));
+                                          *device, singleton_port_key));
     node_id_to_port_id_to_sdk_port_id[node_id][port_id] = sdk_port;
     node_id_to_sdk_port_id_to_port_id[node_id][sdk_port] = port_id;
 
@@ -323,7 +324,7 @@ Es2kChassisManager::~Es2kChassisManager() = default;
     uint32 port_id = singleton_port.id();
     uint64 node_id = singleton_port.node();
     // we checked that node_id was valid in the previous loop
-    auto unit = node_id_to_unit[node_id];
+    auto device = node_id_to_device[node_id];
 
     // TODO(antonin): we currently ignore slot
     // Stratum requires slot and port to be set. We use port and channel to
@@ -342,17 +343,17 @@ Es2kChassisManager::~Es2kChassisManager() = default;
       // if anything fails, config.admin_state will be set to
       // ADMIN_STATE_UNKNOWN (invalid)
       RETURN_IF_ERROR(
-          AddPortHelper(node_id, unit, sdk_port_id, singleton_port, &config));
+          AddPortHelper(node_id, device, sdk_port_id, singleton_port, &config));
     } else {  // port already exists, config may have changed
       if (config_old->admin_state == ADMIN_STATE_UNKNOWN) {
         // something is wrong with the port, we make sure the port is deleted
         // first (and ignore the error status if there is one), then add the
         // port again.
-        if (es2k_port_manager_->IsValidPort(unit, sdk_port_id)) {
-          es2k_port_manager_->DeletePort(unit, sdk_port_id);
+        if (es2k_port_manager_->IsValidPort(device, sdk_port_id)) {
+          es2k_port_manager_->DeletePort(device, sdk_port_id);
         }
-        RETURN_IF_ERROR(
-            AddPortHelper(node_id, unit, sdk_port_id, singleton_port, &config));
+        RETURN_IF_ERROR(AddPortHelper(node_id, device, sdk_port_id,
+                                      singleton_port, &config));
         continue;
       }
 
@@ -368,7 +369,7 @@ Es2kChassisManager::~Es2kChassisManager() = default;
 
       // if anything fails, config.admin_state will be set to
       // ADMIN_STATE_UNKNOWN (invalid)
-      RETURN_IF_ERROR(UpdatePortHelper(node_id, unit, sdk_port_id,
+      RETURN_IF_ERROR(UpdatePortHelper(node_id, device, sdk_port_id,
                                        singleton_port, *config_old, &config));
     }
   }
@@ -382,18 +383,18 @@ Es2kChassisManager::~Es2kChassisManager() = default;
           node_id_to_port_id_to_port_config[node_id].count(port_id) > 0) {
         continue;
       }
-      auto unit = node_id_to_unit_[node_id];
+      auto device = node_id_to_device_[node_id];
       uint32 sdk_port_id = node_id_to_port_id_to_sdk_port_id_[node_id][port_id];
       // remove ports which are no longer present in the ChassisConfig
       // TODO(bocon): Collect these errors and keep trying to remove old ports
       LOG(INFO) << "Deleting port " << port_id << " in node " << node_id
                 << " (SDK port " << sdk_port_id << ").";
-      RETURN_IF_ERROR(es2k_port_manager_->DeletePort(unit, sdk_port_id));
+      RETURN_IF_ERROR(es2k_port_manager_->DeletePort(device, sdk_port_id));
     }
   }
 
-  unit_to_node_id_ = unit_to_node_id;
-  node_id_to_unit_ = node_id_to_unit;
+  device_to_node_id_ = device_to_node_id;
+  node_id_to_device_ = node_id_to_device;
   node_id_to_port_id_to_port_state_ = node_id_to_port_id_to_port_state;
   node_id_to_port_id_to_time_last_changed_ =
       node_id_to_port_id_to_time_last_changed;
@@ -432,24 +433,24 @@ Es2kChassisManager::~Es2kChassisManager() = default;
   }
 
   // Validate Node messages. Make sure there is no two nodes with the same id.
-  std::map<uint64, int> node_id_to_unit;
-  std::map<int, uint64> unit_to_node_id;
+  std::map<uint64, int> node_id_to_device;
+  std::map<int, uint64> device_to_node_id;
   for (const auto& node : config.nodes()) {
     CHECK_RETURN_IF_FALSE(node.slot() > 0)
         << "No positive slot in " << node.ShortDebugString();
     CHECK_RETURN_IF_FALSE(node.id() > 0)
         << "No positive ID in " << node.ShortDebugString();
     CHECK_RETURN_IF_FALSE(
-        gtl::InsertIfNotPresent(&node_id_to_unit, node.id(), -1))
+        gtl::InsertIfNotPresent(&node_id_to_device, node.id(), -1))
         << "The id for Node " << PrintNode(node) << " was already recorded "
         << "for another Node in the config.";
   }
   {
-    int unit = 0;
+    int device = 0;
     for (const auto& node : config.nodes()) {
-      unit_to_node_id[unit] = node.id();
-      node_id_to_unit[node.id()] = unit;
-      ++unit;
+      device_to_node_id[device] = node.id();
+      node_id_to_device[node.id()] = device;
+      ++device;
     }
   }
 
@@ -486,7 +487,7 @@ Es2kChassisManager::~Es2kChassisManager() = default;
     singleton_port_keys.insert(singleton_port_key);
     CHECK_RETURN_IF_FALSE(singleton_port.node() > 0)
         << "No valid node ID in " << singleton_port.ShortDebugString() << ".";
-    CHECK_RETURN_IF_FALSE(node_id_to_unit.count(singleton_port.node()))
+    CHECK_RETURN_IF_FALSE(node_id_to_device.count(singleton_port.node()))
         << "Node ID " << singleton_port.node() << " given for SingletonPort "
         << PrintSingletonPort(singleton_port)
         << " has not been given to any Node in the config.";
@@ -511,11 +512,11 @@ Es2kChassisManager::~Es2kChassisManager() = default;
         singleton_port_key;
 
     // Make sure that the port exists by getting the SDK port ID.
-    const int* unit = gtl::FindOrNull(node_id_to_unit, node_id);
-    CHECK_RETURN_IF_FALSE(unit != nullptr)
+    const int* device = gtl::FindOrNull(node_id_to_device, node_id);
+    CHECK_RETURN_IF_FALSE(device != nullptr)
         << "Node " << node_id << " not found for port " << port_id << ".";
     RETURN_IF_ERROR(
-        es2k_port_manager_->GetPortIdFromPortKey(*unit, singleton_port_key)
+        es2k_port_manager_->GetPortIdFromPortKey(*device, singleton_port_key)
             .status());
   }
 
@@ -530,10 +531,11 @@ Es2kChassisManager::~Es2kChassisManager() = default;
              << "needs to be rebooted to finish config push.";
     }
 
-    if (node_id_to_unit != node_id_to_unit_) {
+    if (node_id_to_device != node_id_to_device_) {
       return MAKE_ERROR(ERR_REBOOT_REQUIRED)
              << "The switch is already initialized, but we detected the newly "
-             << "pushed config requires a change in node_id_to_unit. The stack "
+             << "pushed config requires a change in node_id_to_device. The "
+                "stack "
              << "needs to be rebooted to finish config push.";
     }
   }
@@ -722,7 +724,7 @@ Es2kChassisManager::GetPortConfig(uint64 node_id, uint32 port_id) const {
   if (!initialized_) {
     return MAKE_ERROR(ERR_NOT_INITIALIZED) << "Not initialized!";
   }
-  ASSIGN_OR_RETURN(auto unit, GetUnitFromNodeId(node_id));
+  ASSIGN_OR_RETURN(auto device, GetDeviceFromNodeId(node_id));
 
   auto* port_id_to_port_state =
       gtl::FindOrNull(node_id_to_port_id_to_port_state_, node_id);
@@ -741,7 +743,7 @@ Es2kChassisManager::GetPortConfig(uint64 node_id, uint32 port_id) const {
             << ".";
   ASSIGN_OR_RETURN(auto sdk_port_id, GetSdkPortId(node_id, port_id));
   ASSIGN_OR_RETURN(auto port_state,
-                   es2k_port_manager_->GetPortState(unit, sdk_port_id));
+                   es2k_port_manager_->GetPortState(device, sdk_port_id));
   LOG(INFO) << "State of port " << port_id << " in node " << node_id
             << " (SDK port " << sdk_port_id
             << "): " << PrintPortState(port_state);
@@ -767,17 +769,17 @@ Es2kChassisManager::GetPortConfig(uint64 node_id, uint32 port_id) const {
   if (!initialized_) {
     return MAKE_ERROR(ERR_NOT_INITIALIZED) << "Not initialized!";
   }
-  ASSIGN_OR_RETURN(auto unit, GetUnitFromNodeId(node_id));
+  ASSIGN_OR_RETURN(auto device, GetDeviceFromNodeId(node_id));
   ASSIGN_OR_RETURN(auto sdk_port_id, GetSdkPortId(node_id, port_id));
-  return es2k_port_manager_->GetPortCounters(unit, sdk_port_id, counters);
+  return es2k_port_manager_->GetPortCounters(device, sdk_port_id, counters);
 }
 
-::util::StatusOr<std::map<uint64, int>> Es2kChassisManager::GetNodeIdToUnitMap()
-    const {
+::util::StatusOr<std::map<uint64, int>>
+Es2kChassisManager::GetNodeIdToDeviceMap() const {
   if (!initialized_) {
     return MAKE_ERROR(ERR_NOT_INITIALIZED) << "Not initialized!";
   }
-  return node_id_to_unit_;
+  return node_id_to_device_;
 }
 
 // TODO: Revisit this, port shaping and drop deflect removed. Check with Sandeep
@@ -786,7 +788,7 @@ Es2kChassisManager::GetPortConfig(uint64 node_id, uint32 port_id) const {
   if (!initialized_) {
     return MAKE_ERROR(ERR_NOT_INITIALIZED) << "Not initialized!";
   }
-  ASSIGN_OR_RETURN(auto unit, GetUnitFromNodeId(node_id));
+  ASSIGN_OR_RETURN(auto device, GetDeviceFromNodeId(node_id));
 
   for (auto& p : node_id_to_port_id_to_port_state_[node_id])
     p.second = PORT_STATE_UNKNOWN;
@@ -797,7 +799,7 @@ Es2kChassisManager::GetPortConfig(uint64 node_id, uint32 port_id) const {
 
   LOG(INFO) << "Replaying ports for node " << node_id << ".";
 
-  auto replay_one_port = [node_id, unit, this](
+  auto replay_one_port = [node_id, device, this](
                              uint32 port_id, const PortConfig& config,
                              PortConfig* config_new) -> ::util::Status {
     VLOG(1) << "Replaying port " << port_id << " in node " << node_id << ".";
@@ -821,31 +823,31 @@ Es2kChassisManager::GetPortConfig(uint64 node_id, uint32 port_id) const {
 
     ASSIGN_OR_RETURN(auto sdk_port_id, GetSdkPortId(node_id, port_id));
     RETURN_IF_ERROR(es2k_port_manager_->AddPort(
-        unit, sdk_port_id, *config.speed_bps, *config.fec_mode));
+        device, sdk_port_id, *config.speed_bps, *config.fec_mode));
     config_new->speed_bps = *config.speed_bps;
     config_new->admin_state = ADMIN_STATE_DISABLED;
     config_new->fec_mode = *config.fec_mode;
 
     if (config.mtu) {
       RETURN_IF_ERROR(
-          es2k_port_manager_->SetPortMtu(unit, sdk_port_id, *config.mtu));
+          es2k_port_manager_->SetPortMtu(device, sdk_port_id, *config.mtu));
       config_new->mtu = *config.mtu;
     }
     if (config.autoneg) {
       RETURN_IF_ERROR(es2k_port_manager_->SetPortAutonegPolicy(
-          unit, sdk_port_id, *config.autoneg));
+          device, sdk_port_id, *config.autoneg));
       config_new->autoneg = *config.autoneg;
     }
     if (config.loopback_mode) {
       RETURN_IF_ERROR(es2k_port_manager_->SetPortLoopbackMode(
-          unit, sdk_port_id, *config.loopback_mode));
+          device, sdk_port_id, *config.loopback_mode));
       config_new->loopback_mode = *config.loopback_mode;
     }
 
     if (config.admin_state == ADMIN_STATE_ENABLED) {
       VLOG(1) << "Enabling port " << port_id << " in node " << node_id
               << " (SDK port " << sdk_port_id << ").";
-      RETURN_IF_ERROR(es2k_port_manager_->EnablePort(unit, sdk_port_id));
+      RETURN_IF_ERROR(es2k_port_manager_->EnablePort(device, sdk_port_id));
       config_new->admin_state = ADMIN_STATE_ENABLED;
     }
 
@@ -936,7 +938,7 @@ void Es2kChassisManager::PortStatusEventHandler(int device, int port,
   // }
 
   // Update the state.
-  const uint64* node_id = gtl::FindOrNull(unit_to_node_id_, device);
+  const uint64* node_id = gtl::FindOrNull(device_to_node_id_, device);
   if (node_id == nullptr) {
     LOG(ERROR) << "Inconsistent state. Device " << device << " is not known!";
     return;
@@ -967,21 +969,21 @@ void Es2kChassisManager::PortStatusEventHandler(int device, int port,
             << ".";
 }
 
-::util::StatusOr<int> Es2kChassisManager::GetUnitFromNodeId(
+::util::StatusOr<int> Es2kChassisManager::GetDeviceFromNodeId(
     uint64 node_id) const {
   if (!initialized_) {
     return MAKE_ERROR(ERR_NOT_INITIALIZED) << "Not initialized!";
   }
-  const int* unit = gtl::FindOrNull(node_id_to_unit_, node_id);
-  CHECK_RETURN_IF_FALSE(unit != nullptr)
+  const int* device = gtl::FindOrNull(node_id_to_device_, node_id);
+  CHECK_RETURN_IF_FALSE(device != nullptr)
       << "Node " << node_id << " is not configured or not known.";
 
-  return *unit;
+  return *device;
 }
 
 void Es2kChassisManager::CleanupInternalState() {
-  unit_to_node_id_.clear();
-  node_id_to_unit_.clear();
+  device_to_node_id_.clear();
+  node_id_to_device_.clear();
   node_id_to_port_id_to_port_state_.clear();
   node_id_to_port_id_to_time_last_changed_.clear();
   node_id_to_port_id_to_port_config_.clear();

--- a/stratum/hal/lib/tdi/es2k/es2k_chassis_manager.h
+++ b/stratum/hal/lib/tdi/es2k/es2k_chassis_manager.h
@@ -62,10 +62,10 @@ class Es2kChassisManager {
   virtual ::util::Status ReplayPortsConfig(uint64 node_id)
       EXCLUSIVE_LOCKS_REQUIRED(chassis_lock);
 
-  virtual ::util::StatusOr<std::map<uint64, int>> GetNodeIdToUnitMap() const
+  virtual ::util::StatusOr<std::map<uint64, int>> GetNodeIdToDeviceMap() const
       SHARED_LOCKS_REQUIRED(chassis_lock);
 
-  virtual ::util::StatusOr<int> GetUnitFromNodeId(uint64 node_id) const
+  virtual ::util::StatusOr<int> GetDeviceFromNodeId(uint64 node_id) const
       SHARED_LOCKS_REQUIRED(chassis_lock);
 
   // Factory function for creating the instance of the class.
@@ -171,12 +171,12 @@ class Es2kChassisManager {
           reader) LOCKS_EXCLUDED(chassis_lock);
 
   // helper to add / configure / enable a port with Es2kPortManager
-  ::util::Status AddPortHelper(uint64 node_id, int unit, uint32 port_id,
+  ::util::Status AddPortHelper(uint64 node_id, int device, uint32 port_id,
                                const SingletonPort& singleton_port,
                                PortConfig* config);
 
   // helper to update port configuration with Es2kPortManager
-  ::util::Status UpdatePortHelper(uint64 node_id, int unit, uint32 port_id,
+  ::util::Status UpdatePortHelper(uint64 node_id, int device, uint32 port_id,
                                   const SingletonPort& singleton_port,
                                   const PortConfig& config_old,
                                   PortConfig* config);
@@ -202,11 +202,11 @@ class Es2kChassisManager {
   std::shared_ptr<WriterInterface<GnmiEventPtr>> gnmi_event_writer_
       GUARDED_BY(gnmi_event_lock_);
 
-  // Map from unit number to the node ID as specified by the config.
-  std::map<int, uint64> unit_to_node_id_ GUARDED_BY(chassis_lock);
+  // Map from device number to the node ID as specified by the config.
+  std::map<int, uint64> device_to_node_id_ GUARDED_BY(chassis_lock);
 
-  // Map from node ID to unit number.
-  std::map<uint64, int> node_id_to_unit_ GUARDED_BY(chassis_lock);
+  // Map from node ID to device number.
+  std::map<uint64, int> node_id_to_device_ GUARDED_BY(chassis_lock);
 
   // Map from node ID to another map from port ID to PortState representing
   // the state of the singleton port uniquely identified by (node ID, port ID).

--- a/stratum/hal/lib/tdi/es2k/es2k_chassis_manager_mock.h
+++ b/stratum/hal/lib/tdi/es2k/es2k_chassis_manager_mock.h
@@ -38,9 +38,10 @@ class Es2kChassisManagerMock : public Es2kChassisManager {
   MOCK_METHOD3(GetFrontPanelPortInfo,
                ::util::Status(uint64 node_id, uint32 port_id,
                               FrontPanelPortInfo* fp_port_info));
-  MOCK_CONST_METHOD0(GetNodeIdToUnitMap,
+  MOCK_CONST_METHOD0(GetNodeIdToDeviceMap,
                      ::util::StatusOr<std::map<uint64, int>>());
-  MOCK_CONST_METHOD1(GetUnitFromNodeId, ::util::StatusOr<int>(uint64 node_id));
+  MOCK_CONST_METHOD1(GetDeviceFromNodeId,
+                     ::util::StatusOr<int>(uint64 node_id));
 };
 
 }  // namespace tdi

--- a/stratum/hal/lib/tdi/es2k/es2k_hal_test.cc
+++ b/stratum/hal/lib/tdi/es2k/es2k_hal_test.cc
@@ -1,6 +1,6 @@
 // Copyright 2018 Google LLC
 // Copyright 2018-present Open Networking Foundation
-// Copyright 2022 Intel Corporation
+// Copyright 2022-2023 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 // adapted from ipdk/ipdk_hal_test.cc, which was
@@ -79,7 +79,7 @@ class Es2kHalTest : public ::testing::Test {
 
   void FillTestChassisConfigAndSave(ChassisConfig* chassis_config) {
     const std::string& chassis_config_text = absl::Substitute(
-        kChassisConfigTemplate, kNodeId1, kUnit1 + 1, kNodeId2, kUnit2 + 1);
+        kChassisConfigTemplate, kNodeId1, kDevice1 + 1, kNodeId2, kDevice2 + 1);
     ASSERT_OK(ParseProtoFromString(chassis_config_text, chassis_config));
     ASSERT_OK(
         WriteStringToFile(chassis_config_text, FLAGS_chassis_config_file));
@@ -141,8 +141,8 @@ class Es2kHalTest : public ::testing::Test {
   static constexpr char kErrorMsg[] = "Some error";
   static constexpr uint64 kNodeId1 = 123123123;
   static constexpr uint64 kNodeId2 = 456456456;
-  static constexpr int kUnit1 = 0;
-  static constexpr int kUnit2 = 1;
+  static constexpr int kDevice1 = 0;
+  static constexpr int kDevice2 = 1;
   static constexpr OperationMode kMode = OPERATION_MODE_STANDALONE;
 
   static ::testing::StrictMock<SwitchMock>* switch_mock_;
@@ -156,8 +156,8 @@ constexpr char Es2kHalTest::kForwardingPipelineConfigsTemplate[];
 constexpr char Es2kHalTest::kErrorMsg[];
 constexpr uint64 Es2kHalTest::kNodeId1;
 constexpr uint64 Es2kHalTest::kNodeId2;
-constexpr int Es2kHalTest::kUnit1;
-constexpr int Es2kHalTest::kUnit2;
+constexpr int Es2kHalTest::kDevice1;
+constexpr int Es2kHalTest::kDevice2;
 constexpr OperationMode Es2kHalTest::kMode;
 
 ::testing::StrictMock<SwitchMock>* Es2kHalTest::switch_mock_ = nullptr;

--- a/stratum/hal/lib/tdi/es2k/es2k_switch.cc
+++ b/stratum/hal/lib/tdi/es2k/es2k_switch.cc
@@ -45,7 +45,7 @@ Es2kSwitch::~Es2kSwitch() {}
   absl::WriterMutexLock l(&chassis_lock);
   RETURN_IF_ERROR(chassis_manager_->PushChassisConfig(config));
   ASSIGN_OR_RETURN(const auto& node_id_to_device_id,
-                   chassis_manager_->GetNodeIdToUnitMap());
+                   chassis_manager_->GetNodeIdToDeviceMap());
   node_id_to_tdi_node_.clear();
   for (const auto& entry : node_id_to_device_id) {
     uint64 node_id = entry.first;
@@ -211,7 +211,7 @@ Es2kSwitch::~Es2kSwitch() {}
       // Node information request
       case DataRequest::Request::kNodeInfo: {
         auto device_id =
-            chassis_manager_->GetUnitFromNodeId(req.node_info().node_id());
+            chassis_manager_->GetDeviceFromNodeId(req.node_info().node_id());
         if (!device_id.ok()) {
           status.Update(device_id.status());
         } else {
@@ -287,7 +287,7 @@ std::unique_ptr<Es2kSwitch> Es2kSwitch::CreateInstance(
   Es2kNode* es2k_node = gtl::FindPtrOrNull(device_id_to_es2k_node_, device_id);
   if (es2k_node == nullptr) {
     return MAKE_ERROR(ERR_INVALID_PARAM)
-           << "Unit " << device_id << " is unknown.";
+           << "Device " << device_id << " is unknown.";
   }
   return es2k_node;
 }

--- a/stratum/hal/lib/tdi/es2k/es2k_switch_test.cc
+++ b/stratum/hal/lib/tdi/es2k/es2k_switch_test.cc
@@ -62,12 +62,12 @@ MATCHER_P(DerivedFromStatus, status, "") {
 }
 
 constexpr uint64 kNodeId = 13579;
-constexpr int kUnit = 2;
+constexpr int kDevice = 2;
 constexpr char kErrorMsg[] = "Test error message";
 constexpr uint32 kPortId = 2468;
 
-const std::map<uint64, int>& NodeIdToUnitMap() {
-  static auto* map = new std::map<uint64, int>({{kNodeId, kUnit}});
+const std::map<uint64, int>& NodeIdToDeviceMap() {
+  static auto* map = new std::map<uint64, int>({{kNodeId, kDevice}});
   return *map;
 }
 
@@ -79,16 +79,16 @@ class Es2kSwitchTest : public ::testing::Test {
         absl::make_unique<NiceMock<Es2kChassisManagerMock>>();
     ipsec_manager_mock_ = absl::make_unique<NiceMock<IPsecManagerMock>>();
     node_mock_ = absl::make_unique<NiceMock<Es2kNodeMock>>();
-    unit_to_ipdk_node_mock_[kUnit] = node_mock_.get();
+    device_to_node_mock_[kDevice] = node_mock_.get();
     switch_ = Es2kSwitch::CreateInstance(chassis_manager_mock_.get(),
                                          ipsec_manager_mock_.get(),
-                                         unit_to_ipdk_node_mock_);
+                                         device_to_node_mock_);
 
-    ON_CALL(*chassis_manager_mock_, GetNodeIdToUnitMap())
-        .WillByDefault(Return(NodeIdToUnitMap()));
+    ON_CALL(*chassis_manager_mock_, GetNodeIdToDeviceMap())
+        .WillByDefault(Return(NodeIdToDeviceMap()));
   }
 
-  void TearDown() override { unit_to_ipdk_node_mock_.clear(); }
+  void TearDown() override { device_to_node_mock_.clear(); }
 
   // This operation should always succeed.
   // We use it to set up a number of test cases.
@@ -107,7 +107,7 @@ class Es2kSwitchTest : public ::testing::Test {
   std::unique_ptr<Es2kChassisManagerMock> chassis_manager_mock_;
   std::unique_ptr<IPsecManagerMock> ipsec_manager_mock_;
   std::unique_ptr<Es2kNodeMock> node_mock_;
-  std::map<int, Es2kNode*> unit_to_ipdk_node_mock_;
+  std::map<int, Es2kNode*> device_to_node_mock_;
   std::unique_ptr<Es2kSwitch> switch_;
 };
 

--- a/stratum/hal/lib/tdi/tofino/tofino_chassis_manager.h
+++ b/stratum/hal/lib/tdi/tofino/tofino_chassis_manager.h
@@ -1,5 +1,5 @@
 // Copyright 2018-present Barefoot Networks, Inc.
-// Copyright 2022 Intel Corporation
+// Copyright 2022-2023 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 #ifndef STRATUM_HAL_LIB_TDI_TOFINO_TOFINO_CHASSIS_MANAGER_H_
@@ -66,10 +66,10 @@ class TofinoChassisManager {
                                                FrontPanelPortInfo* fp_port_info)
       SHARED_LOCKS_REQUIRED(chassis_lock);
 
-  virtual ::util::StatusOr<std::map<uint64, int>> GetNodeIdToUnitMap() const
+  virtual ::util::StatusOr<std::map<uint64, int>> GetNodeIdToDeviceMap() const
       SHARED_LOCKS_REQUIRED(chassis_lock);
 
-  virtual ::util::StatusOr<int> GetUnitFromNodeId(uint64 node_id) const
+  virtual ::util::StatusOr<int> GetDeviceFromNodeId(uint64 node_id) const
       SHARED_LOCKS_REQUIRED(chassis_lock);
 
   virtual std::string GetChipType(int device) const;
@@ -194,19 +194,19 @@ class TofinoChassisManager {
           reader) LOCKS_EXCLUDED(chassis_lock);
 
   // helper to add / configure / enable a port with TofinoPortManager
-  ::util::Status AddPortHelper(uint64 node_id, int unit, uint32 port_id,
+  ::util::Status AddPortHelper(uint64 node_id, int device, uint32 port_id,
                                const SingletonPort& singleton_port,
                                PortConfig* config);
 
   // helper to update port configuration with TofinoPortManager
-  ::util::Status UpdatePortHelper(uint64 node_id, int unit, uint32 port_id,
+  ::util::Status UpdatePortHelper(uint64 node_id, int device, uint32 port_id,
                                   const SingletonPort& singleton_port,
                                   const PortConfig& config_old,
                                   PortConfig* config);
 
   // Helper to apply a port shaping config to a single port.
   ::util::Status ApplyPortShapingConfig(
-      uint64 node_id, int unit, uint32 sdk_port_id,
+      uint64 node_id, int device, uint32 sdk_port_id,
       const TofinoConfig::BfPortShapingConfig::BfPerPortShapingConfig&
           shaping_config);
 
@@ -240,11 +240,11 @@ class TofinoChassisManager {
   std::shared_ptr<WriterInterface<GnmiEventPtr>> gnmi_event_writer_
       GUARDED_BY(gnmi_event_lock_);
 
-  // Map from unit number to the node ID as specified by the config.
-  std::map<int, uint64> unit_to_node_id_ GUARDED_BY(chassis_lock);
+  // Map from device number to the node ID as specified by the config.
+  std::map<int, uint64> device_to_node_id_ GUARDED_BY(chassis_lock);
 
-  // Map from node ID to unit number.
-  std::map<uint64, int> node_id_to_unit_ GUARDED_BY(chassis_lock);
+  // Map from node ID to device number.
+  std::map<uint64, int> node_id_to_device_ GUARDED_BY(chassis_lock);
 
   // Map from node ID to another map from port ID to PortState representing
   // the state of the singleton port uniquely identified by (node ID, port ID).

--- a/stratum/hal/lib/tdi/tofino/tofino_chassis_manager_mock.h
+++ b/stratum/hal/lib/tdi/tofino/tofino_chassis_manager_mock.h
@@ -38,9 +38,10 @@ class TofinoChassisManagerMock : public TofinoChassisManager {
   MOCK_METHOD3(GetFrontPanelPortInfo,
                ::util::Status(uint64 node_id, uint32 port_id,
                               FrontPanelPortInfo* fp_port_info));
-  MOCK_CONST_METHOD0(GetNodeIdToUnitMap,
+  MOCK_CONST_METHOD0(GetNodeIdToDeviceMap,
                      ::util::StatusOr<std::map<uint64, int>>());
-  MOCK_CONST_METHOD1(GetUnitFromNodeId, ::util::StatusOr<int>(uint64 node_id));
+  MOCK_CONST_METHOD1(GetDeviceFromNodeId,
+                     ::util::StatusOr<int>(uint64 node_id));
 };
 
 }  // namespace tdi

--- a/stratum/hal/lib/tdi/tofino/tofino_hal_test.cc
+++ b/stratum/hal/lib/tdi/tofino/tofino_hal_test.cc
@@ -1,6 +1,6 @@
 // Copyright 2018 Google LLC
 // Copyright 2018-present Open Networking Foundation
-// Copyright 2022 Intel Corporation
+// Copyright 2022-2023 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 // adapted from ipdk/ipdk_hal_test.cc, which was
@@ -79,7 +79,7 @@ class TofinoHalTest : public ::testing::Test {
 
   void FillTestChassisConfigAndSave(ChassisConfig* chassis_config) {
     const std::string& chassis_config_text = absl::Substitute(
-        kChassisConfigTemplate, kNodeId1, kUnit1 + 1, kNodeId2, kUnit2 + 1);
+        kChassisConfigTemplate, kNodeId1, kDevice1 + 1, kNodeId2, kDevice2 + 1);
     ASSERT_OK(ParseProtoFromString(chassis_config_text, chassis_config));
     ASSERT_OK(
         WriteStringToFile(chassis_config_text, FLAGS_chassis_config_file));
@@ -141,8 +141,8 @@ class TofinoHalTest : public ::testing::Test {
   static constexpr char kErrorMsg[] = "Some error";
   static constexpr uint64 kNodeId1 = 123123123;
   static constexpr uint64 kNodeId2 = 456456456;
-  static constexpr int kUnit1 = 0;
-  static constexpr int kUnit2 = 1;
+  static constexpr int kDevice1 = 0;
+  static constexpr int kDevice2 = 1;
   static constexpr OperationMode kMode = OPERATION_MODE_STANDALONE;
 
   static ::testing::StrictMock<SwitchMock>* switch_mock_;
@@ -156,8 +156,8 @@ constexpr char TofinoHalTest::kForwardingPipelineConfigsTemplate[];
 constexpr char TofinoHalTest::kErrorMsg[];
 constexpr uint64 TofinoHalTest::kNodeId1;
 constexpr uint64 TofinoHalTest::kNodeId2;
-constexpr int TofinoHalTest::kUnit1;
-constexpr int TofinoHalTest::kUnit2;
+constexpr int TofinoHalTest::kDevice1;
+constexpr int TofinoHalTest::kDevice2;
 constexpr OperationMode TofinoHalTest::kMode;
 
 ::testing::StrictMock<SwitchMock>* TofinoHalTest::switch_mock_ = nullptr;

--- a/stratum/hal/lib/tdi/tofino/tofino_switch.cc
+++ b/stratum/hal/lib/tdi/tofino/tofino_switch.cc
@@ -1,5 +1,5 @@
 // Copyright 2020-present Open Networking Foundation
-// Copyright 2022 Intel Corporation
+// Copyright 2022-2023 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 #include "stratum/hal/lib/tdi/tofino/tofino_switch.h"
@@ -43,7 +43,7 @@ TofinoSwitch::~TofinoSwitch() {}
   absl::WriterMutexLock l(&chassis_lock);
   RETURN_IF_ERROR(chassis_manager_->PushChassisConfig(config));
   ASSIGN_OR_RETURN(const auto& node_id_to_device_id,
-                   chassis_manager_->GetNodeIdToUnitMap());
+                   chassis_manager_->GetNodeIdToDeviceMap());
   node_id_to_tdi_node_.clear();
   for (const auto& entry : node_id_to_device_id) {
     uint64 node_id = entry.first;
@@ -209,7 +209,7 @@ TofinoSwitch::~TofinoSwitch() {}
       // Node information request
       case DataRequest::Request::kNodeInfo: {
         auto device_id =
-            chassis_manager_->GetUnitFromNodeId(req.node_info().node_id());
+            chassis_manager_->GetDeviceFromNodeId(req.node_info().node_id());
         if (!device_id.ok()) {
           status.Update(device_id.status());
         } else {
@@ -262,7 +262,7 @@ std::unique_ptr<TofinoSwitch> TofinoSwitch::CreateInstance(
   TdiNode* tdi_node = gtl::FindPtrOrNull(device_id_to_tdi_node_, device_id);
   if (tdi_node == nullptr) {
     return MAKE_ERROR(ERR_INVALID_PARAM)
-           << "Unit " << device_id << " is unknown.";
+           << "Device " << device_id << " is unknown.";
   }
   return tdi_node;
 }

--- a/stratum/hal/lib/tdi/tofino/tofino_switch_test.cc
+++ b/stratum/hal/lib/tdi/tofino/tofino_switch_test.cc
@@ -1,6 +1,6 @@
 // Copyright 2018 Google LLC
 // Copyright 2018-present Open Networking Foundation
-// Copyright 2022 Intel Corporation
+// Copyright 2022-2023 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 // adapted from ipdk_switch_test, which was
@@ -63,12 +63,12 @@ MATCHER_P(DerivedFromStatus, status, "") {
 }
 
 constexpr uint64 kNodeId = 13579;
-constexpr int kUnit = 2;
+constexpr int kDevice = 2;
 constexpr char kErrorMsg[] = "Test error message";
 constexpr uint32 kPortId = 2468;
 
-const std::map<uint64, int>& NodeIdToUnitMap() {
-  static auto* map = new std::map<uint64, int>({{kNodeId, kUnit}});
+const std::map<uint64, int>& NodeIdToDeviceMap() {
+  static auto* map = new std::map<uint64, int>({{kNodeId, kDevice}});
   return *map;
 }
 
@@ -81,19 +81,19 @@ class TofinoSwitchTest : public ::testing::Test {
     chassis_manager_mock_ =
         absl::make_unique<NiceMock<TofinoChassisManagerMock>>();
     node_mock_ = absl::make_unique<NiceMock<TdiNodeMock>>();
-    unit_to_ipdk_node_mock_[kUnit] = node_mock_.get();
+    device_to_node_mock_[kDevice] = node_mock_.get();
     switch_ = TofinoSwitch::CreateInstance(chassis_manager_mock_.get(),
-                                           unit_to_ipdk_node_mock_);
+                                           device_to_node_mock_);
 #if 0
     // no 'shutdown'
     shutdown = false;  // global variable initialization
 #endif
 
-    ON_CALL(*chassis_manager_mock_, GetNodeIdToUnitMap())
-        .WillByDefault(Return(NodeIdToUnitMap()));
+    ON_CALL(*chassis_manager_mock_, GetNodeIdToDeviceMap())
+        .WillByDefault(Return(NodeIdToDeviceMap()));
   }
 
-  void TearDown() override { unit_to_ipdk_node_mock_.clear(); }
+  void TearDown() override { device_to_node_mock_.clear(); }
 
   // This operation should always succeed.
   // We use it to set up a number of test cases.
@@ -113,7 +113,7 @@ class TofinoSwitchTest : public ::testing::Test {
   std::unique_ptr<TdiSdeMock> sde_mock_;
   std::unique_ptr<TofinoChassisManagerMock> chassis_manager_mock_;
   std::unique_ptr<TdiNodeMock> node_mock_;
-  std::map<int, TdiNode*> unit_to_ipdk_node_mock_;
+  std::map<int, TdiNode*> device_to_node_mock_;
   std::unique_ptr<TofinoSwitch> switch_;
 };
 


### PR DESCRIPTION
Modify TDI targets to track changes made to the Barefoot code in #732:

> `unit` is a Broadcom-specific term and has no established meaning in the [TDI] world, where `device` is used for the same purpose. To reduce cognitive load and prevent unnecessary confusion, we replace the term.
>
>This PR does not make any functional changes.