### PR TITLE
Rename protobuf raw string delimiter

### DIFF
--- a/stratum/hal/lib/common/config_monitoring_service_test.cc
+++ b/stratum/hal/lib/common/config_monitoring_service_test.cc
@@ -116,7 +116,7 @@ class ConfigMonitoringServiceTest
     return config_monitoring_service_->DoCapabilities(context, req, resp);
   }
 
-  static constexpr char kChassisConfigTemplate[] = R"PROTO(
+  static constexpr char kChassisConfigTemplate[] = R"pb(
       description: "Sample test config."
       nodes {
         id:  $0
@@ -142,7 +142,7 @@ class ConfigMonitoringServiceTest
         port: 2
         speed_bps: 100000000000
       }
-  )PROTO";
+  )pb";
   static constexpr char kErrorMsg[] = "Some error";
   static constexpr uint64 kNodeId1 = 123123123;
   static constexpr uint64 kNodeId2 = 456456456;
@@ -346,7 +346,7 @@ TEST_P(ConfigMonitoringServiceTest, SubscribeExistingPathSuccess) {
 
   // Build a stream subscription request for subtree that is supported.
   ::gnmi::SubscribeRequest req;
-  constexpr char kReq[] = R"PROTO(
+  constexpr char kReq[] = R"pb(
   subscribe {
     mode: STREAM
     subscription {
@@ -358,7 +358,7 @@ TEST_P(ConfigMonitoringServiceTest, SubscribeExistingPathSuccess) {
       sample_interval: 1
     }
   }
-  )PROTO";
+  )pb";
   ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(kReq, &req))
       << "Failed to parse proto from the following string: " << kReq;
 
@@ -383,7 +383,7 @@ TEST_P(ConfigMonitoringServiceTest, SubscribeExistingPathFail) {
 
   // Build a stream subscription request for subtree that is not supported.
   ::gnmi::SubscribeRequest req;
-  constexpr char kReq[] = R"PROTO(
+  constexpr char kReq[] = R"pb(
   subscribe {
     mode: STREAM
     subscription {
@@ -394,7 +394,7 @@ TEST_P(ConfigMonitoringServiceTest, SubscribeExistingPathFail) {
       sample_interval: 1
     }
   }
-  )PROTO";
+  )pb";
   ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(kReq, &req))
       << "Failed to parse proto from the following string: " << kReq;
 
@@ -430,7 +430,7 @@ TEST_P(ConfigMonitoringServiceTest, SubscribeExistingPathPassFail) {
 
   // Build a stream subscription request for subtree that is not supported.
   ::gnmi::SubscribeRequest req;
-  constexpr char kReq[] = R"PROTO(
+  constexpr char kReq[] = R"pb(
   subscribe {
     mode: STREAM
     subscription {
@@ -449,7 +449,7 @@ TEST_P(ConfigMonitoringServiceTest, SubscribeExistingPathPassFail) {
       sample_interval: 1
     }
   }
-  )PROTO";
+  )pb";
   ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(kReq, &req))
       << "Failed to parse proto from the following string: " << kReq;
 
@@ -486,7 +486,7 @@ TEST_P(ConfigMonitoringServiceTest, SubscribeAndPollSuccess) {
 
   // Build a poll subscription request for subtree that is supported.
   ::gnmi::SubscribeRequest req1;
-  constexpr char kReq1[] = R"PROTO(
+  constexpr char kReq1[] = R"pb(
   subscribe {
     mode: POLL
     subscription {
@@ -496,16 +496,16 @@ TEST_P(ConfigMonitoringServiceTest, SubscribeAndPollSuccess) {
       }
     }
   }
-  )PROTO";
+  )pb";
   ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(kReq1, &req1))
       << "Failed to parse proto from the following string: " << kReq1;
 
   // Build actual poll request.
   ::gnmi::SubscribeRequest req2;
-  constexpr char kReq2[] = R"PROTO(
+  constexpr char kReq2[] = R"pb(
   poll {
   }
-  )PROTO";
+  )pb";
   ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(kReq2, &req2))
       << "Failed to parse proto from the following string: " << kReq2;
 
@@ -536,7 +536,7 @@ TEST_P(ConfigMonitoringServiceTest, DoubleSubscribeFail) {
 
   // Build a stream subscription request for subtree that is supported.
   ::gnmi::SubscribeRequest req;
-  constexpr char kReq[] = R"PROTO(
+  constexpr char kReq[] = R"pb(
   subscribe {
     mode: STREAM
     subscription {
@@ -548,7 +548,7 @@ TEST_P(ConfigMonitoringServiceTest, DoubleSubscribeFail) {
       sample_interval: 1
     }
   }
-  )PROTO";
+  )pb";
   ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(kReq, &req))
       << "Failed to parse proto from the following string: " << kReq;
 
@@ -586,7 +586,7 @@ TEST_P(ConfigMonitoringServiceTest, DuplicateSubscribeFail) {
   // Build a stream subscription request for subtree that is supported.
   // Add another request for the same path. This is illeagal combination.
   ::gnmi::SubscribeRequest req;
-  constexpr char kReq[] = R"PROTO(
+  constexpr char kReq[] = R"pb(
   subscribe {
     mode: STREAM
     subscription {
@@ -606,7 +606,7 @@ TEST_P(ConfigMonitoringServiceTest, DuplicateSubscribeFail) {
       sample_interval: 1
     }
   }
-  )PROTO";
+  )pb";
   ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(kReq, &req))
       << "Failed to parse proto from the following string: " << kReq;
 
@@ -648,7 +648,7 @@ TEST_P(ConfigMonitoringServiceTest, SubscribeOnChangeWithInitialValueSuccess) {
 
   // Build a on_change subscription request for subtree that is supported.
   ::gnmi::SubscribeRequest req;
-  constexpr char kReq[] = R"PROTO(
+  constexpr char kReq[] = R"pb(
   subscribe {
     mode: STREAM
     subscription {
@@ -659,7 +659,7 @@ TEST_P(ConfigMonitoringServiceTest, SubscribeOnChangeWithInitialValueSuccess) {
       mode: ON_CHANGE
    }
   }
-  )PROTO";
+  )pb";
   ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(kReq, &req))
       << "Failed to parse proto from the following string: " << kReq;
 
@@ -707,7 +707,7 @@ TEST_P(ConfigMonitoringServiceTest, CheckConvertTargetDefinedToOnChange) {
   // This subscription request will be changed into an ON_CHANGE subscription
   // request.
   ::gnmi::SubscribeRequest req;
-  constexpr char kReq[] = R"PROTO(
+  constexpr char kReq[] = R"pb(
   subscribe {
     mode: STREAM
     subscription {
@@ -718,7 +718,7 @@ TEST_P(ConfigMonitoringServiceTest, CheckConvertTargetDefinedToOnChange) {
       mode: TARGET_DEFINED
    }
   }
-  )PROTO";
+  )pb";
   ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(kReq, &req))
       << "Failed to parse proto from the following string: " << kReq;
 
@@ -771,12 +771,12 @@ TEST_P(ConfigMonitoringServiceTest, CheckConvertTargetDefinedToOnChange) {
 TEST_P(ConfigMonitoringServiceTest, GnmiGetRootConfigBeforePush) {
   // Prepare a GET request.
   ::gnmi::GetRequest req;
-  constexpr char kReq[] = R"PROTO(
+  constexpr char kReq[] = R"pb(
   path {
   }
   type: CONFIG
   encoding: PROTO
-  )PROTO";
+  )pb";
   ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(kReq, &req))
       << "Failed to parse proto from the following string: " << kReq;
 
@@ -798,12 +798,12 @@ TEST_P(ConfigMonitoringServiceTest, GnmiGetRootNonConfig) {
 
   // Prepare a GET request.
   ::gnmi::GetRequest req;
-  constexpr char kReq[] = R"PROTO(
+  constexpr char kReq[] = R"pb(
   path {
   }
   type: STATE
   encoding: PROTO
-  )PROTO";
+  )pb";
   ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(kReq, &req))
       << "Failed to parse proto from the following string: " << kReq;
 
@@ -825,12 +825,12 @@ TEST_P(ConfigMonitoringServiceTest, GnmiGetRootNonProto) {
 
   // Prepare a GET request.
   ::gnmi::GetRequest req;
-  constexpr char kReq[] = R"PROTO(
+  constexpr char kReq[] = R"pb(
   path {
   }
   type: CONFIG
   encoding: JSON
-  )PROTO";
+  )pb";
   ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(kReq, &req))
       << "Failed to parse proto from the following string: " << kReq;
 
