### PR TITLE
Update workflow to exclude flaky unit tests

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -56,7 +56,7 @@ jobs:
         working-directory: stratum
         run: |
           export SDE_INSTALL=$SDE_INSTALL_DIR
-          xargs -a .github/dpdk-tests.txt bazel test --define target=dpdk
+          xargs -a .github/dpdk-tests.txt bazel test --define target=dpdk --test_tag_filters=-flaky
 
       - name: Collect unit test logs
         if: failure()

--- a/bazel/rules/test_rule.bzl
+++ b/bazel/rules/test_rule.bzl
@@ -17,6 +17,7 @@ def stratum_cc_test(
         defines = None,
         linkopts = [],
         size = "small",
+        tags = None,
         visibility = None):
     cc_test(
         name = name,
@@ -27,5 +28,6 @@ def stratum_cc_test(
         defines = defines,
         linkopts = STRATUM_DEFAULT_LINKOPTS + linkopts,
         size = size,
+        tags = tags,
         visibility = visibility,
     )

--- a/stratum/hal/lib/common/BUILD
+++ b/stratum/hal/lib/common/BUILD
@@ -170,6 +170,7 @@ stratum_cc_test(
         "//stratum/lib/test_utils:matchers",
         "//stratum/public/lib:error",
     ],
+    tags = ["flaky"],
 )
 
 stratum_cc_library(
@@ -504,6 +505,7 @@ stratum_cc_test(
         "//stratum/lib/test_utils:matchers",
         "//stratum/public/lib:error",
     ],
+    tags = ["flaky"],
 )
 
 stratum_cc_library(


### PR DESCRIPTION
- Add a "flaky" tag to unit tests that fail intermittently.

- Modify stratum_cc_test() to support the 'tags' parameter.

- Update GitHub workflow to specify --test_tag_filters=-flaky
  on the bazel test command line. This filters out any tests
  that have been marked as "flaky".