### PR TITLE
Fix errors in mock classes

### DIFF
--- a/stratum/hal/lib/p4/p4_info_manager_mock.h
+++ b/stratum/hal/lib/p4/p4_info_manager_mock.h
@@ -42,32 +42,35 @@ class P4InfoManagerMock : public P4InfoManager {
   MOCK_CONST_METHOD1(FindCounterByName,
                      ::util::StatusOr<const ::p4::config::v1::Counter>(
                          const std::string& counter_name));
+
   MOCK_CONST_METHOD1(
       FindMeterByID,
       ::util::StatusOr<const ::p4::config::v1::Meter>(uint32 meter_id));
   MOCK_CONST_METHOD1(FindMeterByName,
                      ::util::StatusOr<const ::p4::config::v1::Meter>(
                          const std::string& meter_name));
+
   MOCK_CONST_METHOD1(
       FindDirectMeterByID,
       ::util::StatusOr<const ::p4::config::v1::DirectMeter>(uint32 meter_id));
   MOCK_CONST_METHOD1(FindDirectMeterByName,
                      ::util::StatusOr<const ::p4::config::v1::DirectMeter>(
                          const std::string& meter_name));
+
   MOCK_CONST_METHOD1(
       FindDirectPktModMeterByID,
       ::util::StatusOr<const ::p4::config::v1::DirectPacketModMeter>(
           uint32 meter_id));
-
-  MOCK_CONST_METHOD1(FindDirectPktModMeterByName,
-                     ::util::StatusOr<const ::p4::config::v1::DirectMeter>(
-                         const std::string& meter_name));
   MOCK_CONST_METHOD1(
-      FindPktModMeterByID,
+      FindDirectPktModMeterByName,
       ::util::StatusOr<const ::p4::config::v1::DirectPacketModMeter>(
-          uint32 meter_id));
+          const std::string& meter_name));
+
+  MOCK_CONST_METHOD1(FindPktModMeterByID,
+                     ::util::StatusOr<const ::p4::config::v1::PacketModMeter>(
+                         uint32 meter_id));
   MOCK_CONST_METHOD1(FindPktModMeterByName,
-                     ::util::StatusOr<const ::p4::config::v1::DirectMeter>(
+                     ::util::StatusOr<const ::p4::config::v1::PacketModMeter>(
                          const std::string& meter_name));
 
   MOCK_CONST_METHOD1(

--- a/stratum/hal/lib/tdi/tdi_sde_mock.h
+++ b/stratum/hal/lib/tdi/tdi_sde_mock.h
@@ -236,20 +236,6 @@ class TdiSdeMock : public TdiSdeInterface {
                      std::vector<TdiPktModMeterConfig>& cfg));
 
   MOCK_METHOD5(
-      WritePktModMeter,
-      ::util::Status(int device,
-                     std::shared_ptr<TdiSdeInterface::SessionInterface> session,
-                     uint32 table_id, absl::optional<uint32> meter_index,
-                     TdiPktModMeterConfig& cfg));
-  MOCK_METHOD6(
-      ReadPktModMeters,
-      ::util::Status(int device,
-                     std::shared_ptr<TdiSdeInterface::SessionInterface> session,
-                     uint32 table_id, absl::optional<uint32> meter_index,
-                     std::vector<uint32>* meter_indices,
-                     std::vector<TdiPktModMeterConfig>& cfg));
-
-  MOCK_METHOD5(
       InsertActionProfileMember,
       ::util::Status(int device,
                      std::shared_ptr<TdiSdeInterface::SessionInterface> session,

--- a/stratum/hal/lib/tdi/tdi_sde_wrapper.h
+++ b/stratum/hal/lib/tdi/tdi_sde_wrapper.h
@@ -261,7 +261,7 @@ class TdiSdeWrapper : public TdiSdeInterface {
       std::vector<TdiPktModMeterConfig>& cfg) override
       LOCKS_EXCLUDED(data_lock_) {
     return MAKE_ERROR(ERR_OPER_NOT_SUPPORTED)
-           << "ReadPktModMeter not supported";
+           << "ReadPktModMeters not supported";
   }
   ::util::Status InsertActionProfileMember(
       int device, std::shared_ptr<TdiSdeInterface::SessionInterface> session,


### PR DESCRIPTION
Address compilation errors in unit tests:

- Remove duplicate definitions of WritePktModMeter() and ReadPktModMeters() in TdiSdeMock.

- Correct parameter types for FindPktModMeterByName and FindDirectPktModMeterByName in P4InfoManagerMock.

Incidental Boy Scout Rule fix:

- Correct typographical error in ReadPktModMeters in TdiSdeWrapper.