@@ -852,12 +852,12 @@ TEST_P(ConfigMonitoringServiceTest, GnmiGetRootConfig) {
 
   // Prepare a GET request.
   ::gnmi::GetRequest req;
-  constexpr char kReq[] = R"PROTO(
+  constexpr char kReq[] = R"pb(
   path {
   }
   type: CONFIG
   encoding: PROTO
-  )PROTO";
+  )pb";
   ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(kReq, &req))
       << "Failed to parse proto from the following string: " << kReq;
 
@@ -882,7 +882,7 @@ TEST_P(ConfigMonitoringServiceTest, GnmiGetBlah) {
 
   // Prepare a GET request.
   ::gnmi::GetRequest req;
-  constexpr char kReq[] = R"PROTO(
+  constexpr char kReq[] = R"pb(
   path {
     elem { name: "interfaces" }
     elem { name: "interface"
@@ -893,7 +893,7 @@ TEST_P(ConfigMonitoringServiceTest, GnmiGetBlah) {
   }
   type: CONFIG
   encoding: PROTO
-  )PROTO";
+  )pb";
   ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(kReq, &req))
       << "Failed to parse proto from the following string: " << kReq;
 
@@ -916,7 +916,7 @@ TEST_P(ConfigMonitoringServiceTest,
 
   // Prepare a GET request.
   ::gnmi::GetRequest req;
-  constexpr char kReq[] = R"PROTO(
+  constexpr char kReq[] = R"pb(
   path {
     elem { name: "interfaces" }
     elem { name: "interface"
@@ -927,7 +927,7 @@ TEST_P(ConfigMonitoringServiceTest,
   }
   type: CONFIG
   encoding: PROTO
-  )PROTO";
+  )pb";
   ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(kReq, &req))
       << "Failed to parse proto from the following string: " << kReq;
 
@@ -1019,9 +1019,9 @@ TEST_P(ConfigMonitoringServiceTest, DISABLED_GnmiSetRootReplace) {
 //
 //  // Prepare a SET request.
 //  ::gnmi::SetRequest req;
-//  constexpr char kReq[] = R"PROTO(
+//  constexpr char kReq[] = R"pb(
 //    update { val { bytes_val: "" } }
-//  )PROTO";
+//  )pb";
 //  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(kReq, &req))
 //      << "Failed to parse proto from the following string: " << kReq;
 //
@@ -1055,7 +1055,7 @@ TEST_P(ConfigMonitoringServiceTest, DISABLED_GnmiSetRootReplace) {
 //
 //  // Prepare a GET request.
 //  ::gnmi::SetRequest req;
-//  constexpr char kReq[] = R"PROTO(
+//  constexpr char kReq[] = R"pb(
 //    update {
 //      path {
 //        elem { name: "interfaces" }
@@ -1068,7 +1068,7 @@ TEST_P(ConfigMonitoringServiceTest, DISABLED_GnmiSetRootReplace) {
 //      }
 //      val { string_val: "BAD" }
 //    }
-//  )PROTO";
+//  )pb";
 //  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(kReq, &req))
 //      << "Failed to parse proto from the following string: " << kReq;
 //
@@ -1107,7 +1107,7 @@ TEST_P(ConfigMonitoringServiceTest,
 
   // Prepare a GET request.
   ::gnmi::SetRequest req;
-  constexpr char kReq[] = R"PROTO(
+  constexpr char kReq[] = R"pb(
     replace {
       path {
         elem { name: "interfaces" }
@@ -1120,7 +1120,7 @@ TEST_P(ConfigMonitoringServiceTest,
       }
       val { string_val: "BAD" }
     }
-  )PROTO";
+  )pb";
   ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(kReq, &req))
       << "Failed to parse proto from the following string: " << kReq;
 
@@ -1158,7 +1158,7 @@ TEST_P(ConfigMonitoringServiceTest,
 
   // Prepare a GET request.
   ::gnmi::SetRequest req;
-  constexpr char kReq[] = R"PROTO(
+  constexpr char kReq[] = R"pb(
     delete {
       elem { name: "interfaces" }
       elem {
@@ -1168,7 +1168,7 @@ TEST_P(ConfigMonitoringServiceTest,
       elem { name: "state" }
       elem { name: "health-indicator" }
     }
-  )PROTO";
+  )pb";
   ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(kReq, &req))
       << "Failed to parse proto from the following string: " << kReq;
 

--- a/stratum/hal/lib/phal/onlp/onlp_switch_configurator_test.cc
+++ b/stratum/hal/lib/phal/onlp/onlp_switch_configurator_test.cc
@@ -54,7 +54,7 @@ class OnlpSwitchConfiguratorTest : public ::testing::Test {
     return ::util::OkStatus();
   }
 
-  static constexpr char kPhalInitConfig[] = R"PROTO(
+  static constexpr char kPhalInitConfig[] = R"pb(
     cards {
       slot: 1
       ports { port: 1 physical_port_type: PHYSICAL_PORT_TYPE_SFP_CAGE }
@@ -84,7 +84,7 @@ class OnlpSwitchConfiguratorTest : public ::testing::Test {
         cache_policy { type: TIMED_CACHE timed_value: 2 }
       }
     }
-  )PROTO";
+  )pb";
 };
 
 constexpr char OnlpSwitchConfiguratorTest::kPhalInitConfig[];

--- a/stratum/hal/lib/phal/optics_adapter_test.cc
+++ b/stratum/hal/lib/phal/optics_adapter_test.cc
@@ -34,7 +34,7 @@ class OpticsAdapterTest : public ::testing::Test {
   std::unique_ptr<OpticsAdapter> optics_adapter_;
 };
 
-constexpr char phaldb_get_response_proto[] = R"PROTO(
+constexpr char phaldb_get_response_proto[] = R"pb(
   optical_modules {
     id: 0
     network_interfaces {
@@ -46,7 +46,7 @@ constexpr char phaldb_get_response_proto[] = R"PROTO(
       operational_mode: 1
     }
   }
-)PROTO";
+)pb";
 
 // Settable atrributes paths.
 const Path frequency_path = {PathEntry("optical_modules", 0),

--- a/stratum/hal/lib/phal/phaldb_service_test.cc
+++ b/stratum/hal/lib/phal/phaldb_service_test.cc
@@ -77,7 +77,7 @@ class PhalDbServiceTest : public ::testing::TestWithParam<OperationMode> {
   std::unique_ptr<PhalMock> phal_mock_;
   std::unique_ptr<AttributeDatabaseMock> database_mock_;
 
-  const std::string valid_request_path_proto = R"PROTO(
+  const std::string valid_request_path_proto = R"pb(
     entries {
       name: "cards"
       index: 0
@@ -92,17 +92,17 @@ class PhalDbServiceTest : public ::testing::TestWithParam<OperationMode> {
       name: "transceiver"
       terminal_group: true
     }
-  )PROTO";
+  )pb";
 
-  const std::string invalid_request_path_proto = R"PROTO(
+  const std::string invalid_request_path_proto = R"pb(
     entries {
       name: "does_not_exists"
       index: 0
       indexed: true
     }
-  )PROTO";
+  )pb";
 
-  const std::string phaldb_get_response_proto = R"PROTO(
+  const std::string phaldb_get_response_proto = R"pb(
     cards {
       ports {
         physical_port_type: PHYSICAL_PORT_TYPE_SFP_CAGE
@@ -121,7 +121,7 @@ class PhalDbServiceTest : public ::testing::TestWithParam<OperationMode> {
         }
       }
     }
-  )PROTO";
+  )pb";
 };
 
 TEST_P(PhalDbServiceTest, SetupWarm) {

--- a/stratum/hal/lib/phal/sfp_adapter_test.cc
+++ b/stratum/hal/lib/phal/sfp_adapter_test.cc
@@ -47,7 +47,7 @@ class SfpAdapterTest : public ::testing::Test {
   std::unique_ptr<AttributeDatabaseMock> database_;
   std::unique_ptr<SfpAdapter> sfp_adapter_;
 
-  const std::string phaldb_get_response_proto = R"PROTO(
+  const std::string phaldb_get_response_proto = R"pb(
     cards {
       ports {
         physical_port_type: PHYSICAL_PORT_TYPE_SFP_CAGE
@@ -66,7 +66,7 @@ class SfpAdapterTest : public ::testing::Test {
         }
       }
     }
-  )PROTO";
+  )pb";
 };
 
 namespace {

--- a/stratum/hal/lib/tdi/dpdk/dpdk_chassis_manager_test.cc
+++ b/stratum/hal/lib/tdi/dpdk/dpdk_chassis_manager_test.cc
@@ -333,7 +333,7 @@ TEST_F(DpdkChassisManagerTest, SetHotplugParam) {
 }
 
 TEST_F(DpdkChassisManagerTest, ReplayPorts) {
-  const std::string kVendorConfigText = R"PROTO(
+  const std::string kVendorConfigText = R"pb(
     tofino_config {
       node_id_to_deflect_on_drop_configs {
         key: 7654321
@@ -363,7 +363,7 @@ TEST_F(DpdkChassisManagerTest, ReplayPorts) {
         }
       }
     }
-  )PROTO";
+  )pb";
 
   VendorConfig vendor_config;
   ASSERT_OK(ParseProtoFromString(kVendorConfigText, &vendor_config));

