### PR TITLE
Rename ReplayPortsConfig method to ReplayChassisConfig

### DIFF
--- a/stratum/hal/lib/tdi/dpdk/dpdk_chassis_manager.cc
+++ b/stratum/hal/lib/tdi/dpdk/dpdk_chassis_manager.cc
@@ -831,7 +831,7 @@ DpdkChassisManager::GetNodeIdToDeviceMap() const {
   return node_id_to_device_;
 }
 
-::util::Status DpdkChassisManager::ReplayPortsConfig(uint64 node_id) {
+::util::Status DpdkChassisManager::ReplayChassisConfig(uint64 node_id) {
   if (!initialized_) {
     return MAKE_ERROR(ERR_NOT_INITIALIZED) << "Not initialized!";
   }

--- a/stratum/hal/lib/tdi/dpdk/dpdk_chassis_manager.h
+++ b/stratum/hal/lib/tdi/dpdk/dpdk_chassis_manager.h
@@ -60,7 +60,7 @@ class DpdkChassisManager {
                                          PortCounters* counters)
       SHARED_LOCKS_REQUIRED(chassis_lock);
 
-  virtual ::util::Status ReplayPortsConfig(uint64 node_id)
+  virtual ::util::Status ReplayChassisConfig(uint64 node_id)
       EXCLUSIVE_LOCKS_REQUIRED(chassis_lock);
 
   virtual ::util::StatusOr<std::map<uint64, int>> GetNodeIdToDeviceMap() const

--- a/stratum/hal/lib/tdi/dpdk/dpdk_chassis_manager_mock.h
+++ b/stratum/hal/lib/tdi/dpdk/dpdk_chassis_manager_mock.h
@@ -34,7 +34,7 @@ class DpdkChassisManagerMock : public DpdkChassisManager {
                ::util::StatusOr<absl::Time>(uint64 node_id, uint32 port_id));
   MOCK_METHOD3(GetPortCounters, ::util::Status(uint64 node_id, uint32 port_id,
                                                PortCounters* counters));
-  //  MOCK_METHOD1(ReplayPortsConfig, ::util::Status(uint64 node_id));
+  //  MOCK_METHOD1(ReplayChassisConfig, ::util::Status(uint64 node_id));
   //  MOCK_METHOD3(GetFrontPanelPortInfo,
   //               ::util::Status(uint64 node_id, uint32 port_id,
   //                              FrontPanelPortInfo* fp_port_info));

--- a/stratum/hal/lib/tdi/dpdk/dpdk_chassis_manager_test.cc
+++ b/stratum/hal/lib/tdi/dpdk/dpdk_chassis_manager_test.cc
@@ -212,9 +212,9 @@ class DpdkChassisManagerTest : public ::testing::Test {
     return ::util::OkStatus();
   }
 
-  ::util::Status ReplayPortsConfig(uint64 node_id) {
+  ::util::Status ReplayChassisConfig(uint64 node_id) {
     absl::WriterMutexLock l(&chassis_lock);
-    return chassis_manager_->ReplayPortsConfig(node_id);
+    return chassis_manager_->ReplayChassisConfig(node_id);
   }
 
   ::util::Status PushBaseChassisConfig() {
@@ -376,7 +376,7 @@ TEST_F(DpdkChassisManagerTest, ReplayPorts) {
   EXPECT_ADD_PORT_CALL(kDevice, sdkPortId, _);
   EXPECT_ENABLE_PORT_CALL(kDevice, sdkPortId);
 
-  EXPECT_OK(ReplayPortsConfig(kNodeId));
+  EXPECT_OK(ReplayChassisConfig(kNodeId));
 
   ASSERT_OK(ShutdownAndTestCleanState());
 }

--- a/stratum/hal/lib/tdi/es2k/es2k_chassis_manager.cc
+++ b/stratum/hal/lib/tdi/es2k/es2k_chassis_manager.cc
@@ -780,7 +780,7 @@ Es2kChassisManager::GetNodeIdToDeviceMap() const {
 
 // TODO: Revisit this, port shaping and drop deflect removed. Check with Sandeep
 // once
-::util::Status Es2kChassisManager::ReplayPortsConfig(uint64 node_id) {
+::util::Status Es2kChassisManager::ReplayChassisConfig(uint64 node_id) {
   if (!initialized_) {
     return MAKE_ERROR(ERR_NOT_INITIALIZED) << "Not initialized!";
   }

--- a/stratum/hal/lib/tdi/es2k/es2k_chassis_manager.h
+++ b/stratum/hal/lib/tdi/es2k/es2k_chassis_manager.h
@@ -59,7 +59,7 @@ class Es2kChassisManager {
                                          PortCounters* counters)
       SHARED_LOCKS_REQUIRED(chassis_lock);
 
-  virtual ::util::Status ReplayPortsConfig(uint64 node_id)
+  virtual ::util::Status ReplayChassisConfig(uint64 node_id)
       EXCLUSIVE_LOCKS_REQUIRED(chassis_lock);
 
   virtual ::util::StatusOr<std::map<uint64, int>> GetNodeIdToDeviceMap() const

--- a/stratum/hal/lib/tdi/es2k/es2k_chassis_manager_mock.h
+++ b/stratum/hal/lib/tdi/es2k/es2k_chassis_manager_mock.h
@@ -34,7 +34,7 @@ class Es2kChassisManagerMock : public Es2kChassisManager {
                ::util::StatusOr<absl::Time>(uint64 node_id, uint32 port_id));
   MOCK_METHOD3(GetPortCounters, ::util::Status(uint64 node_id, uint32 port_id,
                                                PortCounters* counters));
-  MOCK_METHOD1(ReplayPortsConfig, ::util::Status(uint64 node_id));
+  MOCK_METHOD1(ReplayChassisConfig, ::util::Status(uint64 node_id));
   MOCK_METHOD3(GetFrontPanelPortInfo,
                ::util::Status(uint64 node_id, uint32 port_id,
                               FrontPanelPortInfo* fp_port_info));

--- a/stratum/hal/lib/tdi/es2k/es2k_chassis_manager_test.cc
+++ b/stratum/hal/lib/tdi/es2k/es2k_chassis_manager_test.cc
@@ -235,9 +235,9 @@ class Es2kChassisManagerTest : public ::testing::Test {
     return ::util::OkStatus();
   }
 
-  ::util::Status ReplayPortsConfig(uint64 node_id) {
+  ::util::Status ReplayChassisConfig(uint64 node_id) {
     absl::WriterMutexLock l(&chassis_lock);
-    return chassis_manager_->ReplayPortsConfig(node_id);
+    return chassis_manager_->ReplayChassisConfig(node_id);
   }
 
   ::util::Status PushBaseChassisConfig() {
@@ -499,7 +499,7 @@ TEST_F(Es2kChassisManagerTest, ReplayPorts) {
               EnablePortShaping(kDevice, sdkPortId, TRI_STATE_TRUE))
       .Times(AtLeast(1));
 
-  EXPECT_OK(ReplayPortsConfig(kNodeId));
+  EXPECT_OK(ReplayChassisConfig(kNodeId));
 
   ASSERT_OK(ShutdownAndTestCleanState());
 }

--- a/stratum/hal/lib/tdi/es2k/es2k_switch.cc
+++ b/stratum/hal/lib/tdi/es2k/es2k_switch.cc
@@ -70,7 +70,7 @@ Es2kSwitch::~Es2kSwitch() {}
   absl::WriterMutexLock l(&chassis_lock);
   ASSIGN_OR_RETURN(auto* es2k_node, GetEs2kNodeFromNodeId(node_id));
   RETURN_IF_ERROR(es2k_node->PushForwardingPipelineConfig(config));
-  RETURN_IF_ERROR(chassis_manager_->ReplayPortsConfig(node_id));
+  RETURN_IF_ERROR(chassis_manager_->ReplayChassisConfig(node_id));
 
   LOG(INFO) << "P4-based forwarding pipeline config pushed successfully to "
             << "node with ID " << node_id << ".";
@@ -83,7 +83,7 @@ Es2kSwitch::~Es2kSwitch() {}
   absl::WriterMutexLock l(&chassis_lock);
   ASSIGN_OR_RETURN(auto* es2k_node, GetEs2kNodeFromNodeId(node_id));
   RETURN_IF_ERROR(es2k_node->SaveForwardingPipelineConfig(config));
-  RETURN_IF_ERROR(chassis_manager_->ReplayPortsConfig(node_id));
+  RETURN_IF_ERROR(chassis_manager_->ReplayChassisConfig(node_id));
 
   LOG(INFO) << "P4-based forwarding pipeline config saved successfully to "
             << "node with ID " << node_id << ".";

--- a/stratum/hal/lib/tdi/tofino/tofino_chassis_manager.cc
+++ b/stratum/hal/lib/tdi/tofino/tofino_chassis_manager.cc
@@ -909,7 +909,7 @@ TofinoChassisManager::GetNodeIdToDeviceMap() const {
   return node_id_to_device_;
 }
 
-::util::Status TofinoChassisManager::ReplayPortsConfig(uint64 node_id) {
+::util::Status TofinoChassisManager::ReplayChassisConfig(uint64 node_id) {
   if (!initialized_) {
     return MAKE_ERROR(ERR_NOT_INITIALIZED) << "Not initialized!";
   }

--- a/stratum/hal/lib/tdi/tofino/tofino_chassis_manager.h
+++ b/stratum/hal/lib/tdi/tofino/tofino_chassis_manager.h
@@ -59,7 +59,7 @@ class TofinoChassisManager {
                                          PortCounters* counters)
       SHARED_LOCKS_REQUIRED(chassis_lock);
 
-  virtual ::util::Status ReplayPortsConfig(uint64 node_id)
+  virtual ::util::Status ReplayChassisConfig(uint64 node_id)
       EXCLUSIVE_LOCKS_REQUIRED(chassis_lock);
 
   virtual ::util::Status GetFrontPanelPortInfo(uint64 node_id, uint32 port_id,

--- a/stratum/hal/lib/tdi/tofino/tofino_chassis_manager_mock.h
+++ b/stratum/hal/lib/tdi/tofino/tofino_chassis_manager_mock.h
@@ -34,7 +34,7 @@ class TofinoChassisManagerMock : public TofinoChassisManager {
                ::util::StatusOr<absl::Time>(uint64 node_id, uint32 port_id));
   MOCK_METHOD3(GetPortCounters, ::util::Status(uint64 node_id, uint32 port_id,
                                                PortCounters* counters));
-  MOCK_METHOD1(ReplayPortsConfig, ::util::Status(uint64 node_id));
+  MOCK_METHOD1(ReplayChassisConfig, ::util::Status(uint64 node_id));
   MOCK_METHOD3(GetFrontPanelPortInfo,
                ::util::Status(uint64 node_id, uint32 port_id,
                               FrontPanelPortInfo* fp_port_info));

--- a/stratum/hal/lib/tdi/tofino/tofino_chassis_manager_test.cc
+++ b/stratum/hal/lib/tdi/tofino/tofino_chassis_manager_test.cc
@@ -226,9 +226,9 @@ class TofinoChassisManagerTest : public ::testing::Test {
     return ::util::OkStatus();
   }
 
-  ::util::Status ReplayPortsConfig(uint64 node_id) {
+  ::util::Status ReplayChassisConfig(uint64 node_id) {
     absl::WriterMutexLock l(&chassis_lock);
-    return chassis_manager_->ReplayPortsConfig(node_id);
+    return chassis_manager_->ReplayChassisConfig(node_id);
   }
 
   ::util::Status PushBaseChassisConfig() {
@@ -486,7 +486,7 @@ TEST_F(TofinoChassisManagerTest, ReplayPorts) {
               EnablePortShaping(kDevice, sdkPortId, TRI_STATE_TRUE))
       .Times(AtLeast(1));
 
-  EXPECT_OK(ReplayPortsConfig(kNodeId));
+  EXPECT_OK(ReplayChassisConfig(kNodeId));
 
   ASSERT_OK(ShutdownAndTestCleanState());
 }

--- a/stratum/hal/lib/tdi/tofino/tofino_switch.cc
+++ b/stratum/hal/lib/tdi/tofino/tofino_switch.cc
@@ -68,7 +68,7 @@ TofinoSwitch::~TofinoSwitch() {}
   absl::WriterMutexLock l(&chassis_lock);
   ASSIGN_OR_RETURN(auto* tdi_node, GetTdiNodeFromNodeId(node_id));
   RETURN_IF_ERROR(tdi_node->PushForwardingPipelineConfig(config));
-  RETURN_IF_ERROR(chassis_manager_->ReplayPortsConfig(node_id));
+  RETURN_IF_ERROR(chassis_manager_->ReplayChassisConfig(node_id));
 
   LOG(INFO) << "P4-based forwarding pipeline config pushed successfully to "
             << "node with ID " << node_id << ".";
@@ -81,7 +81,7 @@ TofinoSwitch::~TofinoSwitch() {}
   absl::WriterMutexLock l(&chassis_lock);
   ASSIGN_OR_RETURN(auto* tdi_node, GetTdiNodeFromNodeId(node_id));
   RETURN_IF_ERROR(tdi_node->SaveForwardingPipelineConfig(config));
-  RETURN_IF_ERROR(chassis_manager_->ReplayPortsConfig(node_id));
+  RETURN_IF_ERROR(chassis_manager_->ReplayChassisConfig(node_id));
 
   LOG(INFO) << "P4-based forwarding pipeline config saved successfully to "
             << "node with ID " << node_id << ".";


### PR DESCRIPTION
- Rename the ReplayPortsConfig() method to ReplayChassisConfig() to track an upstream change.