### PR TITLE
Add support for Intel SDE 9.11.0

### DIFF
--- a/bazel/deps.bzl
+++ b/bazel/deps.bzl
@@ -1,4 +1,5 @@
 # Copyright 2018-present Open Networking Foundation
+# Copyright 2023 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
 """Load dependencies needed for Stratum."""
@@ -26,6 +27,7 @@ BF_SDE_PI_VER = {
     "9_3_2": "4546038f5770e84dc0d2bba90f1ee7811c9955df",
     "9_4_0": "4546038f5770e84dc0d2bba90f1ee7811c9955df",
     "9_5_0": "4546038f5770e84dc0d2bba90f1ee7811c9955df",
+    "9_11_0": "4546038f5770e84dc0d2bba90f1ee7811c9955df",
 }
 GNOI_COMMIT = "437c62e630389aa4547b4f0521d0bca3fb2bf811"
 GNOI_SHA = "77d8c271adc22f94a18a5261c28f209370e87a5e615801a4e7e0d09f06da531f"

--- a/bazel/external/bfsde.BUILD
+++ b/bazel/external/bfsde.BUILD
@@ -1,4 +1,5 @@
 # Copyright 2020-present Open Networking Foundation
+# Copyright 2023 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
 load("@//bazel/rules:package_rule.bzl", "pkg_tar_with_symlinks")
@@ -17,8 +18,11 @@ cc_library(
         "barefoot-bin/lib/libbfsys.so*",
         "barefoot-bin/lib/libbfutils.so*",
         "barefoot-bin/lib/libdriver.so*",
-        "barefoot-bin/lib/libpython3.4m.so*",
-    ]) + ["barefoot-bin/lib/libbf_switchd_lib.a"],
+        "barefoot-bin/lib/libpython3*",
+        "barefoot-bin/lib/libtarget_sys.so*",
+        "barefoot-bin/lib/libtarget_utils.so*",
+        "barefoot-bin/lib/libbf_switchd_lib.a*",
+    ]),
     hdrs = glob([
         "barefoot-bin/include/bf_rt/*.h",
         "barefoot-bin/include/bf_rt/*.hpp",
@@ -32,6 +36,8 @@ cc_library(
         "barefoot-bin/include/pipe_mgr/*.h",
         "barefoot-bin/include/pkt_mgr/*.h",
         "barefoot-bin/include/port_mgr/*.h",
+        "barefoot-bin/include/target-sys/**/*.h",
+        "barefoot-bin/include/target-utils/**/*.h",
         "barefoot-bin/include/tofino/bf_pal/*.h",
         "barefoot-bin/include/tofino/pdfixed/*.h",
     ]),
@@ -134,5 +140,12 @@ config_setting(
     name = "sde_version_9.5.0",
     flag_values = {
         ":sde_version_setting": "9.5.0",
+    },
+)
+
+config_setting(
+    name = "sde_version_9.11.0",
+    flag_values = {
+        ":sde_version_setting": "9.11.0",
     },
 )

--- a/stratum/hal/lib/barefoot/BUILD
+++ b/stratum/hal/lib/barefoot/BUILD
@@ -1,5 +1,6 @@
 # Copyright 2018 Google LLC
 # Copyright 2018-present Open Networking Foundation
+# Copyright 2023 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
 load("@rules_proto//proto:defs.bzl", "proto_library")
@@ -29,6 +30,7 @@ SDE_DEFINES = select(
         "@local_barefoot_bin//:sde_version_9.3.2": ["SDE_9_3_2"],
         "@local_barefoot_bin//:sde_version_9.4.0": ["SDE_9_4_0"],
         "@local_barefoot_bin//:sde_version_9.5.0": ["SDE_9_5_0"],
+        "@local_barefoot_bin//:sde_version_9.11.0": ["SDE_9_11_0"],
     },
     no_match_error = "Unsupported SDE version",
 )