--- a/stratum/hal/lib/tdi/es2k/es2k_chassis_manager_test.cc
+++ b/stratum/hal/lib/tdi/es2k/es2k_chassis_manager_test.cc
@@ -357,7 +357,7 @@ TEST_F(Es2kChassisManagerTest, SetPortLoopback) {
 
 #if 0
 TEST_F(Es2kChassisManagerTest, ApplyPortShaping) {
-  const std::string kVendorConfigText = R"PROTO(
+  const std::string kVendorConfigText = R"pb(
     es2k_config {
       node_id_to_port_shaping_config {
         key: 7654321
@@ -374,7 +374,7 @@ TEST_F(Es2kChassisManagerTest, ApplyPortShaping) {
         }
       }
     }
-  )PROTO";
+  )pb";
 
   VendorConfig vendor_config;
   ASSERT_OK(ParseProtoFromString(kVendorConfigText, &vendor_config));
@@ -399,7 +399,7 @@ TEST_F(Es2kChassisManagerTest, ApplyPortShaping) {
 
 #if 0
 TEST_F(Es2kChassisManagerTest, ApplyDeflectOnDrop) {
-  const std::string kVendorConfigText = R"PROTO(
+  const std::string kVendorConfigText = R"pb(
     tofino_config {
       node_id_to_deflect_on_drop_configs {
         key: 7654321
@@ -415,7 +415,7 @@ TEST_F(Es2kChassisManagerTest, ApplyDeflectOnDrop) {
         }
       }
     }
-  )PROTO";
+  )pb";
 
   VendorConfig vendor_config;
   ASSERT_OK(ParseProtoFromString(kVendorConfigText, &vendor_config));
@@ -437,7 +437,7 @@ TEST_F(Es2kChassisManagerTest, ApplyDeflectOnDrop) {
 
 #if 0
 TEST_F(Es2kChassisManagerTest, ReplayPorts) {
-  const std::string kVendorConfigText = R"PROTO(
+  const std::string kVendorConfigText = R"pb(
     tofino_config {
       node_id_to_deflect_on_drop_configs {
         key: 7654321
@@ -467,7 +467,7 @@ TEST_F(Es2kChassisManagerTest, ReplayPorts) {
         }
       }
     }
-  )PROTO";
+  )pb";
 
   VendorConfig vendor_config;
   ASSERT_OK(ParseProtoFromString(kVendorConfigText, &vendor_config));

--- a/stratum/hal/lib/tdi/tdi_action_profile_manager_test.cc
+++ b/stratum/hal/lib/tdi/tdi_action_profile_manager_test.cc
@@ -460,7 +460,7 @@ TEST_F(TdiActionProfileManagerTest, ReadActionProfileEntryTestActionProfileId) {
       // action to take on first and only call
       .WillOnce(Return(kTdiRtTableId));
 
-  const std::string kActionProfMemberResponseText = R"PROTO(
+  const std::string kActionProfMemberResponseText = R"pb(
       entities {
         action_profile_member {
           action_profile_id: 1
@@ -474,7 +474,7 @@ TEST_F(TdiActionProfileManagerTest, ReadActionProfileEntryTestActionProfileId) {
           }
         }
       }
-    )PROTO";
+    )pb";
   ::p4::v1::ReadResponse resp;
   ASSERT_OK(ParseProtoFromString(kActionProfMemberResponseText, &resp));
 
@@ -545,7 +545,7 @@ TEST_F(TdiActionProfileManagerTest,
 
   // JSON representation of the protobuf we expect ReadProfileActionEntry()
   // to specify when it calls the writer mock.
-  const std::string kActionProfGroupResponseText = R"PROTO(
+  const std::string kActionProfGroupResponseText = R"pb(
       entities {
         action_profile_group {
           action_profile_id: 1
@@ -557,7 +557,7 @@ TEST_F(TdiActionProfileManagerTest,
           max_size: 4
         }
       }
-    )PROTO";
+    )pb";
   ::p4::v1::ReadResponse resp;
   ASSERT_OK(ParseProtoFromString(kActionProfGroupResponseText, &resp));
   EXPECT_CALL(writer_mock, Write(EqualsProto(resp))).WillOnce(Return(true));

--- a/stratum/hal/lib/tdi/tdi_counter_manager_test.cc
+++ b/stratum/hal/lib/tdi/tdi_counter_manager_test.cc
@@ -52,7 +52,7 @@ TEST_F(TdiCounterManagerTest, ModifyIndirectCounterTest) {
   EXPECT_CALL(*tdi_sde_wrapper_mock_, GetTdiRtId(kCounterId))
       .WillOnce(Return(kBfRtCounterId));
 
-  const std::string kIndirectCounterEntryText = R"PROTO(
+  const std::string kIndirectCounterEntryText = R"pb(
     counter_id: 55
     index {
       index: 100
@@ -61,7 +61,7 @@ TEST_F(TdiCounterManagerTest, ModifyIndirectCounterTest) {
       byte_count: 100
       packet_count: 200
     }
-  )PROTO";
+  )pb";
   ::p4::v1::CounterEntry entry;
   ASSERT_OK(ParseProtoFromString(kIndirectCounterEntryText, &entry));
 

--- a/stratum/hal/lib/tdi/tdi_packetio_manager_test.cc
+++ b/stratum/hal/lib/tdi/tdi_packetio_manager_test.cc
@@ -90,7 +90,7 @@ class TdiPacketioManagerTest : public ::testing::Test {
   }
 
   static constexpr int kDevice1 = 0;
-  static constexpr char kP4Info[] = R"PROTO(
+  static constexpr char kP4Info[] = R"pb(
     controller_packet_metadata {
       preamble {
         id: 67146229
@@ -138,7 +138,7 @@ class TdiPacketioManagerTest : public ::testing::Test {
         bitwidth: 16
       }
     }
-  )PROTO";
+  )pb";
 
   std::unique_ptr<TdiSdeMock> tdi_sde_wrapper_mock_;
   std::unique_ptr<TdiPacketioManager> tdi_packetio_manager_;
