### PR TITLE
Address compiler warnings

### DIFF
--- a/stratum/hal/lib/p4/p4_info_manager.cc
+++ b/stratum/hal/lib/p4/p4_info_manager.cc
@@ -98,8 +98,10 @@ P4InfoManager::~P4InfoManager() {}
       switch (p4extern.extern_type_id()) {
         case stratum::hal::tdi::kEs2kExternDirectPacketModMeter:
           InitializeDirectMeters(p4extern);
+          break;
         case stratum::hal::tdi::kEs2kExternPacketModMeter:
           InitializeMeters(p4extern);
+          break;
         default:
           LOG(INFO) << "Unrecognized p4_info extern type: "
                     << p4extern.extern_type_id() << " (ignored)";
@@ -108,9 +110,9 @@ P4InfoManager::~P4InfoManager() {}
     }
   }
 
-APPEND_STATUS_IF_ERROR(status, VerifyTableXrefs());
+  APPEND_STATUS_IF_ERROR(status, VerifyTableXrefs());
 
-return status;
+  return status;
 }
 
 void P4InfoManager::InitializeDirectMeters(

--- a/stratum/hal/lib/tdi/tdi_table_manager.cc
+++ b/stratum/hal/lib/tdi/tdi_table_manager.cc
@@ -343,7 +343,6 @@ std::unique_ptr<TdiTableManager> TdiTableManager::CreateInstance(
                  << meter.ShortDebugString() << ".";
       }
       TdiPktModMeterConfig config;
-      memset(&config, 0, sizeof(config));
       config.isPktModMeter = meter_units_in_packets;
       config.meter_prof_id = table_entry.meter_config()
                                  .policer_meter_config()
@@ -991,7 +990,6 @@ TdiTableManager::ReadDirectMeterEntry(
         table_entry.has_meter_config()) {
       // build response entry from returned data
       TdiPktModMeterConfig cfg;
-      memset(&cfg, 0, sizeof(cfg));
       RETURN_IF_ERROR(table_data->GetPktModMeterConfig(cfg));
 
       result.mutable_config()
@@ -1120,7 +1118,7 @@ TdiTableManager::ReadDirectMeterEntry(
   return ::util::OkStatus();
 }
 
-::util::Status GetPktModMeterUnitsInPackets(
+static ::util::Status GetPktModMeterUnitsInPackets(
     const ::p4::config::v1::PacketModMeter& meter, bool& result) {
   switch (meter.spec().unit()) {
     case ::p4::config::v1::MeterSpec::BYTES:
@@ -1280,8 +1278,8 @@ TdiTableManager::ReadDirectMeterEntry(
   return ::util::OkStatus();
 }
 
-::util::Status SetPktModMeterConfig(TdiPktModMeterConfig& config,
-                                    const ::p4::v1::MeterEntry& meter_entry) {
+static ::util::Status SetPktModMeterConfig(
+    TdiPktModMeterConfig& config, const ::p4::v1::MeterEntry& meter_entry) {
   config.meter_prof_id =
       meter_entry.config().policer_meter_config().policer_meter_prof_id();
   config.cir_unit =


### PR DESCRIPTION
- Add missing `break` statements to `switch` statement in P4InfoManager::InitializeAndVerify().

- Remove memset(0) on TdiPktModMeterConfig objects. They are unnecessary because the constructor fully initializes the objects, and they cause the compiler to issue "clearing an object of non-trivial type" warnings.

- Declare a couple of local functions as static, to eliminate "no previous declaration" warnings.