### PR TITLE
Move OpenSSL dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,13 +117,6 @@ function(add_stratum_google_libs _TGT)
     )
 endfunction()
 
-# OpenSSL libraries
-function(add_stratum_openssl_libs _TGT)
-    if(ES2K_TARGET)
-        target_link_libraries(${_TGT} PUBLIC OpenSSL::Crypto)
-    endif()
-endfunction()
-
 # Protobuf libraries
 function(add_stratum_proto_libs _TGT)
     target_link_libraries(${_TGT} PUBLIC
@@ -138,7 +131,6 @@ endfunction()
 function(add_stratum_libraries _TGT)
     add_stratum_abseil_libs(${_TGT})
     add_stratum_google_libs(${_TGT})
-    add_stratum_openssl_libs(${_TGT})
     add_stratum_proto_libs(${_TGT})
     target_link_libraries(${_TGT} PUBLIC pthread)
 endfunction()

--- a/stratum/hal/lib/tdi/CMakeLists.txt
+++ b/stratum/hal/lib/tdi/CMakeLists.txt
@@ -64,6 +64,11 @@ set_source_files_properties(
     PROPERTIES COMPILE_OPTIONS "-Wno-deprecated-declarations"
 )
 
+if(ES2K_TARGET)
+  # For tdi_fixed_function_manager.
+  target_link_libraries(stratum_tdi_common_o PUBLIC OpenSSL::Crypto)
+endif()
+
 target_include_directories(stratum_tdi_common_o PRIVATE
     ${STRATUM_INCLUDES}
     ${SDE_INSTALL_DIR}/include


### PR DESCRIPTION
- Move the conditional dependency on `OpenSSL::Crypto` to the `stratum_tdi_common_o` target, which is closer to the site of the actual dependency.