### PR TITLE
Move gnmi_cli cmake listfile

### DIFF
--- a/stratum/CMakeLists.txt
+++ b/stratum/CMakeLists.txt
@@ -7,6 +7,6 @@
 add_subdirectory(glue)
 add_subdirectory(lib)
 add_subdirectory(public)
-add_subdirectory(tools)
+add_subdirectory(tools/gnmi)
 
 add_subdirectory(hal)

--- a/stratum/tools/gnmi/CMakeLists.txt
+++ b/stratum/tools/gnmi/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Build file for //stratum/tools
+# Build file for //stratum/tools/gnmi
 #
 # Copyright 2022-2023 Intel Corporation
 # SPDX-License-Identifier: Apache 2.0
@@ -8,7 +8,7 @@
 # gnmi_cli #
 ############
 
-add_executable(gnmi_cli gnmi/gnmi_cli.cc)
+add_executable(gnmi_cli gnmi_cli.cc)
 
 set_install_rpath(gnmi_cli ${EXEC_ELEMENT} ${DEP_ELEMENT})
 


### PR DESCRIPTION
- Move the `CMakeLists.txt` file for `gnmi_cli` from the `stratum/tools` directory to `stratum/tools/gnmi`.

This makes the cmake build structure parallel the Bazel build structure.