### PR TITLE
Fix tdi_pipeline_builder compile errors with gRPC v1.59.1

### DIFF
--- a/stratum/hal/bin/tdi/tdi_pipeline_builder.cc
+++ b/stratum/hal/bin/tdi/tdi_pipeline_builder.cc
@@ -112,14 +112,14 @@ p4_device_config field of the P4Runtime SetForwardingPipelineConfig message.
     RET_CHECK(device["p4_programs"].size() == 1)
         << "BfPipelineConfig only supports single P4 programs.";
     const auto& program = device["p4_programs"][0];
-    bf_config.set_p4_name(program["program-name"]);
+    bf_config.set_p4_name(program["program-name"].get<std::string>());
     LOG(INFO) << "Found P4 program: " << bf_config.p4_name();
     std::string tdi_content;
     RETURN_IF_ERROR(ReadFileToString(program["bfrt-config"], &tdi_content));
     bf_config.set_bfruntime_info(tdi_content);
     for (const auto& pipeline : program["p4_pipelines"]) {
       auto profile = bf_config.add_profiles();
-      profile->set_profile_name(pipeline["p4_pipeline_name"]);
+      profile->set_profile_name(pipeline["p4_pipeline_name"].get<std::string>());
       LOG(INFO) << "\tFound pipeline: " << profile->profile_name();
       for (const auto& scope : pipeline["pipe_scope"]) {
         profile->add_pipe_scope(scope);


### PR DESCRIPTION
This CL addresses the issue noticed in tdi_pipeline_builder with compilatio errors of ambiguous function overload with new gRPC (v1.59.1) and protobuf versions. 

The change has also been backtested on older version of gRPC and protobuf and compiles ok without issue.