### PR TITLE
Fix compile error in Tofino build

### DIFF
--- a/stratum/hal/lib/tdi/tofino/tofino_sde_target.cc
+++ b/stratum/hal/lib/tdi/tofino/tofino_sde_target.cc
@@ -345,14 +345,12 @@ bf_status_t TdiSdeWrapper::BfPktRxNotifyCallback(bf_dev_id_t device,
 // PacketModMeter
 ::util::Status TableData::SetPktModMeterConfig(
     const TdiPktModMeterConfig& cfg) {
-  return MAKE_ERROR(ERR_OPER_NOT_SUPPORTED)
-         <" PacketModMeter not supported";
+  return MAKE_ERROR(ERR_OPER_NOT_SUPPORTED) << "PacketModMeter not supported";
 }
 
 ::util::Status TableData::GetPktModMeterConfig(
     TdiPktModMeterConfig& cfg) const {
-  return MAKE_ERROR(ERR_OPER_NOT_SUPPORTED)
-         << "PacketModMeter not supported";
+  return MAKE_ERROR(ERR_OPER_NOT_SUPPORTED) << "PacketModMeter not supported";
 }
 
 }  // namespace tdi


### PR DESCRIPTION
- Correct invalid syntax in tofino_sde_target.cc.
- Use clang-format to correct formatting.