### PR TITLE
Apply upstream changes to outlying files

### DIFF
--- a/stratum/hal/bin/tdi/dpdk/dpdk_main.cc
+++ b/stratum/hal/bin/tdi/dpdk/dpdk_main.cc
@@ -148,7 +148,7 @@ void ParseCommandLine(int argc, char* argv[], bool remove_flags) {
   auto* hal = DpdkHal::CreateSingleton(mode, dpdk_switch.get(),
                                        auth_policy_checker.get(), ready_sync,
                                        done_sync, &target_options);
-  CHECK_RETURN_IF_FALSE(hal) << "Failed to create the Stratum Hal instance.";
+  RET_CHECK(hal) << "Failed to create the Stratum Hal instance.";
 
   // Set up P4 runtime servers.
   ::util::Status status = hal->Setup();

--- a/stratum/hal/config/chassis_config_migrator.cc
+++ b/stratum/hal/config/chassis_config_migrator.cc
@@ -1,4 +1,5 @@
 // Copyright 2021-present Open Networking Foundation
+// Copyright 2023 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 #include <string>
@@ -30,6 +31,10 @@ ls -1 stratum/hal/config/*/chassis_config.pb.txt | \
   xargs -n 1 bazel run //stratum/hal/config:chassis_config_migrator -- \
     -chassis_config_file
 )USAGE";
+
+// Suppress gcc "no previous declaration" warnings.
+::util::Status MigrateSingletonPort(SingletonPort* singleton_port);
+::util::Status Main(int argc, char** argv);
 
 ::util::Status MigrateSingletonPort(SingletonPort* singleton_port) {
   // Only change the port name if it matches the <port>/<slot> pattern.
@@ -66,8 +71,7 @@ ls -1 stratum/hal/config/*/chassis_config.pb.txt | \
   InitGoogle(argv[0], &argc, &argv, true);
   stratum::InitStratumLogging();
 
-  CHECK_RETURN_IF_FALSE(!FLAGS_chassis_config_file.empty())
-      << "No chassis config given.";
+  RET_CHECK(!FLAGS_chassis_config_file.empty()) << "No chassis config given.";
   ChassisConfig config;
   RETURN_IF_ERROR(ReadProtoFromTextFile(FLAGS_chassis_config_file, &config));
   if (config.chassis().platform() != PLT_GENERIC_BAREFOOT_TOFINO &&

--- a/stratum/hal/lib/pi/pi_node.cc
+++ b/stratum/hal/lib/pi/pi_node.cc
@@ -151,7 +151,7 @@ std::unique_ptr<PINode> PINode::CreateInstance(
     return MAKE_ERROR(ERR_INTERNAL) << "Pipeline not initialized";
   }
   if (!req.updates_size()) return ::util::OkStatus();  // nothing to do.
-  CHECK_RETURN_IF_FALSE(results != nullptr)
+  RET_CHECK(results != nullptr)
       << "Need to provide non-null results pointer for non-empty updates.";
 
   auto status = device_mgr_->write(req);
@@ -166,8 +166,8 @@ std::unique_ptr<PINode> PINode::CreateInstance(
   if (!pipeline_initialized_) {
     return MAKE_ERROR(ERR_INTERNAL) << "Pipeline not initialized";
   }
-  CHECK_RETURN_IF_FALSE(writer) << "Channel writer must be non-null.";
-  CHECK_RETURN_IF_FALSE(details) << "Details pointer must be non-null.";
+  RET_CHECK(writer) << "Channel writer must be non-null.";
+  RET_CHECK(details) << "Details pointer must be non-null.";
 
   ::p4::v1::ReadResponse response;
   auto status = device_mgr_->read(req, &response);

--- a/stratum/lib/security/auth_policy_checker.cc
+++ b/stratum/lib/security/auth_policy_checker.cc
@@ -75,7 +75,7 @@ void ReadProtoIfValidFileExists(const std::string& path,
 }
 
 ::util::Status RemoveWatchHelper(int fd, int wd) {
-  CHECK_RETURN_IF_FALSE(fd > 0) << "Invalid fd: " << fd << ".";
+  RET_CHECK(fd > 0) << "Invalid fd: " << fd << ".";
   if (wd > 0) inotify_rm_watch(fd, wd);
 
   return ::util::OkStatus();
@@ -87,8 +87,8 @@ void ReadProtoIfValidFileExists(const std::string& path,
 // modify.
 ::util::StatusOr<int> AddWatchForFileChange(int ifd, const std::string& path) {
   std::string dir = DirName(path);
-  CHECK_RETURN_IF_FALSE(PathExists(dir)) << "Dir '" << dir << "' not found.";
-  CHECK_RETURN_IF_FALSE(IsDir(dir)) << "'" << dir << "' is not a directory.";
+  RET_CHECK(PathExists(dir)) << "Dir '" << dir << "' not found.";
+  RET_CHECK(IsDir(dir)) << "'" << dir << "' is not a directory.";
   ASSIGN_OR_RETURN(
       int wd,
       AddWatchHelper(ifd, dir, IN_CREATE | IN_DELETE | IN_MOVE | IN_MODIFY));


### PR DESCRIPTION
- Replace CHECK_RETURN_IF_FALSE() with RET_CHECK().
- Address gcc compiler warnings in chassis_config_migrator.cc.