@@ -185,7 +187,6 @@ stratum_cc_library(
         ":utils",
         "//stratum/glue:integral_types",
         "//stratum/glue:logging",
-        "//stratum/glue/gtl:cleanup",
         "//stratum/glue/gtl:map_util",
         "//stratum/glue/gtl:stl_util",
         "//stratum/glue/status",
@@ -196,6 +197,7 @@ stratum_cc_library(
         "//stratum/lib:utils",
         "//stratum/lib/channel",
         "@com_google_absl//absl/base:core_headers",
+        "@com_google_absl//absl/cleanup",
         "@com_google_absl//absl/container:flat_hash_map",
         "@local_barefoot_bin//:bfsde",
     ],
@@ -209,7 +211,6 @@ stratum_cc_library(
         ":bf_cc_proto",
         "//stratum/glue:integral_types",
         "//stratum/glue:logging",
-        "//stratum/glue/gtl:cleanup",
         "//stratum/glue/status",
         "//stratum/glue/status:status_macros",
         "//stratum/lib:macros",
@@ -218,6 +219,7 @@ stratum_cc_library(
         "@com_github_gflags_gflags//:gflags",
         "@com_github_nlohmann_json//:json",
         "@com_github_p4lang_p4runtime//:p4runtime_cc_proto",
+        "@com_google_absl//absl/cleanup",
         "@com_google_absl//absl/strings",
     ],
 )
@@ -431,7 +433,6 @@ stratum_cc_library(
         ":bf_sde_interface",
         "//stratum/glue:integral_types",
         "//stratum/glue:logging",
-        "//stratum/glue/gtl:cleanup",
         "//stratum/glue/gtl:map_util",
         "//stratum/glue/status",
         "//stratum/glue/status:status_macros",

--- a/stratum/hal/lib/barefoot/bf_pipeline_utils.cc
+++ b/stratum/hal/lib/barefoot/bf_pipeline_utils.cc
@@ -1,4 +1,5 @@
 // Copyright 2012-present Open Networking Foundation
+// Copyright 2023 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 #include "stratum/hal/lib/barefoot/bf_pipeline_utils.h"
@@ -7,10 +8,10 @@
 
 #include <string>
 
+#include "absl/cleanup/cleanup.h"
 #include "absl/strings/strip.h"
 #include "gflags/gflags.h"
 #include "nlohmann/json.hpp"
-#include "stratum/glue/gtl/cleanup.h"
 #include "stratum/glue/status/status_macros.h"
 #include "stratum/lib/macros.h"
 #include "stratum/lib/utils.h"

--- a/stratum/hal/lib/barefoot/bfrt_packetio_manager.cc
+++ b/stratum/hal/lib/barefoot/bfrt_packetio_manager.cc
@@ -1,4 +1,5 @@
 // Copyright 2020-present Open Networking Foundation
+// Copyright 2023 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 #include "stratum/hal/lib/barefoot/bfrt_packetio_manager.h"
@@ -12,7 +13,6 @@
 #include <deque>
 #include <string>
 
-#include "stratum/glue/gtl/cleanup.h"
 #include "stratum/glue/gtl/map_util.h"
 #include "stratum/hal/lib/common/constants.h"
 #include "stratum/hal/lib/p4/utils.h"

--- a/stratum/hal/lib/pi/BUILD
+++ b/stratum/hal/lib/pi/BUILD
@@ -1,4 +1,5 @@
 # Copyright 2018-present Barefoot Networks, Inc.
+# Copyright 2023 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
 load(
@@ -47,6 +48,7 @@ alias(
             "@local_barefoot_bin//:sde_version_9.3.2": "@com_github_p4lang_PI_bf_9_3_2//proto/frontend:pifeproto",
             "@local_barefoot_bin//:sde_version_9.4.0": "@com_github_p4lang_PI_bf_9_4_0//proto/frontend:pifeproto",
             "@local_barefoot_bin//:sde_version_9.5.0": "@com_github_p4lang_PI_bf_9_5_0//proto/frontend:pifeproto",
+            "@local_barefoot_bin//:sde_version_9.11.0": "@com_github_p4lang_PI_bf_9_11_0//proto/frontend:pifeproto",
         },
         no_match_error = "Unsupported SDE version",
     ),


### PR DESCRIPTION
- Make changes necessary to build stratum_bfrt and run unit tests using Intel SDE 9.11.0.

- Modify barefoot to use absl::cleanup instead of gtl::cleanup.

These changes make it possible to do test builds of the (non-IPU) Stratum Barefoot platform.
This is a necessary precursor to downstreaming Stratum changes for 1.4.
It has no impact on other platforms.