### PR TITLE
Fix "no previous declaration" warnings

### DIFF
--- a/stratum/glue/status/status_macros.cc
+++ b/stratum/glue/status/status_macros.cc
@@ -77,8 +77,9 @@ static LogSeverity GetSuppressedSeverity(LogSeverity severity,
   }
 }
 
-void LogErrorWithSuppression(const ::util::Status& status, const char* filename,
-                             int line, int log_level) {
+static void LogErrorWithSuppression(const ::util::Status& status,
+                                    const char* filename, int line,
+                                    int log_level) {
   const LogSeverity severity = GetSuppressedSeverity(ERROR, log_level);
   LogError(status, filename, line, severity,
            false /* should_log_stack_trace */);

--- a/stratum/hal/config/chassis_config_migrator.cc
+++ b/stratum/hal/config/chassis_config_migrator.cc
@@ -32,11 +32,7 @@ ls -1 stratum/hal/config/*/chassis_config.pb.txt | \
     -chassis_config_file
 )USAGE";
 
-// Suppress gcc "no previous declaration" warnings.
-::util::Status MigrateSingletonPort(SingletonPort* singleton_port);
-::util::Status Main(int argc, char** argv);
-
-::util::Status MigrateSingletonPort(SingletonPort* singleton_port) {
+static ::util::Status MigrateSingletonPort(SingletonPort* singleton_port) {
   // Only change the port name if it matches the <port>/<slot> pattern.
   bool fix_name = true;
   std::vector<std::string> parts = absl::StrSplit(singleton_port->name(), '/');
@@ -66,7 +62,7 @@ ls -1 stratum/hal/config/*/chassis_config.pb.txt | \
   return ::util::OkStatus();
 }
 
-::util::Status Main(int argc, char** argv) {
+static ::util::Status Main(int argc, char** argv) {
   ::gflags::SetUsageMessage(kUsage);
   InitGoogle(argv[0], &argc, &argv, true);
   stratum::InitStratumLogging();

--- a/stratum/hal/lib/common/utils_test.cc
+++ b/stratum/hal/lib/common/utils_test.cc
@@ -391,7 +391,7 @@ TEST(PortUtilsTest, AggregatePortLedColorsStatePairs) {
                  std::make_pair(LED_COLOR_GREEN, LED_STATE_SOLID)}));
 }
 
-void DoubleToDecimalTest(double from, int64 digits, uint32 precision) {
+static void DoubleToDecimalTest(double from, int64 digits, uint32 precision) {
   auto res = ConvertDoubleToDecimal64(from, precision);
   EXPECT_TRUE(res.ok());
   auto decimal_val = res.ValueOrDie();


### PR DESCRIPTION
- Address "no previous declaration" warnings from the gcc compiler by making local functions static.