### PR TITLE
Revert "Eliminate legacy bytestring responses flag"

### DIFF
--- a/stratum/hal/lib/tdi/BUILD
+++ b/stratum/hal/lib/tdi/BUILD
@@ -92,6 +92,15 @@ stratum_cc_library(
 )
 
 stratum_cc_library(
+    name = "tdi_sde_flags",
+    srcs = ["tdi_sde_flags.cc"],
+    hdrs = ["tdi_sde_flags.h"],
+    deps = [
+        "@com_github_gflags_gflags//:gflags",
+    ],
+)
+
+stratum_cc_library(
     name = "tdi_sde_mock",
     testonly = 1,
     hdrs = ["tdi_sde_mock.h"],
@@ -131,6 +140,7 @@ stratum_cc_library(
         ":tdi_bf_status",
         ":tdi_constants",
         ":tdi_id_mapper",
+        ":tdi_sde_flags",
         ":tdi_sde_headers",
         ":tdi_sde_wrapper_interface",
         ":utils",
@@ -504,6 +514,7 @@ stratum_cc_library(
     hdrs = ["tdi_packetio_manager.h"],
     deps = [
         ":tdi_cc_proto",
+        ":tdi_sde_flags",
         ":tdi_sde_interface",
         "//stratum/glue:integral_types",
         "//stratum/glue:logging",

--- a/stratum/hal/lib/tdi/CMakeLists.txt
+++ b/stratum/hal/lib/tdi/CMakeLists.txt
@@ -31,6 +31,8 @@ add_library(stratum_tdi_common_o OBJECT
     tdi_sde_clone_session.cc
     tdi_sde_common.h
     tdi_sde_counter.cc
+    tdi_sde_flags.cc
+    tdi_sde_flags.h
     tdi_sde_helpers.cc
     tdi_sde_helpers.h
     tdi_sde_interface.h

--- a/stratum/hal/lib/tdi/tdi_packetio_manager.cc
+++ b/stratum/hal/lib/tdi/tdi_packetio_manager.cc
@@ -17,6 +17,7 @@
 #include "stratum/glue/gtl/map_util.h"
 #include "stratum/hal/lib/common/constants.h"
 #include "stratum/hal/lib/p4/utils.h"
+#include "stratum/hal/lib/tdi/tdi_sde_flags.h"
 #include "stratum/lib/utils.h"
 
 namespace stratum {
@@ -260,8 +261,10 @@ class BitBuffer {
     auto metadata = packet->add_metadata();
     metadata->set_metadata_id(p.first);
     metadata->set_value(bit_buf.PopField(p.second));
-    *metadata->mutable_value() =
-        ByteStringToP4RuntimeByteString(metadata->value());
+    if (!FLAGS_incompatible_enable_tdi_legacy_bytestring_responses) {
+      *metadata->mutable_value() =
+          ByteStringToP4RuntimeByteString(metadata->value());
+    }
     VLOG(1) << "Encoded PacketIn metadata field with id " << p.first
             << " bitwidth " << p.second << " value 0x"
             << StringToHex(metadata->value());

--- a/stratum/hal/lib/tdi/tdi_sde_flags.cc
+++ b/stratum/hal/lib/tdi/tdi_sde_flags.cc
@@ -1,0 +1,10 @@
+// Copyright 2019-present Barefoot Networks, Inc.
+// Copyright 2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#include "gflags/gflags.h"
+
+DEFINE_bool(incompatible_enable_tdi_legacy_bytestring_responses, true,
+            "Enables the legacy padded byte string format in P4Runtime "
+            "responses for Stratum-tdi. The strings are left unchanged from "
+            "the underlying SDE.");

--- a/stratum/hal/lib/tdi/tdi_sde_flags.h
+++ b/stratum/hal/lib/tdi/tdi_sde_flags.h
@@ -1,0 +1,12 @@
+// Copyright 2019-present Barefoot Networks, Inc.
+// Copyright 2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef STRATUM_HAL_LIB_TDI_TDI_SDE_FLAGS_H_
+#define STRATUM_HAL_LIB_TDI_TDI_SDE_FLAGS_H_
+
+#include "gflags/gflags.h"
+
+DECLARE_bool(incompatible_enable_tdi_legacy_bytestring_responses);
+
+#endif  // STRATUM_HAL_LIB_TDI_TDI_SDE_FLAGS_H_

--- a/stratum/hal/lib/tdi/tdi_sde_table_data.cc
+++ b/stratum/hal/lib/tdi/tdi_sde_table_data.cc
@@ -19,6 +19,7 @@
 #include "stratum/hal/lib/tdi/tdi_bf_status.h"
 #include "stratum/hal/lib/tdi/tdi_constants.h"
 #include "stratum/hal/lib/tdi/tdi_sde_common.h"
+#include "stratum/hal/lib/tdi/tdi_sde_flags.h"
 #include "stratum/hal/lib/tdi/tdi_sde_helpers.h"
 #include "stratum/hal/lib/tdi/tdi_sde_wrapper.h"
 #include "stratum/hal/lib/tdi/utils.h"
@@ -66,7 +67,9 @@ using namespace stratum::hal::tdi::helpers;
   RETURN_IF_TDI_ERROR(table_data_->getValue(
       id, value->size(),
       reinterpret_cast<uint8*>(gtl::string_as_array(value))));
-  *value = ByteStringToP4RuntimeByteString(*value);
+  if (!FLAGS_incompatible_enable_tdi_legacy_bytestring_responses) {
+    *value = ByteStringToP4RuntimeByteString(*value);
+  }
   return ::util::OkStatus();
 }
 

--- a/stratum/hal/lib/tdi/tdi_sde_table_key.cc
+++ b/stratum/hal/lib/tdi/tdi_sde_table_key.cc
@@ -19,6 +19,7 @@
 #include "stratum/hal/lib/tdi/tdi_bf_status.h"
 #include "stratum/hal/lib/tdi/tdi_constants.h"
 #include "stratum/hal/lib/tdi/tdi_sde_common.h"
+#include "stratum/hal/lib/tdi/tdi_sde_flags.h"
 #include "stratum/hal/lib/tdi/tdi_sde_helpers.h"
 #include "stratum/hal/lib/tdi/tdi_sde_wrapper.h"
 #include "stratum/hal/lib/tdi/utils.h"
@@ -159,7 +160,9 @@ using namespace stratum::hal::tdi::helpers;
   RETURN_IF_TDI_ERROR(
       table_key_->getValue(static_cast<tdi_id_t>(id), &exactKey));
 
-  *value = ByteStringToP4RuntimeByteString(*value);
+  if (!FLAGS_incompatible_enable_tdi_legacy_bytestring_responses) {
+    *value = ByteStringToP4RuntimeByteString(*value);
+  }
 
   return ::util::OkStatus();
 }
@@ -190,8 +193,10 @@ using namespace stratum::hal::tdi::helpers;
   RETURN_IF_TDI_ERROR(
       table_key_->getValue(static_cast<tdi_id_t>(id), &ternaryKey));
 
-  *value = ByteStringToP4RuntimeByteString(*value);
-  *mask = ByteStringToP4RuntimeByteString(*mask);
+  if (!FLAGS_incompatible_enable_tdi_legacy_bytestring_responses) {
+    *value = ByteStringToP4RuntimeByteString(*value);
+    *mask = ByteStringToP4RuntimeByteString(*mask);
+  }
 
   return ::util::OkStatus();
 }
@@ -217,7 +222,9 @@ using namespace stratum::hal::tdi::helpers;
 
   RETURN_IF_TDI_ERROR(table_key_->getValue(static_cast<tdi_id_t>(id), &lpmKey));
 
-  *prefix = ByteStringToP4RuntimeByteString(*prefix);
+  if (!FLAGS_incompatible_enable_tdi_legacy_bytestring_responses) {
+    *prefix = ByteStringToP4RuntimeByteString(*prefix);
+  }
   *prefix_length = lpmKey.prefix_len_;
 
   return ::util::OkStatus();
@@ -247,8 +254,10 @@ using namespace stratum::hal::tdi::helpers;
 
   RETURN_IF_TDI_ERROR(
       table_key_->getValue(static_cast<tdi_id_t>(id), &rangeKey));
-  *low = ByteStringToP4RuntimeByteString(*low);
-  *high = ByteStringToP4RuntimeByteString(*high);
+  if (!FLAGS_incompatible_enable_tdi_legacy_bytestring_responses) {
+    *low = ByteStringToP4RuntimeByteString(*low);
+    *high = ByteStringToP4RuntimeByteString(*high);
+  }
   return ::util::OkStatus();
 }
 


### PR DESCRIPTION
This reverts commit c9ba2025f389e33595b1999b611246f9b8c78fad.

The original commit broke `tdi_packetio_manager_test`. It looks as if there was more to the upstream change than just stripping out support for the flag. Mea culpa.