### PR TITLE
Add support for OpenConfig `/interfaces/interface[name=*]/state/id` path

### DIFF
--- a/stratum/docs/gnmi/README.md
+++ b/stratum/docs/gnmi/README.md
@@ -45,6 +45,7 @@ Service and tree initialization
  When the service is initialized, it creates a `GnmiPublisher`, and the `GnmiPublisher` instantiates the `YangParseTree`.
  When the tree is initialized, it generates default nodes for wildcard paths such as:
 
+  - `/interfaces/interface[name=*]/state/id`
   - `/interfaces/interface[name=*]/state/ifindex`
   - `/interfaces/interface[name=*]/state/name`
   - `/interfaces/interface/...`

--- a/stratum/docs/gnmi/supported-paths.md
+++ b/stratum/docs/gnmi/supported-paths.md
@@ -20,6 +20,12 @@ Supported gNMI paths
  - Get type: ALL, STATE
  - Set mode: Not valid
 
+`/interfaces/interface[name=*]/state/id`
+
+ - Subscription mode: ONCE, POLL
+ - Get type: ALL, STATE
+ - Set mode: Not valid
+
 `/interfaces/interface[name=*]/state/ifindex`
 
  - Subscription mode: ONCE, POLL
@@ -200,6 +206,12 @@ Supported gNMI paths
 `/interfaces/interface[name=port name]/state/loopback-mode`
 
  - Subscription mode: ONCE, POLL, SAMPLE, ON_CHANGE
+ - Get type: ALL, STATE
+ - Set mode: Not valid
+
+`/interfaces/interface[name=port name]/state/id`
+
+ - Subscription mode: ONCE, POLL, SAMPLE
  - Get type: ALL, STATE
  - Set mode: Not valid
 

--- a/stratum/hal/lib/tdi/dpdk/dpdk_add_subtree_interface.cc
+++ b/stratum/hal/lib/tdi/dpdk/dpdk_add_subtree_interface.cc
@@ -1,6 +1,6 @@
 // Copyright 2018 Google LLC
 // Copyright 2018-present Open Networking Foundation
