### PR TITLE
Support Abseil version 20230125

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,10 @@ if(ES2K_TARGET)
     find_package(OpenSSL REQUIRED)
 endif()
 
+if(absl_VERSION VERSION_GREATER_EQUAL "20230125")
+  add_compile_definitions(ABSL_LEGACY_THREAD_ANNOTATIONS)
+endif()
+
 # Suppress "warning: attribute ignored" on ABSL_MUST_USE_RESULT [[nodiscard]]
 add_compile_options(-Wno-attributes)
 
@@ -94,6 +98,9 @@ function(add_stratum_abseil_libs _TGT)
         absl::bad_optional_access
         absl::bad_variant_access
     )
+    if(absl_VERSION VERSION_GREATER_EQUAL 20230125)
+        target_link_libraries(${_TGT} PUBLIC absl::log_internal_check_op)
+    endif()
 endfunction()
 
 # Google libraries


### PR DESCRIPTION
- Google renamed the Abseil thread annotation macros in the 20230125 release. Define ABSL_LEGACY_THREAD_ANNOTATIONS to reenable the legacy macro names.

- Add absl::log_internal_check_op to list of required libraries.