### PR TITLE
Pin org_golang_x_sys

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,5 +1,6 @@
 # Copyright 2018 Google LLC
 # Copyright 2018-present Open Networking Foundation
+# Copyright 2023 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
 workspace(name = "com_github_stratum_stratum")
@@ -43,6 +44,9 @@ git_repository(
 
 load("//bazel/rules:build_tools.bzl", "build_tools_deps")
 build_tools_deps()
+
+load("//bazel/rules:go_deps.bzl", "golang_dependencies")
+golang_dependencies()
 
 load("//bazel/rules:proto_gen.bzl", "proto_gen_deps")
 proto_gen_deps()

--- a/bazel/rules/go_deps.bzl
+++ b/bazel/rules/go_deps.bzl
@@ -1,0 +1,13 @@
+# Copyright 2023 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+# Load macros and repository rules.
+load("@bazel_gazelle//:deps.bzl", "go_repository")
+
+def golang_dependencies():
+    go_repository(
+        name = "org_golang_x_sys",
+        importpath = "golang.org/x/sys",
+        sum = "h1:1BGLXjeY4akVXGgbC9HugT3Jv3hCI0z56oJR5vAMgBU=",
+        version = "v0.0.0-20190215142949-d0b11bdaac8a",
+    )


### PR DESCRIPTION
- Pin golang.org/x/sys to prevent an incompatible version from being loaded.