@@ -161,7 +161,7 @@ TEST_F(TdiPacketioManagerTest, PushForwardingPipelineConfigAndShutdown) {
 
 TEST_F(TdiPacketioManagerTest, PushInvalidPacketInConfigAndShutdown) {
   // The total length of packet-in metadata is not byte aligned
-  const char invalid_packet_in[] = R"PROTO(
+  const char invalid_packet_in[] = R"pb(
     controller_packet_metadata {
       preamble {
         id: 67146229
@@ -175,7 +175,7 @@ TEST_F(TdiPacketioManagerTest, PushInvalidPacketInConfigAndShutdown) {
         bitwidth: 9
       }
     }
-  )PROTO";
+  )pb";
   auto status = PushPipelineConfig(invalid_packet_in, false);
   EXPECT_THAT(
       status,
@@ -186,7 +186,7 @@ TEST_F(TdiPacketioManagerTest, PushInvalidPacketInConfigAndShutdown) {
 
 TEST_F(TdiPacketioManagerTest, PushInvalidPacketOutConfigAndShutdown) {
   // The total length of packet-out metadata is not byte aligned
-  const char invalid_packet_out[] = R"PROTO(
+  const char invalid_packet_out[] = R"pb(
     controller_packet_metadata {
       preamble {
         id: 67121543
@@ -200,7 +200,7 @@ TEST_F(TdiPacketioManagerTest, PushInvalidPacketOutConfigAndShutdown) {
         bitwidth: 9
       }
     }
-  )PROTO";
+  )pb";
   auto status = PushPipelineConfig(invalid_packet_out, false);
   EXPECT_THAT(
       status,
@@ -213,7 +213,7 @@ TEST_F(TdiPacketioManagerTest, PushInvalidPacketOutConfigAndShutdown) {
 TEST_F(TdiPacketioManagerTest,
        PushUnknownControllerPacketMetadataConfigAndShutdown) {
   // The unknown
-  const char p4info_with_known[] = R"PROTO(
+  const char p4info_with_known[] = R"pb(
     controller_packet_metadata {
       preamble {
         id: 1234567
@@ -235,7 +235,7 @@ TEST_F(TdiPacketioManagerTest,
         bitwidth: 8
       }
     }
-  )PROTO";
+  )pb";
   EXPECT_OK(PushPipelineConfig(p4info_with_known));
   EXPECT_OK(Shutdown());
 }
@@ -243,7 +243,7 @@ TEST_F(TdiPacketioManagerTest,
 TEST_F(TdiPacketioManagerTest, TransmitPacketAfterPipelineConfigPush) {
   EXPECT_OK(PushPipelineConfig());
   p4::v1::PacketOut packet_out;
-  const char packet_out_str[] = R"PROTO(
+  const char packet_out_str[] = R"pb(
     payload: "abcde"
     metadata {
       metadata_id: 1
@@ -261,7 +261,7 @@ TEST_F(TdiPacketioManagerTest, TransmitPacketAfterPipelineConfigPush) {
       metadata_id: 4
       value: "\xbf\x01"
     }
-  )PROTO";
+  )pb";
   EXPECT_OK(ParseProtoFromString(packet_out_str, &packet_out));
   const std::string expected_packet(
       "\0\x80\0\0\0\0\0\0\0\0\0\0\xBF\x1"
@@ -277,7 +277,7 @@ TEST_F(TdiPacketioManagerTest, TransmitInvalidPacketAfterPipelineConfigPush) {
   EXPECT_OK(PushPipelineConfig());
   p4::v1::PacketOut packet_out;
   // Missing the third metadata.
-  const char packet_out_str[] = R"PROTO(
+  const char packet_out_str[] = R"pb(
     payload: "abcde"
     metadata {
       metadata_id: 1
@@ -291,7 +291,7 @@ TEST_F(TdiPacketioManagerTest, TransmitInvalidPacketAfterPipelineConfigPush) {
       metadata_id: 3
       value: "\x0"
     }
-  )PROTO";
+  )pb";
   EXPECT_OK(ParseProtoFromString(packet_out_str, &packet_out));
   auto status = tdi_packetio_manager_->TransmitPacket(packet_out);
   EXPECT_FALSE(status.ok());
@@ -304,7 +304,7 @@ TEST_F(TdiPacketioManagerTest, TestPacketIn) {
   EXPECT_OK(PushPipelineConfig());
   auto writer = std::make_shared<WriterMock<::p4::v1::PacketIn>>();
   EXPECT_OK(tdi_packetio_manager_->RegisterPacketReceiveWriter(writer));
-  const char expected_packet_in_str[] = R"PROTO(
+  const char expected_packet_in_str[] = R"pb(
     payload: "abcde"
     metadata {
       metadata_id: 1
@@ -314,7 +314,7 @@ TEST_F(TdiPacketioManagerTest, TestPacketIn) {
       metadata_id: 2
       value: "\000"
     }
-  )PROTO";
+  )pb";
   ::p4::v1::PacketIn expected_packet_in;
   EXPECT_OK(ParseProtoFromString(expected_packet_in_str, &expected_packet_in));
   const std::string packet_from_asic(

--- a/stratum/hal/lib/tdi/tdi_pipeline_utils_test.cc
+++ b/stratum/hal/lib/tdi/tdi_pipeline_utils_test.cc
@@ -19,16 +19,16 @@ namespace stratum {
 namespace hal {
 namespace tdi {
 
-static constexpr char bf_config_1pipe_str[] = R"PROTO(
+static constexpr char bf_config_1pipe_str[] = R"pb(
   p4_name: "prog1"
   bfruntime_info: "{json: true}"
   profiles {
     profile_name: "pipe1"
     context: "{json: true}"
     binary: "<raw bin>"
-  })PROTO";
+  })pb";
 
-static constexpr char bf_config_2pipe_str[] = R"PROTO(
+static constexpr char bf_config_2pipe_str[] = R"pb(
   p4_name: "prog1"
   bfruntime_info: "{json: true}"
   profiles {
@@ -40,7 +40,7 @@ static constexpr char bf_config_2pipe_str[] = R"PROTO(
     profile_name: "pipe2"
     context: "{json: true}"
     binary: "<raw bin>"
-  })PROTO";
+  })pb";
 
 TEST(ExtractBfPipelineTest, ExtractBfPipelineConfigFromProtoSuccess) {
   BfPipelineConfig bf_config;

--- a/stratum/hal/lib/tdi/tdi_pre_manager_test.cc
+++ b/stratum/hal/lib/tdi/tdi_pre_manager_test.cc
@@ -57,7 +57,7 @@ TEST_F(TdiPreManagerTest, DeleteMulticastGroupTest) {
       .WillOnce(Return(::util::OkStatus()));
 
   // TODO(max): remove replicas, ignored on delete.
-  const std::string kMulticastGroupEntryText = R"PROTO(
+  const std::string kMulticastGroupEntryText = R"pb(
     multicast_group_entry {
       multicast_group_id: 55
       replicas {
@@ -73,7 +73,7 @@ TEST_F(TdiPreManagerTest, DeleteMulticastGroupTest) {
         instance: 0
       }
     }
-  )PROTO";
+  )pb";
   ::p4::v1::PacketReplicationEngineEntry entry;
   ASSERT_OK(ParseProtoFromString(kMulticastGroupEntryText, &entry));
 

--- a/stratum/hal/lib/tdi/tdi_table_manager_test.cc
+++ b/stratum/hal/lib/tdi/tdi_table_manager_test.cc
@@ -46,7 +46,7 @@ class TdiTableManagerTest : public ::testing::Test {
   }
 
   ::util::Status PushTestConfig() {
-    const std::string kSamplePipelineText = R"PROTO(
+    const std::string kSamplePipelineText = R"pb(
       programs {
         name: "test pipeline config",
         p4info {
@@ -133,7 +133,7 @@ class TdiTableManagerTest : public ::testing::Test {
           }
         }
       }
-    )PROTO";
+    )pb";
     TdiDeviceConfig config;
     RETURN_IF_ERROR(ParseProtoFromString(kSamplePipelineText, &config));
     return tdi_table_manager_->PushForwardingPipelineConfig(config);
@@ -177,7 +177,7 @@ TEST_F(TdiTableManagerTest, WriteDirectCounterEntryTest) {
                         std::unique_ptr<TdiSdeInterface::TableDataInterface>>(
               std::move(table_data_mock)))));
 
-  const std::string kDirectCounterEntryText = R"PROTO(
+  const std::string kDirectCounterEntryText = R"pb(
     table_entry {
       table_id: 33583783
       match {
@@ -194,7 +194,7 @@ TEST_F(TdiTableManagerTest, WriteDirectCounterEntryTest) {
       byte_count: 200
       packet_count: 100
     }
-  )PROTO";
+  )pb";
 
   ::p4::v1::DirectCounterEntry entry;
   ASSERT_OK(ParseProtoFromString(kDirectCounterEntryText, &entry));
@@ -233,7 +233,7 @@ TEST_F(TdiTableManagerTest, WriteDirectMeterEntryTest) {
                         std::unique_ptr<TdiSdeInterface::TableDataInterface>>(
               std::move(table_data_mock)))));
 
-  const std::string kDirectMeterEntryText = R"PROTO(
+  const std::string kDirectMeterEntryText = R"pb(
     table_entry {
       table_id: 33583783
       match {
@@ -252,7 +252,7 @@ TEST_F(TdiTableManagerTest, WriteDirectMeterEntryTest) {
       pir: 100
       pburst: 1000
     }
-  )PROTO";
+  )pb";
 
   ::p4::v1::DirectMeterEntry entry;
   ASSERT_OK(ParseProtoFromString(kDirectMeterEntryText, &entry));
@@ -276,7 +276,7 @@ TEST_F(TdiTableManagerTest, WriteIndirectMeterEntryTest) {
                                  Optional(kMeterIndex), false, 1, 100, 2, 200))
       .WillOnce(Return(::util::OkStatus()));
 
-  const std::string kMeterEntryText = R"PROTO(
+  const std::string kMeterEntryText = R"pb(
     meter_id: 55555
     index {
       index: 12345
@@ -287,7 +287,7 @@ TEST_F(TdiTableManagerTest, WriteIndirectMeterEntryTest) {
       pir: 2
       pburst: 200
     }
-  )PROTO";
+  )pb";
   ::p4::v1::MeterEntry entry;
   ASSERT_OK(ParseProtoFromString(kMeterEntryText, &entry));
 