-// Copyright 2022 Intel Corporation
+// Copyright 2022-2023 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 // Implements the DPDK-specific YangParseTreePaths::AddSubtreeInterface()
@@ -29,7 +29,7 @@ using namespace ::stratum::hal::yang::interface;
 TreeNode* YangParseTreePaths::AddSubtreeInterface(
     const std::string& name, uint64 node_id, uint32 port_id,
     const NodeConfigParams& node_config, YangParseTree* tree) {
-  // No need to lock the mutex - it is locked by method calling this one.
+  // No need to lock the mutex - it is locked by the method calling this one.
   uint64 mac_address = kDummyMacAddress;
 
   TreeNode* node = tree->AddNode(
@@ -39,6 +39,10 @@ TreeNode* YangParseTreePaths::AddSubtreeInterface(
   node = tree->AddNode(
       GetPath("interfaces")("virtual-interface", name)("state")("name")());
   SetUpInterfacesInterfaceStateName(name, node);
+
+  node =
+      tree->AddNode(GetPath("interfaces")("interface", name)("state")("id")());
+  SetUpInterfacesInterfaceStateId(port_id, node);
 
   node = tree->AddNode(GetPath("interfaces")("virtual-interface",
                                              name)("state")("admin-status")());

--- a/stratum/hal/lib/yang/yang_add_subtree_interface.cc
+++ b/stratum/hal/lib/yang/yang_add_subtree_interface.cc
@@ -1,6 +1,6 @@
 // Copyright 2018 Google LLC
 // Copyright 2018-present Open Networking Foundation
-// Copyright 2022 Intel Corporation
+// Copyright 2022-2023 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 // Implements the YangParseTreePaths::AddSubtreeInterface() method.
@@ -27,7 +27,7 @@ using namespace ::stratum::hal::yang::interface;
 TreeNode* YangParseTreePaths::AddSubtreeInterface(
     const std::string& name, uint64 node_id, uint32 port_id,
     const NodeConfigParams& node_config, YangParseTree* tree) {
-  // No need to lock the mutex - it is locked by method calling this one.
+  // No need to lock the mutex - it is locked by the method calling this one.
   TreeNode* node = tree->AddNode(
       GetPath("interfaces")("interface", name)("state")("last-change")());
   SetUpInterfacesInterfaceStateLastChange(node_id, port_id, node, tree);
@@ -39,6 +39,10 @@ TreeNode* YangParseTreePaths::AddSubtreeInterface(
   node = tree->AddNode(
       GetPath("interfaces")("interface", name)("state")("name")());
   SetUpInterfacesInterfaceStateName(name, node);
+
+  node =
+      tree->AddNode(GetPath("interfaces")("interface", name)("state")("id")());
+  SetUpInterfacesInterfaceStateId(port_id, node);
 
   node = tree->AddNode(
       GetPath("interfaces")("interface", name)("state")("oper-status")());

--- a/stratum/hal/lib/yang/yang_parse_tree_interface.cc
+++ b/stratum/hal/lib/yang/yang_parse_tree_interface.cc
@@ -1,6 +1,6 @@
 // Copyright 2018 Google LLC
 // Copyright 2018-present Open Networking Foundation
-// Copyright 2022 Intel Corporation
+// Copyright 2022-2023 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 // Interface setup functions for YangParseTreePaths. Used by the
@@ -115,6 +115,19 @@ void SetUpInterfacesInterfaceStateName(const std::string& name,
                                 GnmiSubscribeStream* stream) {
         return SendResponse(GetResponse(path, name), stream);
       })
+      ->SetOnChangeHandler(on_change_functor);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// /interfaces/interface[name=<name>]/state/id
+void SetUpInterfacesInterfaceStateId(uint32 id, TreeNode* node) {
+  auto on_change_functor = UnsupportedFunc();
+  auto on_poll_functor = [id](const GnmiEvent& event, const ::gnmi::Path& path,
+                              GnmiSubscribeStream* stream) {
+    return SendResponse(GetResponse(path, id), stream);
+  };
+  node->SetOnTimerHandler(on_poll_functor)
+      ->SetOnPollHandler(on_poll_functor)
       ->SetOnChangeHandler(on_change_functor);
 }
 

--- a/stratum/hal/lib/yang/yang_parse_tree_interface.h
+++ b/stratum/hal/lib/yang/yang_parse_tree_interface.h
@@ -1,6 +1,6 @@
 // Copyright 2018 Google LLC
 // Copyright 2018-present Open Networking Foundation
-// Copyright 2022 Intel Corporation
+// Copyright 2022-2023 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 #ifndef STRATUM_HAL_LIB_YANG_YANG_PARSE_TREE_INTERFACE_H_
@@ -34,6 +34,8 @@ void SetUpInterfacesInterfaceStateIfindex(uint32 node_id, uint32 port_id,
                                           TreeNode* node, YangParseTree* tree);
 
 void SetUpInterfacesInterfaceStateName(const std::string& name, TreeNode* node);
+
+void SetUpInterfacesInterfaceStateId(uint32 id, TreeNode* node);
 
 void SetUpInterfacesInterfaceStateOperStatus(uint64 node_id, uint32 port_id,
                                              TreeNode* node,


### PR DESCRIPTION
Merged from the upstream project (Stratum PR 854).

Description from the original PR:

This PR exposes the ChassisConfig SingletonPort IDs under the [P4RT Openconfig](http://ops.openconfig.net/branches/models/master/docs/openconfig-p4rt.html#interfaces-interface-state-id) path `/interfaces/interface[name=*]/state/id`. Once P4RT port translation is implemented, this path contains the port IDs to use in flow programming.

Separated from other downstreaming merges for special attention, because:

1. This PR changes shared code
2. We have modified yang parse tree processing ourselves

That being said, the PR should be incorporated more or less as-is, since we are aligning our codebase with the upstream codebase in order to allow us to upstream our own changes. If there are substantial changes, they should be done in a separate PR.