### PR TITLE
Disable Tofino-specific PacketIo methods

### DIFF
--- a/stratum/hal/lib/tdi/BUILD
+++ b/stratum/hal/lib/tdi/BUILD
@@ -42,11 +42,6 @@ config_setting(
     },
 )
 
-target_defines = select({
-    ":tofino_target": ["TOFINO_TARGET"],
-    "//conditions:default": [],
-})
-
 target_sdk_headers = select({
     ":dpdk_target": ["@local_dpdk_bin//:dpdk_hdrs"],
     ":es2k_target": ["@local_es2k_bin//:es2k_hdrs"],
@@ -60,7 +55,6 @@ stratum_cc_library(
         "tdi_pkt_mod_meter_config.h",
         "tdi_sde_interface.h",
     ],
-    defines = target_defines,
     deps = [
         ":tdi_cc_proto",
         "//stratum/glue:integral_types",
@@ -70,13 +64,12 @@ stratum_cc_library(
         "//stratum/hal/lib/common:utils",
         "//stratum/lib/channel",
         "@com_google_absl//absl/base:core_headers",
-    ] + target_sdk_headers,
+    ],
 )
 
 stratum_cc_library(
     name = "tdi_sde_wrapper_interface",
     hdrs = ["tdi_sde_wrapper.h"],
-    defines = target_defines,
     deps = [
         ":macros",
         ":tdi_sde_interface",
@@ -88,7 +81,7 @@ stratum_cc_library(
         "//stratum/lib/channel",
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/synchronization",
-    ] + target_sdk_headers,
+    ],
 )
 
 stratum_cc_library(
@@ -107,14 +100,13 @@ stratum_cc_library(
     deps = [
         ":tdi_sde_interface",
         "@com_google_googletest//:gtest",
-    ] + target_sdk_headers,
+    ],
 )
 
 stratum_cc_library(
     name = "macros",
     hdrs = ["macros.h"],
     # macros.h depends on bf_types
-    defines = target_defines,
     deps = [
         "//stratum/lib:macros",
     ] + target_sdk_headers,
@@ -135,7 +127,6 @@ stratum_cc_library(
         "tdi_sde_table_key.cc",
         "tdi_sde_wrapper.cc",
     ],
-    defines = target_defines,
     deps = [
         ":macros",
         ":tdi_constants",
@@ -351,7 +342,6 @@ stratum_cc_library(
         "tdi_id_mapper.h",
         "tdi_sde_utils.h",
     ],
-    defines = target_defines,
     deps = [
         ":macros",
         ":tdi_cc_proto",

--- a/stratum/hal/lib/tdi/tdi_sde_wrapper.h
+++ b/stratum/hal/lib/tdi/tdi_sde_wrapper.h
@@ -24,7 +24,7 @@
 #include "stratum/hal/lib/tdi/tdi_sde_interface.h"
 #include "stratum/lib/channel/channel.h"
 
-#ifdef TOFINO_TARGET
+#ifdef TOFINO_PACKETIO
 // FIXME: Target-specific code in a target-agnostic file.
 #include "pkt_mgr/pkt_mgr_intf.h"
 #endif
@@ -354,7 +354,7 @@ class TdiSdeWrapper : public TdiSdeInterface {
   // Return the singleton instance to be used in the SDE callbacks.
   static TdiSdeWrapper* GetSingleton() LOCKS_EXCLUDED(init_lock_);
 
-#ifdef TOFINO_TARGET
+#ifdef TOFINO_PACKETIO
   // FIXME: Target-specific code in a target-agnostic class.
   // Writes a received packet to the registered Rx writer. Called from the SDE
   // callback function.
@@ -391,7 +391,7 @@ class TdiSdeWrapper : public TdiSdeInterface {
   // RW mutex lock for protecting the pipeline state.
   mutable absl::Mutex data_lock_;
 
-#ifdef TOFINO_TARGET
+#ifdef TOFINO_PACKETIO
   // Callback registed with the SDE for Tx notifications.
   static bf_status_t BfPktTxNotifyCallback(bf_dev_id_t device,
                                            bf_pkt_tx_ring_t tx_ring,


### PR DESCRIPTION
- Conditionalize the Tofino-specific methods in TdiSdeWrapper with a new TOFINO_PACKETIO #define, replacing the TOFINO_TARGET #define. There are now no references to TOFINO_TARGET in Stratum.

- Use TOFINO_PACKETIO to conditionalize the bodies of the Tofino StartPacketIo, StopPacketIo, and TxPacket methods.

- Reduced the number of target-specific dependencies in the Bazel build system.

All of this is being done to reduce the number of files that must be recompiled in order to build for a different TDI target.