@@ -299,7 +299,7 @@ TEST_F(TdiTableManagerTest, RejectMeterEntryModifyWithoutMeterId) {
   ASSERT_OK(PushTestConfig());
   auto session_mock = std::make_shared<SessionMock>();
 
-  const std::string kMeterEntryText = R"PROTO(
+  const std::string kMeterEntryText = R"pb(
     meter_id: 0
     index {
       index: 12345
@@ -310,7 +310,7 @@ TEST_F(TdiTableManagerTest, RejectMeterEntryModifyWithoutMeterId) {
       pir: 2
       pburst: 200
     }
-  )PROTO";
+  )pb";
   ::p4::v1::MeterEntry entry;
   ASSERT_OK(ParseProtoFromString(kMeterEntryText, &entry));
 
@@ -325,7 +325,7 @@ TEST_F(TdiTableManagerTest, RejectMeterEntryInsertDelete) {
   ASSERT_OK(PushTestConfig());
   auto session_mock = std::make_shared<SessionMock>();
 
-  const std::string kMeterEntryText = R"PROTO(
+  const std::string kMeterEntryText = R"pb(
     meter_id: 55555
     index {
       index: 12345
@@ -336,7 +336,7 @@ TEST_F(TdiTableManagerTest, RejectMeterEntryInsertDelete) {
       pir: 2
       pburst: 200
     }
-  )PROTO";
+  )pb";
   ::p4::v1::MeterEntry entry;
   ASSERT_OK(ParseProtoFromString(kMeterEntryText, &entry));
 
@@ -376,7 +376,7 @@ TEST_F(TdiTableManagerTest, ReadSingleIndirectMeterEntryTest) {
                         SetArgPointee<6>(cbursts), SetArgPointee<7>(pirs),
                         SetArgPointee<8>(pbursts), SetArgPointee<9>(in_pps),
                         Return(::util::OkStatus())));
-    const std::string kMeterResponseText = R"PROTO(
+    const std::string kMeterResponseText = R"pb(
       entities {
         meter_entry {
           meter_id: 55555
@@ -391,18 +391,18 @@ TEST_F(TdiTableManagerTest, ReadSingleIndirectMeterEntryTest) {
           }
         }
       }
-    )PROTO";
+    )pb";
     ::p4::v1::ReadResponse resp;
     ASSERT_OK(ParseProtoFromString(kMeterResponseText, &resp));
     EXPECT_CALL(writer_mock, Write(EqualsProto(resp))).WillOnce(Return(true));
   }
 
-  const std::string kMeterEntryText = R"PROTO(
+  const std::string kMeterEntryText = R"pb(
     meter_id: 55555
     index {
       index: 12345
     }
-  )PROTO";
+  )pb";
   ::p4::v1::MeterEntry entry;
   ASSERT_OK(ParseProtoFromString(kMeterEntryText, &entry));
 
@@ -415,7 +415,7 @@ TEST_F(TdiTableManagerTest, RejectMeterEntryReadWithoutId) {
   auto session_mock = std::make_shared<SessionMock>();
   WriterMock<::p4::v1::ReadResponse> writer_mock;
 
-  const std::string kMeterEntryText = R"PROTO(
+  const std::string kMeterEntryText = R"pb(
     meter_id: 0
     index {
       index: 12345
@@ -426,7 +426,7 @@ TEST_F(TdiTableManagerTest, RejectMeterEntryReadWithoutId) {
       pir: 2
       pburst: 200
     }
-  )PROTO";
+  )pb";
   ::p4::v1::MeterEntry entry;
   ASSERT_OK(ParseProtoFromString(kMeterEntryText, &entry));
 

--- a/stratum/hal/lib/tdi/tofino/tofino_chassis_manager_test.cc
+++ b/stratum/hal/lib/tdi/tofino/tofino_chassis_manager_test.cc
@@ -344,7 +344,7 @@ TEST_F(TofinoChassisManagerTest, SetPortLoopback) {
 }
 
 TEST_F(TofinoChassisManagerTest, ApplyPortShaping) {
-  const std::string kVendorConfigText = R"PROTO(
+  const std::string kVendorConfigText = R"pb(
     tofino_config {
       node_id_to_port_shaping_config {
         key: 7654321
@@ -361,7 +361,7 @@ TEST_F(TofinoChassisManagerTest, ApplyPortShaping) {
         }
       }
     }
-  )PROTO";
+  )pb";
 
   VendorConfig vendor_config;
   ASSERT_OK(ParseProtoFromString(kVendorConfigText, &vendor_config));
@@ -386,7 +386,7 @@ TEST_F(TofinoChassisManagerTest, ApplyPortShaping) {
 }
 
 TEST_F(TofinoChassisManagerTest, ApplyDeflectOnDrop) {
-  const std::string kVendorConfigText = R"PROTO(
+  const std::string kVendorConfigText = R"pb(
     tofino_config {
       node_id_to_deflect_on_drop_configs {
         key: 7654321
@@ -402,7 +402,7 @@ TEST_F(TofinoChassisManagerTest, ApplyDeflectOnDrop) {
         }
       }
     }
-  )PROTO";
+  )pb";
 
   VendorConfig vendor_config;
   ASSERT_OK(ParseProtoFromString(kVendorConfigText, &vendor_config));
@@ -422,7 +422,7 @@ TEST_F(TofinoChassisManagerTest, ApplyDeflectOnDrop) {
 }
 
 TEST_F(TofinoChassisManagerTest, ReplayPorts) {
-  const std::string kVendorConfigText = R"PROTO(
+  const std::string kVendorConfigText = R"pb(
     tofino_config {
       node_id_to_deflect_on_drop_configs {
         key: 7654321
@@ -452,7 +452,7 @@ TEST_F(TofinoChassisManagerTest, ReplayPorts) {
         }
       }
     }
-  )PROTO";
+  )pb";
 
   VendorConfig vendor_config;
   ASSERT_OK(ParseProtoFromString(kVendorConfigText, &vendor_config));

--- a/stratum/lib/test_utils/p4_proto_builders_test.cc
+++ b/stratum/lib/test_utils/p4_proto_builders_test.cc
@@ -23,21 +23,21 @@ TEST(P4ProtoBuildersTest, Table) {
   P4ControlTableRef expected;
   CHECK_OK(
       ParseProtoFromString(
-          R"PROTO(table_id: 1234
+          R"pb(table_id: 1234
                   table_name: "table_1234"
-                  pipeline_stage: EGRESS_ACL)PROTO", &expected));
+                  pipeline_stage: EGRESS_ACL)pb", &expected));
   EXPECT_THAT(Table(1234, P4Annotation::EGRESS_ACL), EqualsProto(expected));
 }
 
 TEST(P4ProtoBuildersTest, ApplyTable_FromId) {
   P4ControlStatement expected;
   CHECK_OK(ParseProtoFromString(
-      R"PROTO(
+      R"pb(
         apply {
           table_id: 1234
           table_name: "table_1234"
           pipeline_stage: EGRESS_ACL
-        })PROTO", &expected));
+        })pb", &expected));
   EXPECT_THAT(ApplyTable(1234, P4Annotation::EGRESS_ACL),
               EqualsProto(expected));
 }
