### PR TITLE
Pin go pkgs to specific versions

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -118,6 +118,33 @@ load("@io_bazel_rules_go//tests:grpc_repos.bzl", "grpc_dependencies")
 grpc_dependencies()
 
 # ---------------------------------------------------------------------------
+#       Overiride net, text, and sys Go modules to patch new Go update
+# ---------------------------------------------------------------------------
+
+go_repository(
+    name = "org_golang_x_net",
+    importpath = "golang.org/x/net",
+    sum = "h1:hZ/3BUoy5aId7sCpA/Tc5lt8DkFgdVS2onTpJsZ/fl0=",
+    version = "v0.1.0",
+)
+
+go_repository(
+    name = "org_golang_x_text",
+    importpath = "golang.org/x/text",
+    sum = "h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=",
+    version = "v0.3.0",
+)
+
+go_repository(
+    name = "org_golang_x_sys",
+    importpath = "golang.org/x/sys",
+    sum = "h1:eG7RXZHdqOJ1i+0lgLgCpSXAp6M3LYlAo6osgSi0xOM=",
+    version = "v0.5.0",
+)
+
+
+
+# ---------------------------------------------------------------------------
 #       Load CDLang dependencies.
 # ---------------------------------------------------------------------------
 load("//stratum/testing/cdlang:deps.bzl", "cdlang_rules_dependencies")


### PR DESCRIPTION
go_repository pulls in the latest versions of golang packages, which breaks the build with the version of golang that we are using.

Fix the build by overriding the following Bazel go_repository dependencies:
- golang.org/x/net = v0.1.0
- golang.org/x/text = v0.3.0
- golang.org/x/sys = v0.5.0

This fixes the broken Bazel build, allowing us to reenable the GitHub workflow for stratum-dev and resume downstreaming changes.