@@ -45,40 +45,40 @@ TEST(P4ProtoBuildersTest, ApplyTable_FromId) {
 TEST(P4ProtoBuildersTest, ApplyTable_FromTable) {
   ::p4::config::v1::Table table;
   CHECK_OK(ParseProtoFromString(
-      R"PROTO(preamble { id: 1234 name: "HelloWorld" })PROTO", &table));
+      R"pb(preamble { id: 1234 name: "HelloWorld" })pb", &table));
   P4ControlStatement expected;
   CHECK_OK(ParseProtoFromString(
-      R"PROTO(
+      R"pb(
         apply {
           table_id: 1234
           table_name: "HelloWorld"
           pipeline_stage: EGRESS_ACL
-        })PROTO", &expected));
+        })pb", &expected));
   EXPECT_THAT(ApplyTable(table, P4Annotation::EGRESS_ACL),
               EqualsProto(expected));
 }
 
 TEST(P4ProtoBuildersTest, ApplyTable_FromPreamble) {
   ::p4::config::v1::Preamble preamble;
-  CHECK_OK(ParseProtoFromString(R"PROTO(id: 1234 name: "HelloWorld")PROTO",
+  CHECK_OK(ParseProtoFromString(R"pb(id: 1234 name: "HelloWorld")pb",
                                 &preamble));
   P4ControlStatement expected;
   CHECK_OK(ParseProtoFromString(
-      R"PROTO(
+      R"pb(
         apply {
           table_id: 1234
           table_name: "HelloWorld"
           pipeline_stage: EGRESS_ACL
-        })PROTO", &expected));
+        })pb", &expected));
   EXPECT_THAT(ApplyTable(preamble, P4Annotation::EGRESS_ACL),
               EqualsProto(expected));
 }
 
 TEST(P4ProtoBuildersTest, ApplyNested_FromRefs) {
   std::vector<std::string> table_strings = {
-    R"PROTO(table_id: 1 table_name: "t1" pipeline_stage: VLAN_ACL)PROTO",
-    R"PROTO(table_id: 2 table_name: "t2" pipeline_stage: VLAN_ACL)PROTO",
-    R"PROTO(table_id: 3 table_name: "t3" pipeline_stage: VLAN_ACL)PROTO",
+    R"pb(table_id: 1 table_name: "t1" pipeline_stage: VLAN_ACL)pb",
+    R"pb(table_id: 2 table_name: "t2" pipeline_stage: VLAN_ACL)pb",
+    R"pb(table_id: 3 table_name: "t3" pipeline_stage: VLAN_ACL)pb",
   };
   std::vector<hal::P4ControlTableRef> tables;
   for (const std::string& table_string : table_strings) {
@@ -90,7 +90,7 @@ TEST(P4ProtoBuildersTest, ApplyNested_FromRefs) {
   P4ControlBlock expected;
   CHECK_OK(ParseProtoFromString(
       absl::Substitute(
-          R"PROTO(
+          R"pb(
             statements { apply { $0 } }
             statements {
               branch {
@@ -106,7 +106,7 @@ TEST(P4ProtoBuildersTest, ApplyNested_FromRefs) {
                 }
               }
             }
-          )PROTO", table_strings[0], table_strings[1], table_strings[2]),
+          )pb", table_strings[0], table_strings[1], table_strings[2]),
       &expected));
 
   EXPECT_THAT(ApplyNested(tables), EqualsProto(expected));
@@ -114,9 +114,9 @@ TEST(P4ProtoBuildersTest, ApplyNested_FromRefs) {
 
 TEST(P4ProtoBuildersTest, ApplyNested_FromTables) {
   std::vector<std::string> table_strings = {
-      R"PROTO(preamble { id: 1 name: "t1" })PROTO",
-      R"PROTO(preamble { id: 2 name: "t2" })PROTO",
-      R"PROTO(preamble { id: 3 name: "t3" })PROTO",
+      R"pb(preamble { id: 1 name: "t1" })pb",
+      R"pb(preamble { id: 2 name: "t2" })pb",
+      R"pb(preamble { id: 3 name: "t3" })pb",
   };
   std::vector<::p4::config::v1::Table> tables;
   for (const std::string& table_string : table_strings) {
@@ -126,15 +126,15 @@ TEST(P4ProtoBuildersTest, ApplyNested_FromTables) {
   }
 
   std::vector<std::string> ref_strings = {
-    R"PROTO(table_id: 1 table_name: "t1" pipeline_stage: VLAN_ACL)PROTO",
-    R"PROTO(table_id: 2 table_name: "t2" pipeline_stage: VLAN_ACL)PROTO",
-    R"PROTO(table_id: 3 table_name: "t3" pipeline_stage: VLAN_ACL)PROTO",
+    R"pb(table_id: 1 table_name: "t1" pipeline_stage: VLAN_ACL)pb",
+    R"pb(table_id: 2 table_name: "t2" pipeline_stage: VLAN_ACL)pb",
+    R"pb(table_id: 3 table_name: "t3" pipeline_stage: VLAN_ACL)pb",
   };
 
   P4ControlBlock expected;
   CHECK_OK(ParseProtoFromString(
       absl::Substitute(
-          R"PROTO(
+          R"pb(
             statements { apply { $0 } }
             statements {
               branch {
@@ -150,7 +150,7 @@ TEST(P4ProtoBuildersTest, ApplyNested_FromTables) {
                 }
               }
             }
-          )PROTO", ref_strings[0], ref_strings[1], ref_strings[2]),
+          )pb", ref_strings[0], ref_strings[1], ref_strings[2]),
       &expected));
 
   EXPECT_THAT(ApplyNested(tables, P4Annotation::VLAN_ACL),
@@ -164,15 +164,15 @@ TEST(P4ProtoBuildersTest, ApplyNested_Empty) {
 
 TEST(P4ProtoBuildersTest, ApplyNested_SingleTable) {
   std::string table_string =
-      R"PROTO(table_id: 1 table_name: "t1" pipeline_stage: VLAN_ACL)PROTO";
+      R"pb(table_id: 1 table_name: "t1" pipeline_stage: VLAN_ACL)pb";
   hal::P4ControlTableRef table;
   CHECK_OK(ParseProtoFromString(table_string, &table));
 
   P4ControlBlock expected;
   CHECK_OK(ParseProtoFromString(absl::Substitute(
-                                    R"PROTO(
+                                    R"pb(
                                       statements { apply { $0 } }
-                                    )PROTO", table_string),
+                                    )pb", table_string),
                                 &expected));
 
   EXPECT_THAT(ApplyNested({table}), EqualsProto(expected));
@@ -212,26 +212,26 @@ TEST(P4ProtoBuildersTest, P4ControlTableRefBuilderStage) {
 TEST(P4ProtoBuildersTest, P4ControlTableRefBuilderFromPreamble) {
   P4ControlTableRef expected;
   CHECK_OK(ParseProtoFromString(
-      R"PROTO(table_id: 1234 table_name: "table")PROTO", &expected));
+      R"pb(table_id: 1234 table_name: "table")pb", &expected));
 
   ::p4::config::v1::Preamble preamble;
   CHECK_OK(
-      ParseProtoFromString(R"PROTO(id: 1234 name: "table")PROTO", &preamble));
+      ParseProtoFromString(R"pb(id: 1234 name: "table")pb", &preamble));
   EXPECT_THAT(P4ControlTableRefBuilder(preamble).Build(),
               EqualsProto(expected));
 }
 
 TEST(P4ProtoBuildersTest, P4ControlTableRefBuilderFromPreambleAndStage) {
   P4ControlTableRef expected;
-  CHECK_OK(ParseProtoFromString(R"PROTO(
+  CHECK_OK(ParseProtoFromString(R"pb(
     table_id: 1234
     table_name: "table"
     pipeline_stage: VLAN_ACL
-  )PROTO", &expected));
+  )pb", &expected));
 
   ::p4::config::v1::Preamble preamble;
   CHECK_OK(
-      ParseProtoFromString(R"PROTO(id: 1234 name: "table")PROTO", &preamble));
+      ParseProtoFromString(R"pb(id: 1234 name: "table")pb", &preamble));
   EXPECT_THAT(
       P4ControlTableRefBuilder(preamble, P4Annotation::VLAN_ACL).Build(),
       EqualsProto(expected));
@@ -240,35 +240,35 @@ TEST(P4ProtoBuildersTest, P4ControlTableRefBuilderFromPreambleAndStage) {
 TEST(P4ProtoBuildersTest, P4ControlTableRefBuilderFromTable) {
   P4ControlTableRef expected;
   CHECK_OK(ParseProtoFromString(
-      R"PROTO(table_id: 1234 table_name: "table")PROTO", &expected));
+      R"pb(table_id: 1234 table_name: "table")pb", &expected));
 
   ::p4::config::v1::Table table;
   CHECK_OK(ParseProtoFromString(
-      R"PROTO(preamble { id: 1234 name: "table" })PROTO", &table));
+      R"pb(preamble { id: 1234 name: "table" })pb", &table));
   EXPECT_THAT(P4ControlTableRefBuilder(table).Build(), EqualsProto(expected));
 }
 
 TEST(P4ProtoBuildersTest, P4ControlTableRefBuilderFromTableAndStage) {
   P4ControlTableRef expected;
-  CHECK_OK(ParseProtoFromString(R"PROTO(
+  CHECK_OK(ParseProtoFromString(R"pb(
     table_id: 1234
     table_name: "table"
     pipeline_stage: VLAN_ACL
-  )PROTO", &expected));
+  )pb", &expected));
 
   ::p4::config::v1::Table table;
   CHECK_OK(ParseProtoFromString(
-      R"PROTO(preamble { id: 1234 name: "table" })PROTO", &table));
+      R"pb(preamble { id: 1234 name: "table" })pb", &table));
   EXPECT_THAT(P4ControlTableRefBuilder(table, P4Annotation::VLAN_ACL).Build(),
               EqualsProto(expected));
 }
 
 TEST(P4ProtoBuildersTest, P4ControlTableRefBuilderMixed) {
   P4ControlTableRef expected;
-  CHECK_OK(ParseProtoFromString(R"PROTO(
+  CHECK_OK(ParseProtoFromString(R"pb(
     table_id: 1234
     table_name: "table"
-    pipeline_stage: VLAN_ACL)PROTO", &expected));
+    pipeline_stage: VLAN_ACL)pb", &expected));
 
   EXPECT_THAT(P4ControlTableRefBuilder()
                   .Id(1234)
@@ -289,9 +289,9 @@ TEST(P4ProtoBuildersTest, HitBuilderOnHit) {
   P4ControlStatement expected;
   CHECK_OK(ParseProtoFromString(
       absl::Substitute(
-          R"PROTO(
+          R"pb(
             branch { condition { hit { $0 } } true_block { statements { $1 } } }
-          )PROTO", Table(1).ShortDebugString().c_str(),
+          )pb", Table(1).ShortDebugString().c_str(),
           ApplyTable(2).ShortDebugString().c_str()),
       &expected));
 
@@ -302,12 +302,12 @@ TEST(P4ProtoBuildersTest, HitBuilderOnHit) {
 TEST(P4ProtoBuildersTest, HitBuilderOnHitUseFalse) {
   P4ControlStatement expected;
   CHECK_OK(ParseProtoFromString(
-      absl::Substitute(R"PROTO(
+      absl::Substitute(R"pb(
         branch {
           condition { not_operator: true hit { $0 } }
           false_block { statements { $1 } }
         }
-      )PROTO", Table(1).ShortDebugString().c_str(),
+      )pb", Table(1).ShortDebugString().c_str(),
                        ApplyTable(2).ShortDebugString().c_str()),
       &expected));
 
@@ -318,12 +318,12 @@ TEST(P4ProtoBuildersTest, HitBuilderOnHitUseFalse) {
 TEST(P4ProtoBuildersTest, HitBuilderOnMiss) {
   P4ControlStatement expected;
   CHECK_OK(ParseProtoFromString(
-      absl::Substitute(R"PROTO(
+      absl::Substitute(R"pb(
         branch {
           condition { not_operator: true hit { $0 } }
           true_block { statements { $1 } }
         }
-      )PROTO", Table(1).ShortDebugString().c_str(),
+      )pb", Table(1).ShortDebugString().c_str(),
                        ApplyTable(2).ShortDebugString().c_str()),
       &expected));
 
@@ -334,12 +334,12 @@ TEST(P4ProtoBuildersTest, HitBuilderOnMiss) {
 TEST(P4ProtoBuildersTest, HitBuilderOnMissUseFalse) {
   P4ControlStatement expected;
   CHECK_OK(ParseProtoFromString(
-      absl::Substitute(R"PROTO(
+      absl::Substitute(R"pb(
         branch {
           condition { not_operator: false hit { $0 } }
           false_block { statements { $1 } }
         }
-      )PROTO", Table(1).ShortDebugString().c_str(),
+      )pb", Table(1).ShortDebugString().c_str(),
                        ApplyTable(2).ShortDebugString().c_str()),
       &expected));
 
@@ -351,12 +351,12 @@ TEST(P4ProtoBuildersTest, HitBuilderOnMissUseFalse) {
 TEST(P4ProtoBuildersTest, HitBuilderOnMissOverwritesOnHit) {
   P4ControlStatement expected;
   CHECK_OK(ParseProtoFromString(
-      absl::Substitute(R"PROTO(
+      absl::Substitute(R"pb(
         branch {
           condition { not_operator: false hit { $0 } }
           false_block { statements { $1 } }
         }
-      )PROTO", Table(1).ShortDebugString().c_str(),
+      )pb", Table(1).ShortDebugString().c_str(),
                        ApplyTable(2).ShortDebugString().c_str()),
       &expected));
 
@@ -373,9 +373,9 @@ TEST(P4ProtoBuildersTest, HitBuilderOnHitOverwritesOnMiss) {
   P4ControlStatement expected;
   CHECK_OK(ParseProtoFromString(
       absl::Substitute(
-          R"PROTO(
+          R"pb(
             branch { condition { hit { $0 } } true_block { statements { $1 } } }
-          )PROTO", Table(1).ShortDebugString().c_str(),
+          )pb", Table(1).ShortDebugString().c_str(),
           ApplyTable(2).ShortDebugString().c_str()),
       &expected));
 
@@ -388,9 +388,9 @@ TEST(P4ProtoBuildersTest, HitBuilderControlBlock) {
   P4ControlStatement expected;
   CHECK_OK(ParseProtoFromString(
       absl::Substitute(
-          R"PROTO(
+          R"pb(
             branch { condition { hit { $0 } } true_block { statements { $1 } } }
-          )PROTO", Table(1).ShortDebugString().c_str(),
+          )pb", Table(1).ShortDebugString().c_str(),
           ApplyTable(2).ShortDebugString().c_str()),
       &expected));
 
@@ -403,12 +403,12 @@ TEST(P4ProtoBuildersTest, HitBuilderControlBlock) {
 TEST(P4ProtoBuildersTest, HitBuilderMultipleActions) {
   P4ControlStatement expected;
   CHECK_OK(ParseProtoFromString(
-      absl::Substitute(R"PROTO(
+      absl::Substitute(R"pb(
         branch {
           condition { not_operator: true hit { $0 } }
           true_block { statements { $1 } statements { $2 } }
         }
-      )PROTO", Table(1).ShortDebugString().c_str(),
+      )pb", Table(1).ShortDebugString().c_str(),
                        ApplyTable(2).ShortDebugString().c_str(),
                        ApplyTable(3).ShortDebugString().c_str()),
       &expected));
@@ -421,7 +421,7 @@ TEST(P4ProtoBuildersTest, HitBuilderMultipleActions) {
 // IsValidBuilder tests.
 TEST(P4ProtoBuildersTest, IsValidBuilderEmpty) {
   P4ControlStatement expected;
-  CHECK_OK(ParseProtoFromString(R"PROTO(
+  CHECK_OK(ParseProtoFromString(R"pb(
     branch {
       condition {
         is_valid {
@@ -430,7 +430,7 @@ TEST(P4ProtoBuildersTest, IsValidBuilderEmpty) {
         }
       }
     }
-  )PROTO", &expected));
+  )pb", &expected));
 
   EXPECT_THAT(IsValidBuilder().Build(), EqualsProto(expected));
 }
@@ -439,7 +439,7 @@ TEST(P4ProtoBuildersTest, IsValidBuilderEmpty) {
 TEST(P4ProtoBuildersTest, IsValidBuilderValidControlBlock) {
   P4ControlStatement expected;
   CHECK_OK(ParseProtoFromString(
-      absl::Substitute(R"PROTO(
+      absl::Substitute(R"pb(
         branch {
           condition {
             is_valid {
@@ -449,7 +449,7 @@ TEST(P4ProtoBuildersTest, IsValidBuilderValidControlBlock) {
           }
           true_block { statements { $0 } }
         }
-      )PROTO", ApplyTable(1).ShortDebugString().c_str()), &expected));
+      )pb", ApplyTable(1).ShortDebugString().c_str()), &expected));
   hal::P4ControlBlock control_block;
   *control_block.add_statements() = ApplyTable(1);
   EXPECT_THAT(IsValidBuilder().ValidControlBlock(control_block).Build(),
@@ -459,7 +459,7 @@ TEST(P4ProtoBuildersTest, IsValidBuilderValidControlBlock) {
 TEST(P4ProtoBuildersTest, IsValidBuilderInvalidControlBlock) {
   P4ControlStatement expected;
   CHECK_OK(ParseProtoFromString(
-      absl::Substitute(R"PROTO(
+      absl::Substitute(R"pb(
         branch {
           condition {
             is_valid {
@@ -469,7 +469,7 @@ TEST(P4ProtoBuildersTest, IsValidBuilderInvalidControlBlock) {
           }
           false_block { statements { $0 } }
         }
-      )PROTO", ApplyTable(1).ShortDebugString().c_str()), &expected));
+      )pb", ApplyTable(1).ShortDebugString().c_str()), &expected));
   hal::P4ControlBlock control_block;
   *control_block.add_statements() = ApplyTable(1);
   EXPECT_THAT(IsValidBuilder().InvalidControlBlock(control_block).Build(),
@@ -479,7 +479,7 @@ TEST(P4ProtoBuildersTest, IsValidBuilderInvalidControlBlock) {
 TEST(P4ProtoBuildersTest, IsValidBuilderDoIfValid_Statement) {
   P4ControlStatement expected;
   CHECK_OK(ParseProtoFromString(
-      absl::Substitute(R"PROTO(
+      absl::Substitute(R"pb(
         branch {
           condition {
             is_valid {
@@ -489,7 +489,7 @@ TEST(P4ProtoBuildersTest, IsValidBuilderDoIfValid_Statement) {
           }
           true_block { statements { $0 } }
         }
-      )PROTO", ApplyTable(1).ShortDebugString().c_str()), &expected));
+      )pb", ApplyTable(1).ShortDebugString().c_str()), &expected));
   EXPECT_THAT(IsValidBuilder().DoIfValid(ApplyTable(1)).Build(),
               EqualsProto(expected));
 }
@@ -501,7 +501,7 @@ TEST(P4ProtoBuildersTest, IsValidBuilderDoIfValid_Block) {
   P4ControlStatement expected;
   CHECK_OK(ParseProtoFromString(
       absl::Substitute(
-          R"PROTO(
+          R"pb(
             branch {
               condition {
                 is_valid {
@@ -511,7 +511,7 @@ TEST(P4ProtoBuildersTest, IsValidBuilderDoIfValid_Block) {
               }
               true_block { statements { $0 } statements { $1 } }
             }
-          )PROTO", ApplyTable(1).ShortDebugString().c_str(),
+          )pb", ApplyTable(1).ShortDebugString().c_str(),
           ApplyTable(2).ShortDebugString().c_str()),
       &expected));
   EXPECT_THAT(
@@ -522,7 +522,7 @@ TEST(P4ProtoBuildersTest, IsValidBuilderDoIfValid_Block) {
 TEST(P4ProtoBuildersTest, IsValidBuilderDoIfInvalid_Statement) {
   P4ControlStatement expected;
   CHECK_OK(ParseProtoFromString(
-      absl::Substitute(R"PROTO(
+      absl::Substitute(R"pb(
         branch {
           condition {
             is_valid {
@@ -532,7 +532,7 @@ TEST(P4ProtoBuildersTest, IsValidBuilderDoIfInvalid_Statement) {
           }
           false_block { statements { $0 } }
         }
-      )PROTO", ApplyTable(1).ShortDebugString().c_str()), &expected));
+      )pb", ApplyTable(1).ShortDebugString().c_str()), &expected));
   EXPECT_THAT(IsValidBuilder().DoIfInvalid(ApplyTable(1)).Build(),
               EqualsProto(expected));
 }
@@ -544,7 +544,7 @@ TEST(P4ProtoBuildersTest, IsValidBuilderDoIfInvalid_Block) {
   P4ControlStatement expected;
   CHECK_OK(ParseProtoFromString(
       absl::Substitute(
-          R"PROTO(
+          R"pb(
             branch {
               condition {
                 is_valid {
@@ -554,7 +554,7 @@ TEST(P4ProtoBuildersTest, IsValidBuilderDoIfInvalid_Block) {
               }
               false_block { statements { $0 } statements { $1 } }
             }
-          )PROTO", ApplyTable(1).ShortDebugString().c_str(),
+          )pb", ApplyTable(1).ShortDebugString().c_str(),
           ApplyTable(2).ShortDebugString().c_str()),
       &expected));
   EXPECT_THAT(
@@ -565,7 +565,7 @@ TEST(P4ProtoBuildersTest, IsValidBuilderDoIfInvalid_Block) {
 TEST(P4ProtoBuildersTest, IsValidBuilderDoIfValidMultipleActions) {
   P4ControlStatement expected;
   CHECK_OK(ParseProtoFromString(
-      absl::Substitute(R"PROTO(
+      absl::Substitute(R"pb(
         branch {
           condition {
             is_valid {
@@ -575,7 +575,7 @@ TEST(P4ProtoBuildersTest, IsValidBuilderDoIfValidMultipleActions) {
           }
           true_block { statements { $0 } statements { $1 } }
         }
-      )PROTO", ApplyTable(1).ShortDebugString().c_str(),
+      )pb", ApplyTable(1).ShortDebugString().c_str(),
                        ApplyTable(2).ShortDebugString().c_str()),
       &expected));
   EXPECT_THAT(IsValidBuilder()
@@ -588,7 +588,7 @@ TEST(P4ProtoBuildersTest, IsValidBuilderDoIfValidMultipleActions) {
 TEST(P4ProtoBuildersTest, IsValidBuilderDoIfInvalidMultipleActions) {
   P4ControlStatement expected;
   CHECK_OK(ParseProtoFromString(
-      absl::Substitute(R"PROTO(
+      absl::Substitute(R"pb(
         branch {
           condition {
             is_valid {
@@ -598,7 +598,7 @@ TEST(P4ProtoBuildersTest, IsValidBuilderDoIfInvalidMultipleActions) {
           }
           false_block { statements { $0 } statements { $1 } }
         }
-      )PROTO", ApplyTable(1).ShortDebugString().c_str(),
+      )pb", ApplyTable(1).ShortDebugString().c_str(),
                        ApplyTable(2).ShortDebugString().c_str()),
       &expected));
   EXPECT_THAT(IsValidBuilder()
@@ -611,7 +611,7 @@ TEST(P4ProtoBuildersTest, IsValidBuilderDoIfInvalidMultipleActions) {
 TEST(P4ProtoBuildersTest, IsValidBuilderDoIfValidUseNot) {
   P4ControlStatement expected;
   CHECK_OK(ParseProtoFromString(
-      absl::Substitute(R"PROTO(
+      absl::Substitute(R"pb(
         branch {
           condition {
             not_operator: true
@@ -622,7 +622,7 @@ TEST(P4ProtoBuildersTest, IsValidBuilderDoIfValidUseNot) {
           }
           false_block { statements { $0 } }
         }
-      )PROTO", ApplyTable(1).ShortDebugString().c_str()), &expected));
+      )pb", ApplyTable(1).ShortDebugString().c_str()), &expected));
   EXPECT_THAT(IsValidBuilder().UseNot().DoIfValid(ApplyTable(1)).Build(),
               EqualsProto(expected));
 }
@@ -630,7 +630,7 @@ TEST(P4ProtoBuildersTest, IsValidBuilderDoIfValidUseNot) {
 TEST(P4ProtoBuildersTest, IsValidBuilderDoIfInvalidUseNot) {
   P4ControlStatement expected;
   CHECK_OK(ParseProtoFromString(
-      absl::Substitute(R"PROTO(
+      absl::Substitute(R"pb(
         branch {
           condition {
             not_operator: true
@@ -641,7 +641,7 @@ TEST(P4ProtoBuildersTest, IsValidBuilderDoIfInvalidUseNot) {
           }
           true_block { statements { $0 } }
         }
-      )PROTO", ApplyTable(1).ShortDebugString().c_str()), &expected));
+      )pb", ApplyTable(1).ShortDebugString().c_str()), &expected));
   EXPECT_THAT(IsValidBuilder().DoIfInvalid(ApplyTable(1)).UseNot().Build(),
               EqualsProto(expected));
 }
@@ -649,7 +649,7 @@ TEST(P4ProtoBuildersTest, IsValidBuilderDoIfInvalidUseNot) {
 TEST(P4ProtoBuildersTest, IsValidBuilderHeader) {
   P4ControlStatement expected;
   CHECK_OK(ParseProtoFromString(
-      R"PROTO(
+      R"pb(
         branch {
           condition {
             is_valid {
@@ -658,7 +658,7 @@ TEST(P4ProtoBuildersTest, IsValidBuilderHeader) {
             }
           }
         }
-      )PROTO", &expected));
+      )pb", &expected));
   EXPECT_THAT(IsValidBuilder().Header(P4_HEADER_IPV4).Build(),
               EqualsProto(expected));
 }
@@ -666,7 +666,7 @@ TEST(P4ProtoBuildersTest, IsValidBuilderHeader) {
 TEST(P4ProtoBuildersTest, IsValidBuilderComplexBlock) {
   P4ControlStatement expected;
   CHECK_OK(ParseProtoFromString(
-      absl::Substitute(R"PROTO(
+      absl::Substitute(R"pb(
         branch {
           condition {
             not_operator: true
@@ -678,7 +678,7 @@ TEST(P4ProtoBuildersTest, IsValidBuilderComplexBlock) {
           true_block { statements { $0 } statements { $1 } }
           false_block { statements { $2 } statements { $3 } }
         }
-      )PROTO", ApplyTable(1).ShortDebugString().c_str(),
+      )pb", ApplyTable(1).ShortDebugString().c_str(),
                        ApplyTable(2).ShortDebugString().c_str(),
                        ApplyTable(3).ShortDebugString().c_str(),
                        ApplyTable(4).ShortDebugString().c_str()),


### PR DESCRIPTION
- Rename raw literal string delimiter used to define protobuf contents from "PROTO" to "pb", to track an upstream change.