### PR TITLE
Downstream changes from Stratum project (3)

### DIFF
--- a/stratum/hal/bin/barefoot/bf_pipeline_builder.cc
+++ b/stratum/hal/bin/barefoot/bf_pipeline_builder.cc
@@ -37,7 +37,7 @@ p4_device_config field of the P4Runtime SetForwardingPipelineConfig message.
 )USAGE";
 
 ::util::Status Unpack() {
-  CHECK_RETURN_IF_FALSE(!FLAGS_bf_pipeline_config_binary_file.empty())
+  RET_CHECK(!FLAGS_bf_pipeline_config_binary_file.empty())
       << "pipeline_config_binary_file must be specified.";
 
   BfPipelineConfig bf_config;
@@ -47,12 +47,13 @@ p4_device_config field of the P4Runtime SetForwardingPipelineConfig message.
   // TODO(max): replace with <filesystem> once we move to C++17
   char* resolved_path = realpath(FLAGS_unpack_dir.c_str(), nullptr);
   if (!resolved_path) {
-    return MAKE_ERROR(ERR_INTERNAL) << "Unable to resolve path " << FLAGS_unpack_dir;
+    return MAKE_ERROR(ERR_INTERNAL)
+           << "Unable to resolve path " << FLAGS_unpack_dir;
   }
   std::string base_path(resolved_path);
   free(resolved_path);
 
-  CHECK_RETURN_IF_FALSE(!bf_config.p4_name().empty());
+  RET_CHECK(!bf_config.p4_name().empty());
   LOG(INFO) << "Found P4 program: " << bf_config.p4_name();
   RETURN_IF_ERROR(
       RecursivelyCreateDir(absl::StrCat(base_path, "/", bf_config.p4_name())));
@@ -60,7 +61,7 @@ p4_device_config field of the P4Runtime SetForwardingPipelineConfig message.
       bf_config.bfruntime_info(),
       absl::StrCat(base_path, "/", bf_config.p4_name(), "/", "bfrt.json")));
   for (const auto& profile : bf_config.profiles()) {
-    CHECK_RETURN_IF_FALSE(!profile.profile_name().empty());
+    RET_CHECK(!profile.profile_name().empty());
     LOG(INFO) << "\tFound profile: " << profile.profile_name();
     RETURN_IF_ERROR(RecursivelyCreateDir(absl::StrCat(
         base_path, "/", bf_config.p4_name(), "/", profile.profile_name())));
@@ -86,15 +87,14 @@ p4_device_config field of the P4Runtime SetForwardingPipelineConfig message.
     return Unpack();
   }
 
-  CHECK_RETURN_IF_FALSE(!FLAGS_p4c_conf_file.empty())
-      << "p4c_conf_file must be specified.";
+  RET_CHECK(!FLAGS_p4c_conf_file.empty()) << "p4c_conf_file must be specified.";
 
   nlohmann::json conf;
   {
     std::string conf_content;
     RETURN_IF_ERROR(ReadFileToString(FLAGS_p4c_conf_file, &conf_content));
     conf = nlohmann::json::parse(conf_content, nullptr, false);
-    CHECK_RETURN_IF_FALSE(!conf.is_discarded()) << "Failed to parse .conf";
+    RET_CHECK(!conf.is_discarded()) << "Failed to parse .conf";
     VLOG(1) << ".conf content: " << conf.dump();
   }
 
@@ -102,11 +102,11 @@ p4_device_config field of the P4Runtime SetForwardingPipelineConfig message.
   // Taken from bf_pipeline_utils.cc
   BfPipelineConfig bf_config;
   try {
-    CHECK_RETURN_IF_FALSE(conf["p4_devices"].size() == 1)
+    RET_CHECK(conf["p4_devices"].size() == 1)
         << "Stratum only supports single devices.";
     // Only support single devices for now.
     const auto& device = conf["p4_devices"][0];
-    CHECK_RETURN_IF_FALSE(device["p4_programs"].size() == 1)
+    RET_CHECK(device["p4_programs"].size() == 1)
         << "BfPipelineConfig only supports single P4 programs.";
     const auto& program = device["p4_programs"][0];
     bf_config.set_p4_name(program["program-name"]);

--- a/stratum/hal/bin/barefoot/main.cc
+++ b/stratum/hal/bin/barefoot/main.cc
@@ -114,7 +114,7 @@ void registerDeviceMgrLogger() {
   auto* hal = Hal::CreateSingleton(stratum::hal::OPERATION_MODE_STANDALONE,
                                    bf_switch.get(), auth_policy_checker.get(),
                                    credentials_manager.get());
-  CHECK_RETURN_IF_FALSE(hal) << "Failed to create the Stratum Hal instance.";
+  RET_CHECK(hal) << "Failed to create the Stratum Hal instance.";
 
   // Setup and start serving RPCs.
   ::util::Status status = hal->Setup();

--- a/stratum/hal/bin/barefoot/main_bfrt.cc
+++ b/stratum/hal/bin/barefoot/main_bfrt.cc
@@ -81,7 +81,7 @@ static ::util::Status Main(int argc, char* argv[]) {
   auto* hal = Hal::CreateSingleton(stratum::hal::OPERATION_MODE_STANDALONE,
                                    bf_switch.get(), auth_policy_checker.get(),
                                    credentials_manager.get());
-  CHECK_RETURN_IF_FALSE(hal) << "Failed to create the Stratum Hal instance.";
+  RET_CHECK(hal) << "Failed to create the Stratum Hal instance.";
 
   // Setup and start serving RPCs.
   ::util::Status status = hal->Setup();

--- a/stratum/hal/bin/bcm/sim/main.cc
+++ b/stratum/hal/bin/bcm/sim/main.cc
@@ -104,7 +104,7 @@ struct PerNodeInstances {
   auto* hal = Hal::CreateSingleton(OPERATION_MODE_SIM, bcm_switch.get(),
                                    auth_policy_checker.get(),
                                    credentials_manager.get());
-  CHECK_RETURN_IF_FALSE(hal) << "Failed to create the Stratum Hal instance.";
+  RET_CHECK(hal) << "Failed to create the Stratum Hal instance.";
   // Sanity check, setup and start serving RPCs.
   RETURN_IF_ERROR(hal->SanityCheck());
   ::util::Status status = hal->Setup();

--- a/stratum/hal/bin/bcm/standalone/main.cc
+++ b/stratum/hal/bin/bcm/standalone/main.cc
@@ -105,7 +105,7 @@ struct PerNodeInstances {
   auto* hal = Hal::CreateSingleton(OPERATION_MODE_STANDALONE, bcm_switch.get(),
                                    auth_policy_checker.get(),
                                    credentials_manager.get());
-  CHECK_RETURN_IF_FALSE(hal) << "Failed to create the Stratum Hal instance.";
+  RET_CHECK(hal) << "Failed to create the Stratum Hal instance.";
 
   // Sanity check, setup and start serving RPCs.
   RETURN_IF_ERROR(hal->SanityCheck());

--- a/stratum/hal/bin/bmv2/main.cc
+++ b/stratum/hal/bin/bmv2/main.cc
@@ -125,8 +125,8 @@ void ParseInterfaces(int argc, char* argv[], bm::OptionsParser& parser) {
   // blocks until a P4 pipeline is set
   {
     int status = runner->init_and_start(parser);
-    CHECK_RETURN_IF_FALSE(status == 0)
-        << "Error when starting bmv2 simple_switch, status: " << status;
+    RET_CHECK(status == 0) << "Error when starting bmv2 simple_switch, status: "
+                           << status;
   }
 
   int unit(0);
@@ -156,7 +156,7 @@ void ParseInterfaces(int argc, char* argv[], bm::OptionsParser& parser) {
                                    pi_switch.get(), auth_policy_checker.get(),
                                    credentials_manager.get());
 
-  CHECK_RETURN_IF_FALSE(hal) << "Failed to create the Stratum Hal instance.";
+  RET_CHECK(hal) << "Failed to create the Stratum Hal instance.";
 
   // Setup and start serving RPCs.
   // TODO(antonin): currently this fails because persistent_config_dir flag is

--- a/stratum/hal/bin/np4intel/main.cc
+++ b/stratum/hal/bin/np4intel/main.cc
@@ -139,7 +139,7 @@ void registerDeviceMgrLogger() {
   auto* hal = Hal::CreateSingleton(stratum::hal::OPERATION_MODE_SIM,
                                    pi_switch.get(), auth_policy_checker.get(),
                                    credentials_manager.get());
-  CHECK_RETURN_IF_FALSE(hal) << "Failed to create the Hal instance.";
+  RET_CHECK(hal) << "Failed to create the Hal instance.";
 
   // Setup and start serving RPCs.
   ::util::Status status = hal->Setup();

--- a/stratum/hal/config/chassis_config_migrator.cc
+++ b/stratum/hal/config/chassis_config_migrator.cc
@@ -73,7 +73,7 @@ static ::util::Status Main(int argc, char** argv) {
   if (config.chassis().platform() != PLT_GENERIC_BAREFOOT_TOFINO &&
       config.chassis().platform() != PLT_GENERIC_BAREFOOT_TOFINO2) {
     return MAKE_ERROR(ERR_INVALID_PARAM)
-        << "Chassis config is not for a Tofino platform";
+           << "Chassis config is not for a Tofino platform";
   }
   for (auto& singleton_port : *config.mutable_singleton_ports()) {
     RETURN_IF_ERROR(MigrateSingletonPort(&singleton_port));

--- a/stratum/hal/lib/barefoot/bf_chassis_manager.cc
+++ b/stratum/hal/lib/barefoot/bf_chassis_manager.cc
@@ -436,16 +436,15 @@ BfChassisManager::~BfChassisManager() = default;
       const uint64 node_id = key.first;
       const TofinoConfig::BfPortShapingConfig& port_id_to_shaping_config =
           key.second;
-      CHECK_RETURN_IF_FALSE(node_id_to_port_id_to_sdk_port_id.count(node_id));
-      CHECK_RETURN_IF_FALSE(node_id_to_device.count(node_id));
+      RET_CHECK(node_id_to_port_id_to_sdk_port_id.count(node_id));
+      RET_CHECK(node_id_to_device.count(node_id));
       int device = node_id_to_device[node_id];
       for (const auto& e :
            port_id_to_shaping_config.per_port_shaping_configs()) {
         const uint32 port_id = e.first;
         const TofinoConfig::BfPortShapingConfig::BfPerPortShapingConfig&
             shaping_config = e.second;
-        CHECK_RETURN_IF_FALSE(
-            node_id_to_port_id_to_sdk_port_id[node_id].count(port_id));
+        RET_CHECK(node_id_to_port_id_to_sdk_port_id[node_id].count(port_id));
         const uint32 sdk_port_id =
             node_id_to_port_id_to_sdk_port_id[node_id][port_id];
         RETURN_IF_ERROR(ApplyPortShapingConfig(node_id, device, sdk_port_id,
@@ -464,14 +463,14 @@ BfChassisManager::~BfChassisManager() = default;
       const uint64 node_id = key.first;
       const auto& deflect_config = key.second;
       for (const auto& drop_target : deflect_config.drop_targets()) {
-        CHECK_RETURN_IF_FALSE(node_id_to_port_id_to_sdk_port_id.count(node_id));
-        CHECK_RETURN_IF_FALSE(node_id_to_device.count(node_id));
+        RET_CHECK(node_id_to_port_id_to_sdk_port_id.count(node_id));
+        RET_CHECK(node_id_to_device.count(node_id));
         const int device = node_id_to_device[node_id];
         uint32 sdk_port_id;
         switch (drop_target.port_type_case()) {
           case TofinoConfig::DeflectOnPacketDropConfig::DropTarget::kPort: {
             const uint32 port_id = drop_target.port();
-            CHECK_RETURN_IF_FALSE(
+            RET_CHECK(
                 node_id_to_port_id_to_sdk_port_id[node_id].count(port_id));
             sdk_port_id = node_id_to_port_id_to_sdk_port_id[node_id][port_id];
             break;
@@ -490,8 +489,8 @@ BfChassisManager::~BfChassisManager() = default;
         LOG(INFO) << "Configured deflect-on-drop to SDK port " << sdk_port_id
                   << " in node " << node_id << ".";
       }
-      CHECK_RETURN_IF_FALSE(gtl::InsertIfNotPresent(
-          &node_id_to_deflect_on_drop_config, node_id, deflect_config));
+      RET_CHECK(gtl::InsertIfNotPresent(&node_id_to_deflect_on_drop_config,
+                                        node_id, deflect_config));
     }
 
     // Handle QoS configuration.
@@ -507,11 +506,9 @@ BfChassisManager::~BfChassisManager() = default;
           case TofinoConfig::TofinoQosConfig::PpgConfig::kSdkPort:
             break;
           case TofinoConfig::TofinoQosConfig::PpgConfig::kPort: {
-            CHECK_RETURN_IF_FALSE(
-                node_id_to_port_id_to_sdk_port_id.count(node_id));
-            CHECK_RETURN_IF_FALSE(
-                node_id_to_port_id_to_sdk_port_id[node_id].count(
-                    ppg_config.port()))
+            RET_CHECK(node_id_to_port_id_to_sdk_port_id.count(node_id));
+            RET_CHECK(node_id_to_port_id_to_sdk_port_id[node_id].count(
+                ppg_config.port()))
                 << "Invalid singleton port " << ppg_config.port()
                 << " in PpgConfig " << ppg_config.ShortDebugString() << ".";
             ppg_config.set_sdk_port(
@@ -529,11 +526,9 @@ BfChassisManager::~BfChassisManager() = default;
           case TofinoConfig::TofinoQosConfig::QueueConfig::kSdkPort:
             break;
           case TofinoConfig::TofinoQosConfig::QueueConfig::kPort: {
-            CHECK_RETURN_IF_FALSE(
-                node_id_to_port_id_to_sdk_port_id.count(node_id));
-            CHECK_RETURN_IF_FALSE(
-                node_id_to_port_id_to_sdk_port_id[node_id].count(
-                    queue_config.port()))
+            RET_CHECK(node_id_to_port_id_to_sdk_port_id.count(node_id));
+            RET_CHECK(node_id_to_port_id_to_sdk_port_id[node_id].count(
+                queue_config.port()))
                 << "Invalid singleton port " << queue_config.port()
                 << " in QueueConfig " << queue_config.ShortDebugString() << ".";
             queue_config.set_sdk_port(
@@ -549,7 +544,7 @@ BfChassisManager::~BfChassisManager() = default;
       }
       const int device = node_id_to_device[node_id];
       RETURN_IF_ERROR(bf_sde_interface_->ConfigureQos(device, qos_config));
-      CHECK_RETURN_IF_FALSE(
+      RET_CHECK(
           gtl::InsertIfNotPresent(&node_id_to_qos_config, node_id, qos_config));
     }
   }
@@ -633,15 +628,15 @@ BfChassisManager::~BfChassisManager() = default;
 
 ::util::Status BfChassisManager::VerifyChassisConfig(
     const ChassisConfig& config) {
-  CHECK_RETURN_IF_FALSE(config.trunk_ports_size() == 0)
+  RET_CHECK(config.trunk_ports_size() == 0)
       << "Trunk ports are not supported on Tofino.";
-  CHECK_RETURN_IF_FALSE(config.port_groups_size() == 0)
+  RET_CHECK(config.port_groups_size() == 0)
       << "Port groups are not supported on Tofino.";
-  CHECK_RETURN_IF_FALSE(config.nodes_size() > 0)
+  RET_CHECK(config.nodes_size() > 0)
       << "The config must contain at least one node.";
 
   // Find the supported Tofino chip types based on the given platform.
-  CHECK_RETURN_IF_FALSE(config.has_chassis() && config.chassis().platform())
+  RET_CHECK(config.has_chassis() && config.chassis().platform())
       << "Config needs a Chassis message with correct platform.";
   switch (config.chassis().platform()) {
     case PLT_GENERIC_BAREFOOT_TOFINO:
@@ -657,12 +652,10 @@ BfChassisManager::~BfChassisManager() = default;
   std::map<uint64, int> node_id_to_device;
   std::map<int, uint64> device_to_node_id;
   for (const auto& node : config.nodes()) {
-    CHECK_RETURN_IF_FALSE(node.slot() > 0)
+    RET_CHECK(node.slot() > 0)
         << "No positive slot in " << node.ShortDebugString();
-    CHECK_RETURN_IF_FALSE(node.id() > 0)
-        << "No positive ID in " << node.ShortDebugString();
-    CHECK_RETURN_IF_FALSE(
-        gtl::InsertIfNotPresent(&node_id_to_device, node.id(), -1))
+    RET_CHECK(node.id() > 0) << "No positive ID in " << node.ShortDebugString();
+    RET_CHECK(gtl::InsertIfNotPresent(&node_id_to_device, node.id(), -1))
         << "The id for Node " << PrintNode(node) << " was already recorded "
         << "for another Node in the config.";
   }
@@ -687,34 +680,34 @@ BfChassisManager::~BfChassisManager() = default;
   std::map<uint64, std::set<uint32>> node_id_to_port_ids;
   std::set<PortKey> singleton_port_keys;
   for (const auto& singleton_port : config.singleton_ports()) {
-    CHECK_RETURN_IF_FALSE(singleton_port.id() > 0)
+    RET_CHECK(singleton_port.id() > 0)
         << "No positive ID in " << PrintSingletonPort(singleton_port) << ".";
-    CHECK_RETURN_IF_FALSE(singleton_port.id() != kCpuPortId)
+    RET_CHECK(singleton_port.id() != kCpuPortId)
         << "SingletonPort " << PrintSingletonPort(singleton_port)
         << " has the reserved CPU port ID (" << kCpuPortId << ").";
-    CHECK_RETURN_IF_FALSE(singleton_port.id() != kSdnCpuPortId)
+    RET_CHECK(singleton_port.id() != kSdnCpuPortId)
         << "SingletonPort " << PrintSingletonPort(singleton_port)
         << " has the reserved CPU port ID (" << kSdnCpuPortId << ").";
-    CHECK_RETURN_IF_FALSE(singleton_port.slot() > 0)
+    RET_CHECK(singleton_port.slot() > 0)
         << "No valid slot in " << singleton_port.ShortDebugString() << ".";
-    CHECK_RETURN_IF_FALSE(singleton_port.port() > 0)
+    RET_CHECK(singleton_port.port() > 0)
         << "No valid port in " << singleton_port.ShortDebugString() << ".";
-    CHECK_RETURN_IF_FALSE(singleton_port.speed_bps() > 0)
+    RET_CHECK(singleton_port.speed_bps() > 0)
         << "No valid speed_bps in " << singleton_port.ShortDebugString() << ".";
     PortKey singleton_port_key(singleton_port.slot(), singleton_port.port(),
                                singleton_port.channel());
-    CHECK_RETURN_IF_FALSE(!singleton_port_keys.count(singleton_port_key))
+    RET_CHECK(!singleton_port_keys.count(singleton_port_key))
         << "The (slot, port, channel) tuple for SingletonPort "
         << PrintSingletonPort(singleton_port)
         << " was already recorded for another SingletonPort in the config.";
     singleton_port_keys.insert(singleton_port_key);
-    CHECK_RETURN_IF_FALSE(singleton_port.node() > 0)
+    RET_CHECK(singleton_port.node() > 0)
         << "No valid node ID in " << singleton_port.ShortDebugString() << ".";
-    CHECK_RETURN_IF_FALSE(node_id_to_device.count(singleton_port.node()))
+    RET_CHECK(node_id_to_device.count(singleton_port.node()))
         << "Node ID " << singleton_port.node() << " given for SingletonPort "
         << PrintSingletonPort(singleton_port)
         << " has not been given to any Node in the config.";
-    CHECK_RETURN_IF_FALSE(
+    RET_CHECK(
         !node_id_to_port_ids[singleton_port.node()].count(singleton_port.id()))
         << "The id for SingletonPort " << PrintSingletonPort(singleton_port)
         << " was already recorded for another SingletonPort for node with ID "
@@ -738,7 +731,7 @@ BfChassisManager::~BfChassisManager() = default;
 
     // Make sure that the port exists by getting the SDK port ID.
     const int* device = gtl::FindOrNull(node_id_to_device, node_id);
-    CHECK_RETURN_IF_FALSE(device != nullptr)
+    RET_CHECK(device != nullptr)
         << "Node " << node_id << " not found for port " << port_id << ".";
     ASSIGN_OR_RETURN(uint32 sdk_port, bf_sde_interface_->GetPortIdFromPortKey(
                                           *device, singleton_port_key));
@@ -755,8 +748,7 @@ BfChassisManager::~BfChassisManager() = default;
       const uint64 node_id = e.first;
       const TofinoConfig::TofinoQosConfig& qos_config = e.second;
       const int* device = gtl::FindOrNull(node_id_to_device, node_id);
-      CHECK_RETURN_IF_FALSE(device != nullptr)
-          << "Node " << node_id << " not found.";
+      RET_CHECK(device != nullptr) << "Node " << node_id << " not found.";
       for (const auto& queue_config : qos_config.queue_configs()) {
         uint32 sdk_port_id;
         switch (queue_config.port_type_case()) {
@@ -764,9 +756,8 @@ BfChassisManager::~BfChassisManager() = default;
             sdk_port_id = queue_config.sdk_port();
             break;
           case TofinoConfig::TofinoQosConfig::QueueConfig::kPort: {
-            CHECK_RETURN_IF_FALSE(
-                node_id_to_port_id_to_sdk_port_id[node_id].count(
-                    queue_config.port()))
+            RET_CHECK(node_id_to_port_id_to_sdk_port_id[node_id].count(
+                queue_config.port()))
                 << "Invalid singleton port " << queue_config.port()
                 << " in queue config " << queue_config.ShortDebugString()
                 << ".";
@@ -779,16 +770,14 @@ BfChassisManager::~BfChassisManager() = default;
                    << "Unsupported port type in QueueConfig "
                    << queue_config.ShortDebugString() << ".";
         }
-        CHECK_RETURN_IF_FALSE(
-            gtl::FindOrNull(node_id_to_sdk_port_id_to_port_id[node_id],
-                            sdk_port_id) != nullptr)
+        RET_CHECK(gtl::FindOrNull(node_id_to_sdk_port_id_to_port_id[node_id],
+                                  sdk_port_id) != nullptr)
             << "Invalid port " << sdk_port_id << " in queue config "
             << queue_config.ShortDebugString() << ".";
-        CHECK_RETURN_IF_FALSE(queue_config.queue_mapping_size() <=
-                              kMaxQueuesPerPort);
+        RET_CHECK(queue_config.queue_mapping_size() <= kMaxQueuesPerPort);
         // Check that queue mappings are in ascending order starting from zero.
         for (int i = 0; i < queue_config.queue_mapping_size(); ++i) {
-          CHECK_RETURN_IF_FALSE(i == queue_config.queue_mapping(i).queue_id())
+          RET_CHECK(i == queue_config.queue_mapping(i).queue_id())
               << "Found out-of-order queue mapping for queue id "
               << queue_config.queue_mapping(i).queue_id() << " in queue config "
               << queue_config.ShortDebugString() << ".";
@@ -836,10 +825,10 @@ BfChassisManager::~BfChassisManager() = default;
 BfChassisManager::GetPortConfig(uint64 node_id, uint32 port_id) const {
   auto* port_id_to_config =
       gtl::FindOrNull(node_id_to_port_id_to_port_config_, node_id);
-  CHECK_RETURN_IF_FALSE(port_id_to_config != nullptr)
+  RET_CHECK(port_id_to_config != nullptr)
       << "Node " << node_id << " is not configured or not known.";
   const PortConfig* config = gtl::FindOrNull(*port_id_to_config, port_id);
-  CHECK_RETURN_IF_FALSE(config != nullptr)
+  RET_CHECK(config != nullptr)
       << "Port " << port_id << " is not configured or not known for node "
       << node_id << ".";
   return config;
@@ -853,11 +842,11 @@ BfChassisManager::GetPortConfig(uint64 node_id, uint32 port_id) const {
 
   const auto* port_map =
       gtl::FindOrNull(node_id_to_port_id_to_sdk_port_id_, node_id);
-  CHECK_RETURN_IF_FALSE(port_map != nullptr)
+  RET_CHECK(port_map != nullptr)
       << "Node " << node_id << " is not configured or not known.";
 
   const uint32* sdk_port_id = gtl::FindOrNull(*port_map, port_id);
-  CHECK_RETURN_IF_FALSE(sdk_port_id != nullptr)
+  RET_CHECK(sdk_port_id != nullptr)
       << "Port " << port_id << " for node " << node_id
       << " is not configured or not known.";
 
@@ -1004,11 +993,11 @@ BfChassisManager::GetPortConfig(uint64 node_id, uint32 port_id) const {
 
   const std::map<uint32, PortState>* port_id_to_port_state =
       gtl::FindOrNull(node_id_to_port_id_to_port_state_, node_id);
-  CHECK_RETURN_IF_FALSE(port_id_to_port_state != nullptr)
+  RET_CHECK(port_id_to_port_state != nullptr)
       << "Node " << node_id << " is not configured or not known.";
   const PortState* port_state =
       gtl::FindOrNull(*port_id_to_port_state, port_id);
-  CHECK_RETURN_IF_FALSE(port_state != nullptr)
+  RET_CHECK(port_state != nullptr)
       << "Port " << port_id << " is not known on node " << node_id << ".";
 
   if (*port_state == PORT_STATE_UNKNOWN) {
@@ -1029,10 +1018,8 @@ BfChassisManager::GetPortConfig(uint64 node_id, uint32 port_id) const {
     return MAKE_ERROR(ERR_NOT_INITIALIZED) << "Not initialized!";
   }
 
-  CHECK_RETURN_IF_FALSE(
-      node_id_to_port_id_to_time_last_changed_.count(node_id));
-  CHECK_RETURN_IF_FALSE(
-      node_id_to_port_id_to_time_last_changed_[node_id].count(port_id));
+  RET_CHECK(node_id_to_port_id_to_time_last_changed_.count(node_id));
+  RET_CHECK(node_id_to_port_id_to_time_last_changed_[node_id].count(port_id));
   return node_id_to_port_id_to_time_last_changed_[node_id][port_id];
 }
 
@@ -1191,12 +1178,11 @@ BfChassisManager::GetPortConfig(uint64 node_id, uint32 port_id) const {
     uint64 node_id, uint32 port_id, FrontPanelPortInfo* fp_port_info) {
   auto* port_id_to_port_key =
       gtl::FindOrNull(node_id_to_port_id_to_singleton_port_key_, node_id);
-  CHECK_RETURN_IF_FALSE(port_id_to_port_key != nullptr)
+  RET_CHECK(port_id_to_port_key != nullptr)
       << "Node " << node_id << " is not configured or not known.";
   auto* port_key = gtl::FindOrNull(*port_id_to_port_key, port_id);
-  CHECK_RETURN_IF_FALSE(port_key != nullptr)
-      << "Node " << node_id << ", port " << port_id
-      << " is not configured or not known.";
+  RET_CHECK(port_key != nullptr) << "Node " << node_id << ", port " << port_id
+                                 << " is not configured or not known.";
   return phal_interface_->GetFrontPanelPortInfo(port_key->slot, port_key->port,
                                                 fp_port_info);
 }
@@ -1509,7 +1495,7 @@ void BfChassisManager::TransceiverEventHandler(int slot, int port,
     return MAKE_ERROR(ERR_NOT_INITIALIZED) << "Not initialized!";
   }
   const int* device = gtl::FindOrNull(node_id_to_device_, node_id);
-  CHECK_RETURN_IF_FALSE(device != nullptr)
+  RET_CHECK(device != nullptr)
       << "Node " << node_id << " is not configured or not known.";
 
   return *device;

--- a/stratum/hal/lib/barefoot/bf_chassis_manager_test.cc
+++ b/stratum/hal/lib/barefoot/bf_chassis_manager_test.cc
@@ -159,23 +159,17 @@ class BfChassisManagerTest : public ::testing::Test {
   }
 
   ::util::Status CheckCleanInternalState() {
-    CHECK_RETURN_IF_FALSE(bf_chassis_manager_->device_to_node_id_.empty());
-    CHECK_RETURN_IF_FALSE(bf_chassis_manager_->node_id_to_device_.empty());
-    CHECK_RETURN_IF_FALSE(
-        bf_chassis_manager_->node_id_to_port_id_to_port_state_.empty());
-    CHECK_RETURN_IF_FALSE(
-        bf_chassis_manager_->node_id_to_port_id_to_port_config_.empty());
-    CHECK_RETURN_IF_FALSE(
+    RET_CHECK(bf_chassis_manager_->device_to_node_id_.empty());
+    RET_CHECK(bf_chassis_manager_->node_id_to_device_.empty());
+    RET_CHECK(bf_chassis_manager_->node_id_to_port_id_to_port_state_.empty());
+    RET_CHECK(bf_chassis_manager_->node_id_to_port_id_to_port_config_.empty());
+    RET_CHECK(
         bf_chassis_manager_->node_id_to_port_id_to_singleton_port_key_.empty());
-    CHECK_RETURN_IF_FALSE(
-        bf_chassis_manager_->node_id_to_port_id_to_sdk_port_id_.empty());
-    CHECK_RETURN_IF_FALSE(
-        bf_chassis_manager_->node_id_to_sdk_port_id_to_port_id_.empty());
-    CHECK_RETURN_IF_FALSE(
-        bf_chassis_manager_->xcvr_port_key_to_xcvr_state_.empty());
-    CHECK_RETURN_IF_FALSE(bf_chassis_manager_->port_status_event_channel_ ==
-                          nullptr);
-    CHECK_RETURN_IF_FALSE(bf_chassis_manager_->xcvr_event_channel_ == nullptr);
+    RET_CHECK(bf_chassis_manager_->node_id_to_port_id_to_sdk_port_id_.empty());
+    RET_CHECK(bf_chassis_manager_->node_id_to_sdk_port_id_to_port_id_.empty());
+    RET_CHECK(bf_chassis_manager_->xcvr_port_key_to_xcvr_state_.empty());
+    RET_CHECK(bf_chassis_manager_->port_status_event_channel_ == nullptr);
+    RET_CHECK(bf_chassis_manager_->xcvr_event_channel_ == nullptr);
     return ::util::OkStatus();
   }
 
@@ -197,7 +191,7 @@ class BfChassisManagerTest : public ::testing::Test {
   }
 
   ::util::Status PushBaseChassisConfig(ChassisConfigBuilder* builder) {
-    CHECK_RETURN_IF_FALSE(!Initialized())
+    RET_CHECK(!Initialized())
         << "Can only call PushBaseChassisConfig() for first ChassisConfig!";
     RegisterSdkPortId(builder->AddPort(kPortId, kPort, ADMIN_STATE_ENABLED));
 
@@ -222,11 +216,9 @@ class BfChassisManagerTest : public ::testing::Test {
 
     RETURN_IF_ERROR(PushChassisConfig(builder->Get()));
     auto device = GetDeviceFromNodeId(kNodeId);
-    CHECK_RETURN_IF_FALSE(device.ok());
-    CHECK_RETURN_IF_FALSE(device.ValueOrDie() == kDevice)
-        << "Invalid device number!";
-    CHECK_RETURN_IF_FALSE(Initialized())
-        << "Class is not initialized after push!";
+    RET_CHECK(device.ok());
+    RET_CHECK(device.ValueOrDie() == kDevice) << "Invalid device number!";
+    RET_CHECK(Initialized()) << "Class is not initialized after push!";
     return ::util::OkStatus();
   }
 

--- a/stratum/hal/lib/barefoot/bf_pipeline_utils.cc
+++ b/stratum/hal/lib/barefoot/bf_pipeline_utils.cc
@@ -45,10 +45,10 @@ std::string Uint32ToLeByteStream(uint32 val) {
 
 ::util::Status BfPipelineConfigToPiConfig(const BfPipelineConfig& bf_config,
                                           std::string* pi_node_config) {
-  CHECK_RETURN_IF_FALSE(pi_node_config) << "null pointer.";
+  RET_CHECK(pi_node_config) << "null pointer.";
 
   // Validate restrictions.
-  CHECK_RETURN_IF_FALSE(bf_config.profiles_size() == 1)
+  RET_CHECK(bf_config.profiles_size() == 1)
       << "Only single pipeline P4 configs are supported.";
   const auto& profile = bf_config.profiles(0);
 

--- a/stratum/hal/lib/barefoot/bf_sde_wrapper.cc
+++ b/stratum/hal/lib/barefoot/bf_sde_wrapper.cc
@@ -248,7 +248,7 @@ inline constexpr uint64 BytesPerSecondToKbits(uint64 bytes) {
   RETURN_IF_BFRT_ERROR(table_key.tableGet(&table));
   RETURN_IF_BFRT_ERROR(table->keyFieldIdGet(field_name, &field_id));
   RETURN_IF_BFRT_ERROR(table->keyFieldDataTypeGet(field_id, &data_type));
-  CHECK_RETURN_IF_FALSE(data_type == bfrt::DataType::UINT64)
+  RET_CHECK(data_type == bfrt::DataType::UINT64)
       << "Requested uint64 but field " << field_name << " has type "
       << static_cast<int>(data_type);
   RETURN_IF_BFRT_ERROR(table_key.getValue(field_id, field_value));
@@ -264,7 +264,7 @@ inline constexpr uint64 BytesPerSecondToKbits(uint64 bytes) {
   RETURN_IF_BFRT_ERROR(table_key->tableGet(&table));
   RETURN_IF_BFRT_ERROR(table->keyFieldIdGet(field_name, &field_id));
   RETURN_IF_BFRT_ERROR(table->keyFieldDataTypeGet(field_id, &data_type));
-  CHECK_RETURN_IF_FALSE(data_type == bfrt::DataType::UINT64)
+  RET_CHECK(data_type == bfrt::DataType::UINT64)
       << "Setting uint64 but field " << field_name << " has type "
       << static_cast<int>(data_type);
   RETURN_IF_BFRT_ERROR(table_key->setValue(field_id, value));
@@ -289,7 +289,7 @@ inline constexpr uint64 BytesPerSecondToKbits(uint64 bytes) {
     RETURN_IF_BFRT_ERROR(table->dataFieldIdGet(field_name, &field_id));
     RETURN_IF_BFRT_ERROR(table->dataFieldDataTypeGet(field_id, &data_type));
   }
-  CHECK_RETURN_IF_FALSE(data_type == bfrt::DataType::UINT64)
+  RET_CHECK(data_type == bfrt::DataType::UINT64)
       << "Requested uint64 but field " << field_name << " has type "
       << static_cast<int>(data_type);
   RETURN_IF_BFRT_ERROR(table_data.getValue(field_id, field_value));
@@ -314,7 +314,7 @@ inline constexpr uint64 BytesPerSecondToKbits(uint64 bytes) {
     RETURN_IF_BFRT_ERROR(table->dataFieldIdGet(field_name, &field_id));
     RETURN_IF_BFRT_ERROR(table->dataFieldDataTypeGet(field_id, &data_type));
   }
-  CHECK_RETURN_IF_FALSE(data_type == bfrt::DataType::STRING)
+  RET_CHECK(data_type == bfrt::DataType::STRING)
       << "Requested string but field " << field_name << " has type "
       << static_cast<int>(data_type);
   RETURN_IF_BFRT_ERROR(table_data.getValue(field_id, field_value));
@@ -339,7 +339,7 @@ inline constexpr uint64 BytesPerSecondToKbits(uint64 bytes) {
     RETURN_IF_BFRT_ERROR(table->dataFieldIdGet(field_name, &field_id));
     RETURN_IF_BFRT_ERROR(table->dataFieldDataTypeGet(field_id, &data_type));
   }
-  CHECK_RETURN_IF_FALSE(data_type == bfrt::DataType::BOOL)
+  RET_CHECK(data_type == bfrt::DataType::BOOL)
       << "Requested bool but field " << field_name << " has type "
       << static_cast<int>(data_type);
   RETURN_IF_BFRT_ERROR(table_data.getValue(field_id, field_value));
@@ -365,8 +365,8 @@ template <typename T>
     RETURN_IF_BFRT_ERROR(table->dataFieldIdGet(field_name, &field_id));
     RETURN_IF_BFRT_ERROR(table->dataFieldDataTypeGet(field_id, &data_type));
   }
-  CHECK_RETURN_IF_FALSE(data_type == bfrt::DataType::INT_ARR ||
-                        data_type == bfrt::DataType::BOOL_ARR)
+  RET_CHECK(data_type == bfrt::DataType::INT_ARR ||
+            data_type == bfrt::DataType::BOOL_ARR)
       << "Requested array but field has type " << static_cast<int>(data_type);
   RETURN_IF_BFRT_ERROR(table_data.getValue(field_id, field_values));
 
@@ -390,7 +390,7 @@ template <typename T>
     RETURN_IF_BFRT_ERROR(table->dataFieldIdGet(field_name, &field_id));
     RETURN_IF_BFRT_ERROR(table->dataFieldDataTypeGet(field_id, &data_type));
   }
-  CHECK_RETURN_IF_FALSE(data_type == bfrt::DataType::UINT64)
+  RET_CHECK(data_type == bfrt::DataType::UINT64)
       << "Setting uint64 but field " << field_name << " has type "
       << static_cast<int>(data_type);
   RETURN_IF_BFRT_ERROR(table_data->setValue(field_id, value));
@@ -415,7 +415,7 @@ template <typename T>
     RETURN_IF_BFRT_ERROR(table->dataFieldIdGet(field_name, &field_id));
     RETURN_IF_BFRT_ERROR(table->dataFieldDataTypeGet(field_id, &data_type));
   }
-  CHECK_RETURN_IF_FALSE(data_type == bfrt::DataType::STRING)
+  RET_CHECK(data_type == bfrt::DataType::STRING)
       << "Setting string but field " << field_name << " has type "
       << static_cast<int>(data_type);
   RETURN_IF_BFRT_ERROR(table_data->setValue(field_id, field_value));
@@ -440,7 +440,7 @@ template <typename T>
     RETURN_IF_BFRT_ERROR(table->dataFieldIdGet(field_name, &field_id));
     RETURN_IF_BFRT_ERROR(table->dataFieldDataTypeGet(field_id, &data_type));
   }
-  CHECK_RETURN_IF_FALSE(data_type == bfrt::DataType::BOOL)
+  RET_CHECK(data_type == bfrt::DataType::BOOL)
       << "Setting bool but field " << field_name << " has type "
       << static_cast<int>(data_type);
   RETURN_IF_BFRT_ERROR(table_data->setValue(field_id, field_value));
@@ -466,8 +466,8 @@ template <typename T>
     RETURN_IF_BFRT_ERROR(table->dataFieldIdGet(field_name, &field_id));
     RETURN_IF_BFRT_ERROR(table->dataFieldDataTypeGet(field_id, &data_type));
   }
-  CHECK_RETURN_IF_FALSE(data_type == bfrt::DataType::INT_ARR ||
-                        data_type == bfrt::DataType::BOOL_ARR)
+  RET_CHECK(data_type == bfrt::DataType::INT_ARR ||
+            data_type == bfrt::DataType::BOOL_ARR)
       << "Requested array but field has type " << static_cast<int>(data_type);
   RETURN_IF_BFRT_ERROR(table_data->setValue(field_id, value));
 
@@ -479,8 +479,8 @@ template <typename T>
     bf_rt_target_t bf_dev_target, const bfrt::BfRtTable* table,
     std::vector<std::unique_ptr<bfrt::BfRtTableKey>>* table_keys,
     std::vector<std::unique_ptr<bfrt::BfRtTableData>>* table_datums) {
-  CHECK_RETURN_IF_FALSE(table_keys) << "table_keys is null";
-  CHECK_RETURN_IF_FALSE(table_datums) << "table_datums is null";
+  RET_CHECK(table_keys) << "table_keys is null";
+  RET_CHECK(table_datums) << "table_datums is null";
 
   // Get number of entries. Some types of tables are preallocated and are always
   // "full". The SDE does not support querying the usage on these.
@@ -792,7 +792,7 @@ TableKey::CreateTableKey(const bfrt::BfRtInfo* bfrt_info_, int table_id) {
   bfrt::DataType data_type;
   RETURN_IF_BFRT_ERROR(table->dataFieldIdGet(kActionMemberId, &field_id));
   RETURN_IF_BFRT_ERROR(table->dataFieldDataTypeGet(field_id, &data_type));
-  CHECK_RETURN_IF_FALSE(data_type == bfrt::DataType::UINT64)
+  RET_CHECK(data_type == bfrt::DataType::UINT64)
       << "Requested uint64 but field $ACTION_MEMBER_ID has type "
       << static_cast<int>(data_type);
   bool is_active;
@@ -824,7 +824,7 @@ TableKey::CreateTableKey(const bfrt::BfRtInfo* bfrt_info_, int table_id) {
   bfrt::DataType data_type;
   RETURN_IF_BFRT_ERROR(table->dataFieldIdGet(kSelectorGroupId, &field_id));
   RETURN_IF_BFRT_ERROR(table->dataFieldDataTypeGet(field_id, &data_type));
-  CHECK_RETURN_IF_FALSE(data_type == bfrt::DataType::UINT64)
+  RET_CHECK(data_type == bfrt::DataType::UINT64)
       << "Requested uint64 but field $SELECTOR_GROUP_ID has type "
       << static_cast<int>(data_type);
   bool is_active;
@@ -878,8 +878,8 @@ TableKey::CreateTableKey(const bfrt::BfRtInfo* bfrt_info_, int table_id) {
 }
 
 ::util::Status TableData::GetCounterData(uint64* bytes, uint64* packets) const {
-  CHECK_RETURN_IF_FALSE(bytes);
-  CHECK_RETURN_IF_FALSE(packets);
+  RET_CHECK(bytes);
+  RET_CHECK(packets);
   const bfrt::BfRtTable* table;
   RETURN_IF_BFRT_ERROR(table_data_->getParent(&table));
 
@@ -918,7 +918,7 @@ TableKey::CreateTableKey(const bfrt::BfRtInfo* bfrt_info_, int table_id) {
 }
 
 ::util::Status TableData::GetActionId(int* action_id) const {
-  CHECK_RETURN_IF_FALSE(action_id);
+  RET_CHECK(action_id);
   const bfrt::BfRtTable* table;
   RETURN_IF_BFRT_ERROR(table_data_->getParent(&table));
   bf_rt_id_t bf_action_id = 0;
@@ -1547,8 +1547,7 @@ bool BfSdeWrapper::IsValidPort(int device, int port) {
 ::util::StatusOr<bool> BfSdeWrapper::IsSoftwareModel(int device) {
   bool is_sw_model;
   auto bf_status = bf_pal_pltfm_type_get(device, &is_sw_model);
-  CHECK_RETURN_IF_FALSE(bf_status == BF_SUCCESS)
-      << "Error getting software model status.";
+  RET_CHECK(bf_status == BF_SUCCESS) << "Error getting software model status.";
 
   return is_sw_model;
 }
@@ -1678,9 +1677,8 @@ std::string BfSdeWrapper::GetSdeVersion() const {
 ::util::StatusOr<uint32> BfSdeWrapper::GetPortIdFromPortKey(
     int device, const PortKey& port_key) {
   const int port = port_key.port;
-  CHECK_RETURN_IF_FALSE(port >= 0)
-      << "Port ID must be non-negative. Attempted to get port " << port
-      << " on dev " << device << ".";
+  RET_CHECK(port >= 0) << "Port ID must be non-negative. Attempted to get port "
+                       << port << " on dev " << device << ".";
 
   // PortKey uses three possible values for channel:
   //     > 0: port is channelized (first channel is 1)
@@ -1691,12 +1689,12 @@ std::string BfSdeWrapper::GetSdeVersion() const {
   //     Otherwise, port is already 0 in the non-channelized case
   const int channel =
       (port_key.channel > 0) ? port_key.channel - 1 : port_key.channel;
-  CHECK_RETURN_IF_FALSE(channel >= 0)
-      << "Channel must be set for port " << port << " on dev " << device << ".";
+  RET_CHECK(channel >= 0) << "Channel must be set for port " << port
+                          << " on dev " << device << ".";
 
   char port_string[MAX_PORT_HDL_STRING_LEN];
   int r = snprintf(port_string, sizeof(port_string), "%d/%d", port, channel);
-  CHECK_RETURN_IF_FALSE(r > 0 && r < sizeof(port_string))
+  RET_CHECK(r > 0 && r < sizeof(port_string))
       << "Failed to build port string for port " << port << " channel "
       << channel << " on dev " << device << ".";
 
@@ -1708,12 +1706,12 @@ std::string BfSdeWrapper::GetSdeVersion() const {
 
 ::util::StatusOr<int> BfSdeWrapper::GetPcieCpuPort(int device) {
   int port = p4_devport_mgr_pcie_cpu_port_get(device);
-  CHECK_RETURN_IF_FALSE(port != -1);
+  RET_CHECK(port != -1);
   return port;
 }
 
 ::util::Status BfSdeWrapper::SetTmCpuPort(int device, int port) {
-  CHECK_RETURN_IF_FALSE(p4_pd_tm_set_cpuport(device, port) == 0)
+  RET_CHECK(p4_pd_tm_set_cpuport(device, port) == 0)
       << "Unable to set CPU port " << port << " on device " << device;
   return ::util::OkStatus();
 }
@@ -1732,9 +1730,8 @@ std::string BfSdeWrapper::GetSdeVersion() const {
 ::util::Status BfSdeWrapper::InitializeSde(const std::string& sde_install_path,
                                            const std::string& sde_config_file,
                                            bool run_in_background) {
-  CHECK_RETURN_IF_FALSE(sde_install_path != "")
-      << "sde_install_path is required";
-  CHECK_RETURN_IF_FALSE(sde_config_file != "") << "sde_config_file is required";
+  RET_CHECK(sde_install_path != "") << "sde_install_path is required";
+  RET_CHECK(sde_config_file != "") << "sde_config_file is required";
 
   // Parse bf_switchd arguments.
   auto switchd_main_ctx = absl::make_unique<bf_switchd_context_t>();
@@ -1774,8 +1771,8 @@ std::string BfSdeWrapper::GetSdeVersion() const {
                                        const BfrtDeviceConfig& device_config) {
   absl::WriterMutexLock l(&data_lock_);
 
-  // CHECK_RETURN_IF_FALSE(initialized_) << "Not initialized";
-  CHECK_RETURN_IF_FALSE(device_config.programs_size() > 0);
+  // RET_CHECK(initialized_) << "Not initialized";
+  RET_CHECK(device_config.programs_size() > 0);
 
   // if (pipeline_initialized_) {
   // RETURN_IF_BFRT_ERROR(bf_device_remove(device));
@@ -1809,7 +1806,7 @@ std::string BfSdeWrapper::GetSdeVersion() const {
     p4_program->bfrt_json_file = &(*bfrt_path)[0];
     p4_program->num_p4_pipelines = program.pipelines_size();
     path_strings.emplace_back(std::move(bfrt_path));
-    CHECK_RETURN_IF_FALSE(program.pipelines_size() > 0);
+    RET_CHECK(program.pipelines_size() > 0);
     for (int j = 0; j < program.pipelines_size(); ++j) {
       const auto& pipeline = program.pipelines(j);
       const std::string pipeline_path =
@@ -1830,7 +1827,7 @@ std::string BfSdeWrapper::GetSdeVersion() const {
       path_strings.emplace_back(std::move(config_path));
       path_strings.emplace_back(std::move(context_path));
 
-      CHECK_RETURN_IF_FALSE(pipeline.scope_size() <= MAX_P4_PIPELINES);
+      RET_CHECK(pipeline.scope_size() <= MAX_P4_PIPELINES);
       pipeline_profile->num_pipes_in_scope = pipeline.scope_size();
       for (int p = 0; p < pipeline.scope_size(); ++p) {
         const auto& scope = pipeline.scope(p);
@@ -1847,18 +1844,18 @@ std::string BfSdeWrapper::GetSdeVersion() const {
   // Set SDE log levels for modules of interest.
   // TODO(max): create story around SDE logs. How to get them into glog? What
   // levels to enable for which modules?
-  CHECK_RETURN_IF_FALSE(
+  RET_CHECK(
       bf_sys_log_level_set(BF_MOD_BFRT, BF_LOG_DEST_STDOUT, BF_LOG_WARN) == 0);
-  CHECK_RETURN_IF_FALSE(
-      bf_sys_log_level_set(BF_MOD_PKT, BF_LOG_DEST_STDOUT, BF_LOG_WARN) == 0);
-  CHECK_RETURN_IF_FALSE(
+  RET_CHECK(bf_sys_log_level_set(BF_MOD_PKT, BF_LOG_DEST_STDOUT, BF_LOG_WARN) ==
+            0);
+  RET_CHECK(
       bf_sys_log_level_set(BF_MOD_PIPE, BF_LOG_DEST_STDOUT, BF_LOG_WARN) == 0);
-  CHECK_RETURN_IF_FALSE(
-      bf_sys_log_level_set(BF_MOD_TM, BF_LOG_DEST_STDOUT, BF_LOG_WARN) == 0);
+  RET_CHECK(bf_sys_log_level_set(BF_MOD_TM, BF_LOG_DEST_STDOUT, BF_LOG_WARN) ==
+            0);
   stat_mgr_enable_detail_trace = false;
   if (VLOG_IS_ON(2)) {
-    CHECK_RETURN_IF_FALSE(bf_sys_log_level_set(BF_MOD_PIPE, BF_LOG_DEST_STDOUT,
-                                               BF_LOG_INFO) == 0);
+    RET_CHECK(bf_sys_log_level_set(BF_MOD_PIPE, BF_LOG_DEST_STDOUT,
+                                   BF_LOG_INFO) == 0);
     stat_mgr_enable_detail_trace = true;
   }
 
@@ -1966,8 +1963,8 @@ BfSdeWrapper::CreateTableData(int table_id, int action_id) {
                                             bf_pkt_rx_ring_t rx_ring) {
   absl::ReaderMutexLock l(&packet_rx_callback_lock_);
   auto rx_writer = gtl::FindOrNull(device_to_packet_rx_writer_, device);
-  CHECK_RETURN_IF_FALSE(rx_writer)
-      << "No Rx callback registered for device id " << device << ".";
+  RET_CHECK(rx_writer) << "No Rx callback registered for device id " << device
+                       << ".";
 
   std::string buffer(reinterpret_cast<const char*>(bf_pkt_get_pkt_data(pkt)),
                      bf_pkt_get_pkt_size(pkt));
@@ -2064,7 +2061,7 @@ namespace {
     int device, std::shared_ptr<BfSdeInterface::SessionInterface> session) {
   if (VLOG_IS_ON(2)) {
     auto real_session = std::dynamic_pointer_cast<Session>(session);
-    CHECK_RETURN_IF_FALSE(real_session);
+    RET_CHECK(real_session);
 
     auto bf_dev_tgt = GetDeviceTarget(device);
     const bfrt::BfRtTable* table;
@@ -2105,7 +2102,7 @@ namespace {
 ::util::StatusOr<uint32> BfSdeWrapper::GetFreeMulticastNodeId(
     int device, std::shared_ptr<BfSdeInterface::SessionInterface> session) {
   auto real_session = std::dynamic_pointer_cast<Session>(session);
-  CHECK_RETURN_IF_FALSE(real_session);
+  RET_CHECK(real_session);
 
   auto bf_dev_tgt = GetDeviceTarget(device);
   const bfrt::BfRtTable* table;
@@ -2153,7 +2150,7 @@ namespace {
   ::absl::ReaderMutexLock l(&data_lock_);
 
   auto real_session = std::dynamic_pointer_cast<Session>(session);
-  CHECK_RETURN_IF_FALSE(real_session);
+  RET_CHECK(real_session);
 
   const bfrt::BfRtTable* table;  // PRE node table.
   bf_rt_id_t table_id;
@@ -2191,7 +2188,7 @@ namespace {
   ::absl::ReaderMutexLock l(&data_lock_);
 
   auto real_session = std::dynamic_pointer_cast<Session>(session);
-  CHECK_RETURN_IF_FALSE(real_session);
+  RET_CHECK(real_session);
 
   auto bf_dev_tgt = GetDeviceTarget(device);
   const bfrt::BfRtTable* table;
@@ -2218,7 +2215,7 @@ namespace {
     const std::vector<uint32>& mc_node_ids) {
   ::absl::ReaderMutexLock l(&data_lock_);
   auto real_session = std::dynamic_pointer_cast<Session>(session);
-  CHECK_RETURN_IF_FALSE(real_session);
+  RET_CHECK(real_session);
 
   auto bf_dev_tgt = GetDeviceTarget(device);
   const bfrt::BfRtTable* table;
@@ -2242,12 +2239,12 @@ namespace {
     int device, std::shared_ptr<BfSdeInterface::SessionInterface> session,
     uint32 mc_node_id, int* replication_id, std::vector<uint32>* lag_ids,
     std::vector<uint32>* ports) {
-  CHECK_RETURN_IF_FALSE(replication_id);
-  CHECK_RETURN_IF_FALSE(lag_ids);
-  CHECK_RETURN_IF_FALSE(ports);
+  RET_CHECK(replication_id);
+  RET_CHECK(lag_ids);
+  RET_CHECK(ports);
   ::absl::ReaderMutexLock l(&data_lock_);
   auto real_session = std::dynamic_pointer_cast<Session>(session);
-  CHECK_RETURN_IF_FALSE(real_session);
+  RET_CHECK(real_session);
 
   auto bf_dev_tgt = GetDeviceTarget(device);
   const bfrt::BfRtTable* table;  // PRE node table.
@@ -2284,7 +2281,7 @@ namespace {
     int device, std::shared_ptr<BfSdeInterface::SessionInterface> session,
     uint32 group_id, const std::vector<uint32>& mc_node_ids, bool insert) {
   auto real_session = std::dynamic_pointer_cast<Session>(session);
-  CHECK_RETURN_IF_FALSE(real_session);
+  RET_CHECK(real_session);
 
   const bfrt::BfRtTable* table;  // PRE MGID table.
   bf_rt_id_t table_id;
@@ -2345,7 +2342,7 @@ namespace {
     uint32 group_id) {
   ::absl::ReaderMutexLock l(&data_lock_);
   auto real_session = std::dynamic_pointer_cast<Session>(session);
-  CHECK_RETURN_IF_FALSE(real_session);
+  RET_CHECK(real_session);
 
   auto bf_dev_tgt = GetDeviceTarget(device);
   const bfrt::BfRtTable* table;  // PRE MGID table.
@@ -2364,11 +2361,11 @@ namespace {
     int device, std::shared_ptr<BfSdeInterface::SessionInterface> session,
     uint32 group_id, std::vector<uint32>* group_ids,
     std::vector<std::vector<uint32>>* mc_node_ids) {
-  CHECK_RETURN_IF_FALSE(group_ids);
-  CHECK_RETURN_IF_FALSE(mc_node_ids);
+  RET_CHECK(group_ids);
+  RET_CHECK(mc_node_ids);
   ::absl::ReaderMutexLock l(&data_lock_);
   auto real_session = std::dynamic_pointer_cast<Session>(session);
-  CHECK_RETURN_IF_FALSE(real_session);
+  RET_CHECK(real_session);
 
   auto bf_dev_tgt = GetDeviceTarget(device);
   const bfrt::BfRtTable* table;  // PRE MGID table.
@@ -2418,7 +2415,7 @@ namespace {
     uint32 session_id, int egress_port, int egress_queue, int cos,
     int max_pkt_len, bool insert) {
   auto real_session = std::dynamic_pointer_cast<Session>(session);
-  CHECK_RETURN_IF_FALSE(real_session);
+  RET_CHECK(real_session);
 
   const bfrt::BfRtTable* table;
   RETURN_IF_BFRT_ERROR(
@@ -2485,7 +2482,7 @@ namespace {
     uint32 session_id) {
   ::absl::ReaderMutexLock l(&data_lock_);
   auto real_session = std::dynamic_pointer_cast<Session>(session);
-  CHECK_RETURN_IF_FALSE(real_session);
+  RET_CHECK(real_session);
 
   const bfrt::BfRtTable* table;
   RETURN_IF_BFRT_ERROR(
@@ -2511,13 +2508,13 @@ namespace {
     uint32 session_id, std::vector<uint32>* session_ids,
     std::vector<int>* egress_ports, std::vector<int>* coss,
     std::vector<int>* max_pkt_lens) {
-  CHECK_RETURN_IF_FALSE(session_ids);
-  CHECK_RETURN_IF_FALSE(egress_ports);
-  CHECK_RETURN_IF_FALSE(coss);
-  CHECK_RETURN_IF_FALSE(max_pkt_lens);
+  RET_CHECK(session_ids);
+  RET_CHECK(egress_ports);
+  RET_CHECK(coss);
+  RET_CHECK(max_pkt_lens);
   ::absl::ReaderMutexLock l(&data_lock_);
   auto real_session = std::dynamic_pointer_cast<Session>(session);
-  CHECK_RETURN_IF_FALSE(real_session);
+  RET_CHECK(real_session);
 
   auto bf_dev_tgt = GetDeviceTarget(device);
   const bfrt::BfRtTable* table;
@@ -2569,13 +2566,12 @@ namespace {
     // Data: $session_enable
     bool session_enable;
     RETURN_IF_ERROR(GetField(*table_data, "$session_enable", &session_enable));
-    CHECK_RETURN_IF_FALSE(session_enable)
-        << "Found a session that is not enabled.";
+    RET_CHECK(session_enable) << "Found a session that is not enabled.";
     // Data: $ucast_egress_port_valid
     bool ucast_egress_port_valid;
     RETURN_IF_ERROR(GetField(*table_data, "$ucast_egress_port_valid",
                              &ucast_egress_port_valid));
-    CHECK_RETURN_IF_FALSE(ucast_egress_port_valid)
+    RET_CHECK(ucast_egress_port_valid)
         << "Found a unicase egress port that is not set valid.";
   }
 
@@ -2593,7 +2589,7 @@ namespace {
     absl::optional<uint64> packet_count) {
   ::absl::ReaderMutexLock l(&data_lock_);
   auto real_session = std::dynamic_pointer_cast<Session>(session);
-  CHECK_RETURN_IF_FALSE(real_session);
+  RET_CHECK(real_session);
 
   const bfrt::BfRtTable* table;
   RETURN_IF_BFRT_ERROR(bfrt_info_->bfrtTableFromIdGet(counter_id, &table));
@@ -2637,12 +2633,12 @@ namespace {
     std::vector<absl::optional<uint64>>* byte_counts,
     std::vector<absl::optional<uint64>>* packet_counts,
     absl::Duration timeout) {
-  CHECK_RETURN_IF_FALSE(counter_indices);
-  CHECK_RETURN_IF_FALSE(byte_counts);
-  CHECK_RETURN_IF_FALSE(packet_counts);
+  RET_CHECK(counter_indices);
+  RET_CHECK(byte_counts);
+  RET_CHECK(packet_counts);
   ::absl::ReaderMutexLock l(&data_lock_);
   auto real_session = std::dynamic_pointer_cast<Session>(session);
-  CHECK_RETURN_IF_FALSE(real_session);
+  RET_CHECK(real_session);
 
   auto bf_dev_tgt = GetDeviceTarget(device);
   const bfrt::BfRtTable* table;
@@ -2741,7 +2737,7 @@ namespace {
     const std::string& register_data) {
   ::absl::ReaderMutexLock l(&data_lock_);
   auto real_session = std::dynamic_pointer_cast<Session>(session);
-  CHECK_RETURN_IF_FALSE(real_session);
+  RET_CHECK(real_session);
 
   const bfrt::BfRtTable* table;
   RETURN_IF_BFRT_ERROR(bfrt_info_->bfrtTableFromIdGet(table_id, &table));
@@ -2799,11 +2795,11 @@ namespace {
     uint32 table_id, absl::optional<uint32> register_index,
     std::vector<uint32>* register_indices, std::vector<uint64>* register_datas,
     absl::Duration timeout) {
-  CHECK_RETURN_IF_FALSE(register_indices);
-  CHECK_RETURN_IF_FALSE(register_datas);
+  RET_CHECK(register_indices);
+  RET_CHECK(register_datas);
   ::absl::ReaderMutexLock l(&data_lock_);
   auto real_session = std::dynamic_pointer_cast<Session>(session);
-  CHECK_RETURN_IF_FALSE(real_session);
+  RET_CHECK(real_session);
 
   RETURN_IF_ERROR(SynchronizeRegisters(device, session, table_id, timeout));
 
@@ -2851,7 +2847,7 @@ namespace {
         // fetching the data in an uint64 vector with one entry per pipe.
         std::vector<uint64> register_data;
         RETURN_IF_BFRT_ERROR(table_data->getValue(f1_field_id, &register_data));
-        CHECK_RETURN_IF_FALSE(register_data.size() > 0);
+        RET_CHECK(register_data.size() > 0);
         register_datas->push_back(register_data[0]);
         break;
       }
@@ -2875,7 +2871,7 @@ namespace {
     uint64 cir, uint64 cburst, uint64 pir, uint64 pburst) {
   ::absl::ReaderMutexLock l(&data_lock_);
   auto real_session = std::dynamic_pointer_cast<Session>(session);
-  CHECK_RETURN_IF_FALSE(real_session);
+  RET_CHECK(real_session);
 
   const bfrt::BfRtTable* table;
   RETURN_IF_BFRT_ERROR(bfrt_info_->bfrtTableFromIdGet(table_id, &table));
@@ -2938,14 +2934,14 @@ namespace {
     std::vector<uint32>* meter_indices, std::vector<uint64>* cirs,
     std::vector<uint64>* cbursts, std::vector<uint64>* pirs,
     std::vector<uint64>* pbursts, std::vector<bool>* in_pps) {
-  CHECK_RETURN_IF_FALSE(meter_indices);
-  CHECK_RETURN_IF_FALSE(cirs);
-  CHECK_RETURN_IF_FALSE(cbursts);
-  CHECK_RETURN_IF_FALSE(pirs);
-  CHECK_RETURN_IF_FALSE(pbursts);
+  RET_CHECK(meter_indices);
+  RET_CHECK(cirs);
+  RET_CHECK(cbursts);
+  RET_CHECK(pirs);
+  RET_CHECK(pbursts);
   ::absl::ReaderMutexLock l(&data_lock_);
   auto real_session = std::dynamic_pointer_cast<Session>(session);
-  CHECK_RETURN_IF_FALSE(real_session);
+  RET_CHECK(real_session);
 
   auto bf_dev_tgt = GetDeviceTarget(device);
   const bfrt::BfRtTable* table;
@@ -3047,9 +3043,9 @@ namespace {
     uint32 table_id, int member_id, const TableDataInterface* table_data,
     bool insert) {
   auto real_session = std::dynamic_pointer_cast<Session>(session);
-  CHECK_RETURN_IF_FALSE(real_session);
+  RET_CHECK(real_session);
   auto real_table_data = dynamic_cast<const TableData*>(table_data);
-  CHECK_RETURN_IF_FALSE(real_table_data);
+  RET_CHECK(real_table_data);
 
   const bfrt::BfRtTable* table;
   RETURN_IF_BFRT_ERROR(bfrt_info_->bfrtTableFromIdGet(table_id, &table));
@@ -3106,7 +3102,7 @@ namespace {
     uint32 table_id, int member_id) {
   ::absl::ReaderMutexLock l(&data_lock_);
   auto real_session = std::dynamic_pointer_cast<Session>(session);
-  CHECK_RETURN_IF_FALSE(real_session);
+  RET_CHECK(real_session);
 
   const bfrt::BfRtTable* table;
   RETURN_IF_BFRT_ERROR(bfrt_info_->bfrtTableFromIdGet(table_id, &table));
@@ -3136,11 +3132,11 @@ namespace {
     int device, std::shared_ptr<BfSdeInterface::SessionInterface> session,
     uint32 table_id, int member_id, std::vector<int>* member_ids,
     std::vector<std::unique_ptr<TableDataInterface>>* table_datas) {
-  CHECK_RETURN_IF_FALSE(member_ids);
-  CHECK_RETURN_IF_FALSE(table_datas);
+  RET_CHECK(member_ids);
+  RET_CHECK(table_datas);
   ::absl::ReaderMutexLock l(&data_lock_);
   auto real_session = std::dynamic_pointer_cast<Session>(session);
-  CHECK_RETURN_IF_FALSE(real_session);
+  RET_CHECK(real_session);
 
   auto bf_dev_tgt = GetDeviceTarget(device);
   const bfrt::BfRtTable* table;
@@ -3188,7 +3184,7 @@ namespace {
     const std::vector<uint32>& member_ids,
     const std::vector<bool>& member_status, bool insert) {
   auto real_session = std::dynamic_pointer_cast<Session>(session);
-  CHECK_RETURN_IF_FALSE(real_session);
+  RET_CHECK(real_session);
 
   const bfrt::BfRtTable* table;
   RETURN_IF_BFRT_ERROR(bfrt_info_->bfrtTableFromIdGet(table_id, &table));
@@ -3260,7 +3256,7 @@ namespace {
     uint32 table_id, int group_id) {
   ::absl::ReaderMutexLock l(&data_lock_);
   auto real_session = std::dynamic_pointer_cast<Session>(session);
-  CHECK_RETURN_IF_FALSE(real_session);
+  RET_CHECK(real_session);
 
   const bfrt::BfRtTable* table;
   RETURN_IF_BFRT_ERROR(bfrt_info_->bfrtTableFromIdGet(table_id, &table));
@@ -3291,13 +3287,13 @@ namespace {
     std::vector<int>* max_group_sizes,
     std::vector<std::vector<uint32>>* member_ids,
     std::vector<std::vector<bool>>* member_status) {
-  CHECK_RETURN_IF_FALSE(group_ids);
-  CHECK_RETURN_IF_FALSE(max_group_sizes);
-  CHECK_RETURN_IF_FALSE(member_ids);
-  CHECK_RETURN_IF_FALSE(member_status);
+  RET_CHECK(group_ids);
+  RET_CHECK(max_group_sizes);
+  RET_CHECK(member_ids);
+  RET_CHECK(member_status);
   ::absl::ReaderMutexLock l(&data_lock_);
   auto real_session = std::dynamic_pointer_cast<Session>(session);
-  CHECK_RETURN_IF_FALSE(real_session);
+  RET_CHECK(real_session);
 
   auto bf_dev_tgt = GetDeviceTarget(device);
   const bfrt::BfRtTable* table;
@@ -3363,11 +3359,11 @@ namespace {
     const TableDataInterface* table_data) {
   ::absl::ReaderMutexLock l(&data_lock_);
   auto real_session = std::dynamic_pointer_cast<Session>(session);
-  CHECK_RETURN_IF_FALSE(real_session);
+  RET_CHECK(real_session);
   auto real_table_key = dynamic_cast<const TableKey*>(table_key);
-  CHECK_RETURN_IF_FALSE(real_table_key);
+  RET_CHECK(real_table_key);
   auto real_table_data = dynamic_cast<const TableData*>(table_data);
-  CHECK_RETURN_IF_FALSE(real_table_data);
+  RET_CHECK(real_table_data);
 
   const bfrt::BfRtTable* table;
   RETURN_IF_BFRT_ERROR(bfrt_info_->bfrtTableFromIdGet(table_id, &table));
@@ -3397,11 +3393,11 @@ namespace {
     const TableDataInterface* table_data) {
   ::absl::ReaderMutexLock l(&data_lock_);
   auto real_session = std::dynamic_pointer_cast<Session>(session);
-  CHECK_RETURN_IF_FALSE(real_session);
+  RET_CHECK(real_session);
   auto real_table_key = dynamic_cast<const TableKey*>(table_key);
-  CHECK_RETURN_IF_FALSE(real_table_key);
+  RET_CHECK(real_table_key);
   auto real_table_data = dynamic_cast<const TableData*>(table_data);
-  CHECK_RETURN_IF_FALSE(real_table_data);
+  RET_CHECK(real_table_data);
   const bfrt::BfRtTable* table;
   RETURN_IF_BFRT_ERROR(bfrt_info_->bfrtTableFromIdGet(table_id, &table));
 
@@ -3429,9 +3425,9 @@ namespace {
     uint32 table_id, const TableKeyInterface* table_key) {
   ::absl::ReaderMutexLock l(&data_lock_);
   auto real_session = std::dynamic_pointer_cast<Session>(session);
-  CHECK_RETURN_IF_FALSE(real_session);
+  RET_CHECK(real_session);
   auto real_table_key = dynamic_cast<const TableKey*>(table_key);
-  CHECK_RETURN_IF_FALSE(real_table_key);
+  RET_CHECK(real_table_key);
   const bfrt::BfRtTable* table;
   RETURN_IF_BFRT_ERROR(bfrt_info_->bfrtTableFromIdGet(table_id, &table));
 
@@ -3456,11 +3452,11 @@ namespace {
     TableDataInterface* table_data) {
   ::absl::ReaderMutexLock l(&data_lock_);
   auto real_session = std::dynamic_pointer_cast<Session>(session);
-  CHECK_RETURN_IF_FALSE(real_session);
+  RET_CHECK(real_session);
   auto real_table_key = dynamic_cast<const TableKey*>(table_key);
-  CHECK_RETURN_IF_FALSE(real_table_key);
+  RET_CHECK(real_table_key);
   auto real_table_data = dynamic_cast<const TableData*>(table_data);
-  CHECK_RETURN_IF_FALSE(real_table_data);
+  RET_CHECK(real_table_data);
   const bfrt::BfRtTable* table;
   RETURN_IF_BFRT_ERROR(bfrt_info_->bfrtTableFromIdGet(table_id, &table));
 
@@ -3480,7 +3476,7 @@ namespace {
     std::vector<std::unique_ptr<TableDataInterface>>* table_datas) {
   ::absl::ReaderMutexLock l(&data_lock_);
   auto real_session = std::dynamic_pointer_cast<Session>(session);
-  CHECK_RETURN_IF_FALSE(real_session);
+  RET_CHECK(real_session);
   const bfrt::BfRtTable* table;
   RETURN_IF_BFRT_ERROR(bfrt_info_->bfrtTableFromIdGet(table_id, &table));
   auto bf_dev_tgt = GetDeviceTarget(device);
@@ -3508,9 +3504,9 @@ namespace {
     uint32 table_id, const TableDataInterface* table_data) {
   ::absl::ReaderMutexLock l(&data_lock_);
   auto real_session = std::dynamic_pointer_cast<Session>(session);
-  CHECK_RETURN_IF_FALSE(real_session);
+  RET_CHECK(real_session);
   auto real_table_data = dynamic_cast<const TableData*>(table_data);
-  CHECK_RETURN_IF_FALSE(real_table_data);
+  RET_CHECK(real_table_data);
   const bfrt::BfRtTable* table;
   RETURN_IF_BFRT_ERROR(bfrt_info_->bfrtTableFromIdGet(table_id, &table));
 
@@ -3526,7 +3522,7 @@ namespace {
     uint32 table_id) {
   ::absl::ReaderMutexLock l(&data_lock_);
   auto real_session = std::dynamic_pointer_cast<Session>(session);
-  CHECK_RETURN_IF_FALSE(real_session);
+  RET_CHECK(real_session);
   const bfrt::BfRtTable* table;
   RETURN_IF_BFRT_ERROR(bfrt_info_->bfrtTableFromIdGet(table_id, &table));
 
@@ -3542,9 +3538,9 @@ namespace {
     uint32 table_id, TableDataInterface* table_data) {
   ::absl::ReaderMutexLock l(&data_lock_);
   auto real_session = std::dynamic_pointer_cast<Session>(session);
-  CHECK_RETURN_IF_FALSE(real_session);
+  RET_CHECK(real_session);
   auto real_table_data = dynamic_cast<const TableData*>(table_data);
-  CHECK_RETURN_IF_FALSE(real_table_data);
+  RET_CHECK(real_table_data);
   const bfrt::BfRtTable* table;
   RETURN_IF_BFRT_ERROR(bfrt_info_->bfrtTableFromIdGet(table_id, &table));
 
@@ -3590,7 +3586,7 @@ namespace {
     int device, std::shared_ptr<BfSdeInterface::SessionInterface> session,
     uint32 table_id, absl::Duration timeout) {
   auto real_session = std::dynamic_pointer_cast<Session>(session);
-  CHECK_RETURN_IF_FALSE(real_session);
+  RET_CHECK(real_session);
 
   const bfrt::BfRtTable* table;
   RETURN_IF_BFRT_ERROR(bfrt_info_->bfrtTableFromIdGet(table_id, &table));
@@ -3633,7 +3629,7 @@ namespace {
     int device, std::shared_ptr<BfSdeInterface::SessionInterface> session,
     uint32 table_id, absl::Duration timeout) {
   auto real_session = std::dynamic_pointer_cast<Session>(session);
-  CHECK_RETURN_IF_FALSE(real_session);
+  RET_CHECK(real_session);
 
   const bfrt::BfRtTable* table;
   RETURN_IF_BFRT_ERROR(bfrt_info_->bfrtTableFromIdGet(table_id, &table));

--- a/stratum/hal/lib/barefoot/bf_sde_wrapper.h
+++ b/stratum/hal/lib/barefoot/bf_sde_wrapper.h
@@ -120,7 +120,7 @@ class BfSdeWrapper : public BfSdeInterface {
     static ::util::StatusOr<std::shared_ptr<BfSdeInterface::SessionInterface>>
     CreateSession() {
       auto bfrt_session = bfrt::BfRtSession::sessionCreate();
-      CHECK_RETURN_IF_FALSE(bfrt_session) << "Failed to create new session.";
+      RET_CHECK(bfrt_session) << "Failed to create new session.";
       VLOG(1) << "Started new BfRt session with ID "
               << bfrt_session->sessHandleGet();
 

--- a/stratum/hal/lib/barefoot/bf_switch.cc
+++ b/stratum/hal/lib/barefoot/bf_switch.cc
@@ -190,8 +190,8 @@ namespace {
 ::util::Status BfSwitch::WriteForwardingEntries(
     const ::p4::v1::WriteRequest& req, std::vector<::util::Status>* results) {
   if (!req.updates_size()) return ::util::OkStatus();  // nothing to do.
-  CHECK_RETURN_IF_FALSE(req.device_id()) << "No device_id in WriteRequest.";
-  CHECK_RETURN_IF_FALSE(results != nullptr)
+  RET_CHECK(req.device_id()) << "No device_id in WriteRequest.";
+  RET_CHECK(results != nullptr)
       << "Need to provide non-null results pointer for non-empty updates.";
 
   ASSIGN_OR_RETURN(auto* pi_node, GetPINodeFromNodeId(req.device_id()));
@@ -202,9 +202,9 @@ namespace {
     const ::p4::v1::ReadRequest& req,
     WriterInterface<::p4::v1::ReadResponse>* writer,
     std::vector<::util::Status>* details) {
-  CHECK_RETURN_IF_FALSE(req.device_id()) << "No device_id in ReadRequest.";
-  CHECK_RETURN_IF_FALSE(writer) << "Channel writer must be non-null.";
-  CHECK_RETURN_IF_FALSE(details) << "Details pointer must be non-null.";
+  RET_CHECK(req.device_id()) << "No device_id in ReadRequest.";
+  RET_CHECK(writer) << "Channel writer must be non-null.";
+  RET_CHECK(details) << "Details pointer must be non-null.";
 
   ASSIGN_OR_RETURN(auto* pi_node, GetPINodeFromNodeId(req.device_id()));
   return pi_node->ReadForwardingEntries(req, writer, details);

--- a/stratum/hal/lib/barefoot/bfrt_counter_manager.cc
+++ b/stratum/hal/lib/barefoot/bfrt_counter_manager.cc
@@ -51,13 +51,13 @@ BfrtCounterManager::~BfrtCounterManager() = default;
   ASSIGN_OR_RETURN(const auto& translated_counter_entry,
                    bfrt_p4runtime_translator_->TranslateCounterEntry(
                        counter_entry, /*to_sdk=*/true));
-  CHECK_RETURN_IF_FALSE(type == ::p4::v1::Update::MODIFY)
+  RET_CHECK(type == ::p4::v1::Update::MODIFY)
       << "Update type of CounterEntry "
       << translated_counter_entry.ShortDebugString() << " must be MODIFY.";
-  CHECK_RETURN_IF_FALSE(translated_counter_entry.has_index())
+  RET_CHECK(translated_counter_entry.has_index())
       << "Modifying an indirect counter without counter index is currently not "
          "supported.";
-  CHECK_RETURN_IF_FALSE(translated_counter_entry.index().index() >= 0)
+  RET_CHECK(translated_counter_entry.index().index() >= 0)
       << "Counter index must be greater than or equal to zero.";
 
   // Find counter table.
@@ -86,9 +86,9 @@ BfrtCounterManager::~BfrtCounterManager() = default;
   ASSIGN_OR_RETURN(const auto& translated_counter_entry,
                    bfrt_p4runtime_translator_->TranslateCounterEntry(
                        counter_entry, /*to_sdk=*/true));
-  CHECK_RETURN_IF_FALSE(translated_counter_entry.counter_id() != 0)
+  RET_CHECK(translated_counter_entry.counter_id() != 0)
       << "Querying an indirect counter without counter id is not supported.";
-  CHECK_RETURN_IF_FALSE(translated_counter_entry.index().index() >= 0)
+  RET_CHECK(translated_counter_entry.index().index() >= 0)
       << "Counter index must be greater than or equal to zero.";
 
   // Index 0 is a valid value and not a wildcard.

--- a/stratum/hal/lib/barefoot/bfrt_id_mapper.cc
+++ b/stratum/hal/lib/barefoot/bfrt_id_mapper.cc
@@ -150,8 +150,7 @@ std::unique_ptr<BfrtIdMapper> BfrtIdMapper::CreateInstance() {
   try {
     nlohmann::json context_json =
         nlohmann::json::parse(context_json_content, nullptr, false);
-    CHECK_RETURN_IF_FALSE(!context_json.is_discarded())
-        << "Failed to parse context.json";
+    RET_CHECK(!context_json.is_discarded()) << "Failed to parse context.json";
 
     // Builds mappings for ActionProfile and ActionSelector.
     for (const auto& table : context_json["tables"]) {
@@ -175,11 +174,11 @@ std::unique_ptr<BfrtIdMapper> BfrtIdMapper::CreateInstance() {
       }
 
       const auto& action_selector_name = selection_table_refs[0]["name"];
-      CHECK_RETURN_IF_FALSE(!action_selector_name.empty())
+      RET_CHECK(!action_selector_name.empty())
           << "ActionSelector for ActionProfile " << action_profile_name
           << " name is empty, this should not happened";
-      CHECK_RETURN_IF_FALSE(gtl::InsertIfNotPresent(
-          &prof_to_sel, action_profile_name, action_selector_name))
+      RET_CHECK(gtl::InsertIfNotPresent(&prof_to_sel, action_profile_name,
+                                        action_selector_name))
           << "Action profile with name " << action_profile_name
           << " already exists.";
     }
@@ -201,11 +200,11 @@ std::unique_ptr<BfrtIdMapper> BfrtIdMapper::CreateInstance() {
     RETURN_IF_BFRT_ERROR(bfrt_table->tableIdGet(&table_id));
 
     if (table_type == bfrt::BfRtTable::TableType::ACTION_PROFILE) {
-      CHECK_RETURN_IF_FALSE(
+      RET_CHECK(
           gtl::InsertIfNotPresent(&act_prof_bfrt_ids, table_name, table_id))
           << "Action profile with name " << table_name << " already exists.";
     } else if (table_type == bfrt::BfRtTable::TableType::SELECTOR) {
-      CHECK_RETURN_IF_FALSE(
+      RET_CHECK(
           gtl::InsertIfNotPresent(&selector_bfrt_ids, table_name, table_id))
           << "Action selector with name " << table_name << " already exists.";
     }
@@ -235,10 +234,8 @@ std::unique_ptr<BfrtIdMapper> BfrtIdMapper::CreateInstance() {
         break;
       }
     }
-    CHECK_RETURN_IF_FALSE(prof_id != 0)
-        << "Unable to find ID for action profile " << prof;
-    CHECK_RETURN_IF_FALSE(sel_id != 0)
-        << "Unable to find ID for action selector " << sel;
+    RET_CHECK(prof_id != 0) << "Unable to find ID for action profile " << prof;
+    RET_CHECK(sel_id != 0) << "Unable to find ID for action selector " << sel;
 
     act_profile_to_selector_mapping_[prof_id] = sel_id;
     act_selector_to_profile_mapping_[sel_id] = prof_id;
@@ -248,14 +245,14 @@ std::unique_ptr<BfrtIdMapper> BfrtIdMapper::CreateInstance() {
 
 ::util::StatusOr<uint32> BfrtIdMapper::GetBfRtId(uint32 p4info_id) const {
   absl::ReaderMutexLock l(&lock_);
-  CHECK_RETURN_IF_FALSE(gtl::ContainsKey(p4info_to_bfrt_id_, p4info_id))
+  RET_CHECK(gtl::ContainsKey(p4info_to_bfrt_id_, p4info_id))
       << "Unable to find bfrt id from p4info id: " << p4info_id;
   return gtl::FindOrDie(p4info_to_bfrt_id_, p4info_id);
 }
 
 ::util::StatusOr<uint32> BfrtIdMapper::GetP4InfoId(bf_rt_id_t bfrt_id) const {
   absl::ReaderMutexLock l(&lock_);
-  CHECK_RETURN_IF_FALSE(gtl::ContainsKey(bfrt_to_p4info_id_, bfrt_id))
+  RET_CHECK(gtl::ContainsKey(bfrt_to_p4info_id_, bfrt_id))
       << "Unable to find p4info id from bfrt id: " << bfrt_id;
   return gtl::FindOrDie(bfrt_to_p4info_id_, bfrt_id);
 }
@@ -263,7 +260,7 @@ std::unique_ptr<BfrtIdMapper> BfrtIdMapper::CreateInstance() {
 ::util::StatusOr<bf_rt_id_t> BfrtIdMapper::GetActionSelectorBfRtId(
     bf_rt_id_t action_profile_id) const {
   absl::ReaderMutexLock l(&lock_);
-  CHECK_RETURN_IF_FALSE(
+  RET_CHECK(
       gtl::ContainsKey(act_profile_to_selector_mapping_, action_profile_id))
       << "Unable to find action selector of an action profile: "
       << action_profile_id;
@@ -273,7 +270,7 @@ std::unique_ptr<BfrtIdMapper> BfrtIdMapper::CreateInstance() {
 ::util::StatusOr<bf_rt_id_t> BfrtIdMapper::GetActionProfileBfRtId(
     bf_rt_id_t action_selector_id) const {
   absl::ReaderMutexLock l(&lock_);
-  CHECK_RETURN_IF_FALSE(
+  RET_CHECK(
       gtl::ContainsKey(act_selector_to_profile_mapping_, action_selector_id))
       << "Unable to find action profile of an action selector: "
       << action_selector_id;

--- a/stratum/hal/lib/barefoot/bfrt_node.cc
+++ b/stratum/hal/lib/barefoot/bfrt_node.cc
@@ -132,7 +132,7 @@ std::unique_ptr<BfrtNode> BfrtNode::CreateInstance(
   if (!initialized_) {
     return MAKE_ERROR(ERR_NOT_INITIALIZED) << "Not initialized!";
   }
-  CHECK_RETURN_IF_FALSE(bfrt_config_.programs_size() > 0);
+  RET_CHECK(bfrt_config_.programs_size() > 0);
 
   // Calling AddDevice() overwrites any previous pipeline.
   RETURN_IF_ERROR(bf_sde_interface_->AddDevice(device_id_, bfrt_config_));
@@ -155,9 +155,8 @@ std::unique_ptr<BfrtNode> BfrtNode::CreateInstance(
 
 ::util::Status BfrtNode::VerifyForwardingPipelineConfig(
     const ::p4::v1::ForwardingPipelineConfig& config) const {
-  CHECK_RETURN_IF_FALSE(config.has_p4info()) << "Missing P4 info";
-  CHECK_RETURN_IF_FALSE(!config.p4_device_config().empty())
-      << "Missing P4 device config";
+  RET_CHECK(config.has_p4info()) << "Missing P4 info";
+  RET_CHECK(!config.p4_device_config().empty()) << "Missing P4 device config";
   BfPipelineConfig bf_config;
   RETURN_IF_ERROR(ExtractBfPipelineConfig(config, &bf_config));
   RETURN_IF_ERROR(bfrt_table_manager_->VerifyForwardingPipelineConfig(config));
@@ -187,10 +186,9 @@ std::unique_ptr<BfrtNode> BfrtNode::CreateInstance(
 ::util::Status BfrtNode::WriteForwardingEntries(
     const ::p4::v1::WriteRequest& req, std::vector<::util::Status>* results) {
   absl::WriterMutexLock l(&lock_);
-  CHECK_RETURN_IF_FALSE(req.device_id() == node_id_)
+  RET_CHECK(req.device_id() == node_id_)
       << "Request device id must be same as id of this BfrtNode.";
-  CHECK_RETURN_IF_FALSE(req.atomicity() ==
-                        ::p4::v1::WriteRequest::CONTINUE_ON_ERROR)
+  RET_CHECK(req.atomicity() == ::p4::v1::WriteRequest::CONTINUE_ON_ERROR)
       << "Request atomicity "
       << ::p4::v1::WriteRequest::Atomicity_Name(req.atomicity())
       << " is not supported.";
@@ -270,11 +268,11 @@ std::unique_ptr<BfrtNode> BfrtNode::CreateInstance(
     const ::p4::v1::ReadRequest& req,
     WriterInterface<::p4::v1::ReadResponse>* writer,
     std::vector<::util::Status>* details) {
-  CHECK_RETURN_IF_FALSE(writer) << "Channel writer must be non-null.";
-  CHECK_RETURN_IF_FALSE(details) << "Details pointer must be non-null.";
+  RET_CHECK(writer) << "Channel writer must be non-null.";
+  RET_CHECK(details) << "Details pointer must be non-null.";
 
   absl::ReaderMutexLock l(&lock_);
-  CHECK_RETURN_IF_FALSE(req.device_id() == node_id_)
+  RET_CHECK(req.device_id() == node_id_)
       << "Request device id must be same as id of this BfrtNode.";
   if (!initialized_ || !pipeline_initialized_) {
     return MAKE_ERROR(ERR_NOT_INITIALIZED) << "Not initialized!";
@@ -363,8 +361,7 @@ std::unique_ptr<BfrtNode> BfrtNode::CreateInstance(
       }
     }
   }
-  CHECK_RETURN_IF_FALSE(writer->Write(resp))
-      << "Write to stream channel failed.";
+  RET_CHECK(writer->Write(resp)) << "Write to stream channel failed.";
   if (!success) {
     return MAKE_ERROR(ERR_AT_LEAST_ONE_OPER_FAILED)
            << "One or more read operations failed.";
@@ -420,7 +417,7 @@ std::unique_ptr<BfrtNode> BfrtNode::CreateInstance(
   switch (entry.extern_type_id()) {
     case kTnaExternActionProfileId: {
       ::p4::v1::ActionProfileMember act_prof_member;
-      CHECK_RETURN_IF_FALSE(entry.entry().UnpackTo(&act_prof_member))
+      RET_CHECK(entry.entry().UnpackTo(&act_prof_member))
           << "Entry " << entry.ShortDebugString()
           << " is not an action profile member.";
       return bfrt_table_manager_->WriteActionProfileMember(session, type,
@@ -428,7 +425,7 @@ std::unique_ptr<BfrtNode> BfrtNode::CreateInstance(
     }
     case kTnaExternActionSelectorId: {
       ::p4::v1::ActionProfileGroup act_prof_group;
-      CHECK_RETURN_IF_FALSE(entry.entry().UnpackTo(&act_prof_group))
+      RET_CHECK(entry.entry().UnpackTo(&act_prof_group))
           << "Entry " << entry.ShortDebugString()
           << " is not an action profile group.";
       return bfrt_table_manager_->WriteActionProfileGroup(session, type,
@@ -447,7 +444,7 @@ std::unique_ptr<BfrtNode> BfrtNode::CreateInstance(
   switch (entry.extern_type_id()) {
     case kTnaExternActionProfileId: {
       ::p4::v1::ActionProfileMember act_prof_member;
-      CHECK_RETURN_IF_FALSE(entry.entry().UnpackTo(&act_prof_member))
+      RET_CHECK(entry.entry().UnpackTo(&act_prof_member))
           << "Entry " << entry.ShortDebugString()
           << " is not an action profile member";
       return bfrt_table_manager_->ReadActionProfileMember(
@@ -455,7 +452,7 @@ std::unique_ptr<BfrtNode> BfrtNode::CreateInstance(
     }
     case kTnaExternActionSelectorId: {
       ::p4::v1::ActionProfileGroup act_prof_group;
-      CHECK_RETURN_IF_FALSE(entry.entry().UnpackTo(&act_prof_group))
+      RET_CHECK(entry.entry().UnpackTo(&act_prof_group))
           << "Entry " << entry.ShortDebugString()
           << " is not an action profile group";
       return bfrt_table_manager_->ReadActionProfileGroup(

--- a/stratum/hal/lib/barefoot/bfrt_packetio_manager.cc
+++ b/stratum/hal/lib/barefoot/bfrt_packetio_manager.cc
@@ -66,8 +66,7 @@ std::unique_ptr<BfrtPacketioManager> BfrtPacketioManager::CreateInstance(
 
 ::util::Status BfrtPacketioManager::PushForwardingPipelineConfig(
     const BfrtDeviceConfig& config) {
-  CHECK_RETURN_IF_FALSE(config.programs_size() == 1)
-      << "Only one program is supported.";
+  RET_CHECK(config.programs_size() == 1) << "Only one program is supported.";
   const auto& program = config.programs(0);
   {
     absl::WriterMutexLock l(&data_lock_);
@@ -168,8 +167,7 @@ class BitBuffer {
 
   // Add a bytestring to the back of the buffer.
   ::util::Status PushBack(const std::string& bytestring, size_t bitwidth) {
-    CHECK_RETURN_IF_FALSE(bytestring.size() <=
-                          (bitwidth + kBitsPerByte - 1) / kBitsPerByte)
+    RET_CHECK(bytestring.size() <= (bitwidth + kBitsPerByte - 1) / kBitsPerByte)
         << "Bytestring " << StringToHex(bytestring) << " overflows bit width "
         << bitwidth << ".";
 
@@ -187,7 +185,7 @@ class BitBuffer {
     }
     // Remove bits from partial byte at the front.
     while (new_bits.size() > bitwidth) {
-      CHECK_RETURN_IF_FALSE(new_bits.front() == 0)
+      RET_CHECK(new_bits.front() == 0)
           << "Bytestring " << StringToHex(bytestring) << " overflows bit width "
           << bitwidth << ".";
       new_bits.pop_front();
@@ -252,7 +250,7 @@ class BitBuffer {
                            [&id](::p4::v1::PacketMetadata metadata) {
                              return metadata.metadata_id() == id;
                            });
-    CHECK_RETURN_IF_FALSE(it != packet.metadata().end())
+    RET_CHECK(it != packet.metadata().end())
         << "Missing metadata with Id " << id << " in PacketOut "
         << packet.ShortDebugString();
     RETURN_IF_ERROR(bit_buf.PushBack(it->value(), bitwidth));
@@ -271,7 +269,7 @@ class BitBuffer {
 ::util::Status BfrtPacketioManager::ParsePacketIn(const std::string& buffer,
                                                   ::p4::v1::PacketIn* packet) {
   absl::ReaderMutexLock l(&data_lock_);
-  CHECK_RETURN_IF_FALSE(buffer.size() >= packetin_header_size_)
+  RET_CHECK(buffer.size() >= packetin_header_size_)
       << "Received packet is too small.";
 
   BitBuffer bit_buf;
@@ -378,9 +376,9 @@ class BitBuffer {
     }
   }
 
-  CHECK_RETURN_IF_FALSE(packetin_bits % 8 == 0)
+  RET_CHECK(packetin_bits % 8 == 0)
       << "PacketIn header size must be multiple of 8 bits.";
-  CHECK_RETURN_IF_FALSE(packetout_bits % 8 == 0)
+  RET_CHECK(packetout_bits % 8 == 0)
       << "PacketOut header size must be multiple of 8 bits.";
   packetin_header_ = std::move(packetin_header);
   packetout_header_ = std::move(packetout_header);

--- a/stratum/hal/lib/barefoot/bfrt_pre_manager.cc
+++ b/stratum/hal/lib/barefoot/bfrt_pre_manager.cc
@@ -98,12 +98,12 @@ std::unique_ptr<BfrtPreManager> BfrtPreManager::CreateInstance(
     std::shared_ptr<BfSdeInterface::SessionInterface> session,
     const ::p4::v1::MulticastGroupEntry& entry) {
   const uint32 group_id = entry.multicast_group_id();
-  CHECK_RETURN_IF_FALSE(group_id <= kMaxMulticastGroupId);
+  RET_CHECK(group_id <= kMaxMulticastGroupId);
 
   // Collect instance (rid) -> egress ports mapping
   absl::flat_hash_map<uint32, std::vector<uint32>> instance_to_egress_ports;
   for (const auto& replica : entry.replicas()) {
-    CHECK_RETURN_IF_FALSE(replica.instance() <= UINT16_MAX);
+    RET_CHECK(replica.instance() <= UINT16_MAX);
     instance_to_egress_ports[replica.instance()].push_back(
         replica.egress_port());
   }
@@ -193,7 +193,7 @@ std::unique_ptr<BfrtPreManager> BfrtPreManager::CreateInstance(
   RETURN_IF_ERROR(bf_sde_interface_->GetMulticastGroups(
       device_, session, entry.multicast_group_id(), &group_ids,
       &mc_node_ids_per_group));
-  CHECK_RETURN_IF_FALSE(group_ids.size() == mc_node_ids_per_group.size());
+  RET_CHECK(group_ids.size() == mc_node_ids_per_group.size());
 
   // Build response.
   ::p4::v1::ReadResponse resp;
@@ -250,27 +250,26 @@ std::unique_ptr<BfrtPreManager> BfrtPreManager::CreateInstance(
     std::shared_ptr<BfSdeInterface::SessionInterface> session,
     const ::p4::v1::Update::Type& type,
     const ::p4::v1::CloneSessionEntry& entry) {
-  CHECK_RETURN_IF_FALSE(entry.session_id() != 0 &&
-                        entry.session_id() <= kMaxCloneSessionId)
+  RET_CHECK(entry.session_id() != 0 && entry.session_id() <= kMaxCloneSessionId)
       << "Invalid session id in CloneSessionEntry " << entry.ShortDebugString()
       << ".";
-  CHECK_RETURN_IF_FALSE(entry.packet_length_bytes() <= UINT16_MAX)
+  RET_CHECK(entry.packet_length_bytes() <= UINT16_MAX)
       << "Packet length exceeds maximum value: " << entry.ShortDebugString()
       << ".";
 
   switch (type) {
     case ::p4::v1::Update::INSERT: {
-      CHECK_RETURN_IF_FALSE(entry.replicas_size() == 1)
+      RET_CHECK(entry.replicas_size() == 1)
           << "Multiple replicas are not supported: " << entry.ShortDebugString()
           << ".";
-      CHECK_RETURN_IF_FALSE(entry.class_of_service() < 8)
+      RET_CHECK(entry.class_of_service() < 8)
           << "Class of service must be smaller than 8: "
           << entry.ShortDebugString() << ".";
       const auto& replica = entry.replicas(0);
-      CHECK_RETURN_IF_FALSE(replica.egress_port() != 0)
+      RET_CHECK(replica.egress_port() != 0)
           << "Invalid egress port in Replica " << replica.ShortDebugString()
           << ".";
-      CHECK_RETURN_IF_FALSE(replica.instance() == 0)
+      RET_CHECK(replica.instance() == 0)
           << "Instances on Replicas are not supported: "
           << replica.ShortDebugString() << ".";
       RETURN_IF_ERROR(bf_sde_interface_->InsertCloneSession(
@@ -279,14 +278,14 @@ std::unique_ptr<BfrtPreManager> BfrtPreManager::CreateInstance(
       break;
     }
     case ::p4::v1::Update::MODIFY: {
-      CHECK_RETURN_IF_FALSE(entry.replicas_size() == 1)
+      RET_CHECK(entry.replicas_size() == 1)
           << "Multiple replicas are not supported: " << entry.ShortDebugString()
           << ".";
       const auto& replica = entry.replicas(0);
-      CHECK_RETURN_IF_FALSE(replica.egress_port() != 0)
+      RET_CHECK(replica.egress_port() != 0)
           << "Invalid egress port in Replica " << replica.ShortDebugString()
           << ".";
-      CHECK_RETURN_IF_FALSE(replica.instance() == 0)
+      RET_CHECK(replica.instance() == 0)
           << "Instances on Replicas are not supported: "
           << replica.ShortDebugString() << ".";
       RETURN_IF_ERROR(bf_sde_interface_->ModifyCloneSession(
@@ -319,9 +318,9 @@ std::unique_ptr<BfrtPreManager> BfrtPreManager::CreateInstance(
   RETURN_IF_ERROR(bf_sde_interface_->GetCloneSessions(
       device_, session, entry.session_id(), &session_ids, &egress_ports, &coss,
       &max_pkt_lens));
-  CHECK_RETURN_IF_FALSE(session_ids.size() == egress_ports.size());
-  CHECK_RETURN_IF_FALSE(session_ids.size() == coss.size());
-  CHECK_RETURN_IF_FALSE(session_ids.size() == max_pkt_lens.size());
+  RET_CHECK(session_ids.size() == egress_ports.size());
+  RET_CHECK(session_ids.size() == coss.size());
+  RET_CHECK(session_ids.size() == max_pkt_lens.size());
 
   // Build response.
   ::p4::v1::ReadResponse resp;

--- a/stratum/hal/lib/barefoot/bfrt_switch.cc
+++ b/stratum/hal/lib/barefoot/bfrt_switch.cc
@@ -133,8 +133,8 @@ BfrtSwitch::~BfrtSwitch() {}
 ::util::Status BfrtSwitch::WriteForwardingEntries(
     const ::p4::v1::WriteRequest& req, std::vector<::util::Status>* results) {
   if (!req.updates_size()) return ::util::OkStatus();  // nothing to do.
-  CHECK_RETURN_IF_FALSE(req.device_id()) << "No device_id in WriteRequest.";
-  CHECK_RETURN_IF_FALSE(results != nullptr)
+  RET_CHECK(req.device_id()) << "No device_id in WriteRequest.";
+  RET_CHECK(results != nullptr)
       << "Need to provide non-null results pointer for non-empty updates.";
 
   absl::ReaderMutexLock l(&chassis_lock);
@@ -146,9 +146,9 @@ BfrtSwitch::~BfrtSwitch() {}
     const ::p4::v1::ReadRequest& req,
     WriterInterface<::p4::v1::ReadResponse>* writer,
     std::vector<::util::Status>* details) {
-  CHECK_RETURN_IF_FALSE(req.device_id()) << "No device_id in ReadRequest.";
-  CHECK_RETURN_IF_FALSE(writer) << "Channel writer must be non-null.";
-  CHECK_RETURN_IF_FALSE(details) << "Details pointer must be non-null.";
+  RET_CHECK(req.device_id()) << "No device_id in ReadRequest.";
+  RET_CHECK(writer) << "Channel writer must be non-null.";
+  RET_CHECK(details) << "Details pointer must be non-null.";
 
   absl::ReaderMutexLock l(&chassis_lock);
   ASSIGN_OR_RETURN(auto* bfrt_node, GetBfrtNodeFromNodeId(req.device_id()));

--- a/stratum/hal/lib/barefoot/utils.cc
+++ b/stratum/hal/lib/barefoot/utils.cc
@@ -57,13 +57,13 @@ std::string RangeDefaultHigh(size_t bitwidth) {
 }
 
 ::util::StatusOr<uint64> ConvertPriorityFromP4rtToBfrt(int32 priority) {
-  CHECK_RETURN_IF_FALSE(priority >= 0);
-  CHECK_RETURN_IF_FALSE(priority <= kMaxPriority);
+  RET_CHECK(priority >= 0);
+  RET_CHECK(priority <= kMaxPriority);
   return kMaxPriority - priority;
 }
 
 ::util::StatusOr<int32> ConvertPriorityFromBfrtToP4rt(uint64 priority) {
-  CHECK_RETURN_IF_FALSE(priority <= kMaxPriority);
+  RET_CHECK(priority <= kMaxPriority);
   return static_cast<int32>(kMaxPriority - priority);
 }
 

--- a/stratum/hal/lib/bcm/bcm_chassis_manager.cc
+++ b/stratum/hal/lib/bcm/bcm_chassis_manager.cc
@@ -236,7 +236,7 @@ void BcmChassisManager::SetUnitToBcmNodeMap(
     return MAKE_ERROR(ERR_NOT_INITIALIZED) << "Not initialized!";
   }
   const BcmChip* bcm_chip = gtl::FindPtrOrNull(unit_to_bcm_chip_, unit);
-  CHECK_RETURN_IF_FALSE(bcm_chip != nullptr) << "Unknown unit " << unit << ".";
+  RET_CHECK(bcm_chip != nullptr) << "Unknown unit " << unit << ".";
 
   return BcmChip(*bcm_chip);
 }
@@ -249,7 +249,7 @@ void BcmChassisManager::SetUnitToBcmNodeMap(
   }
   const BcmPort* bcm_port =
       gtl::FindPtrOrNull(singleton_port_key_to_bcm_port_, singleton_port_key);
-  CHECK_RETURN_IF_FALSE(bcm_port != nullptr)
+  RET_CHECK(bcm_port != nullptr)
       << "Unknown singleton port key: " << singleton_port_key.ToString() << ".";
 
   return BcmPort(*bcm_port);
@@ -262,14 +262,14 @@ void BcmChassisManager::SetUnitToBcmNodeMap(
   }
   const auto* port_id_to_port_key =
       gtl::FindOrNull(node_id_to_port_id_to_singleton_port_key_, node_id);
-  CHECK_RETURN_IF_FALSE(port_id_to_port_key != nullptr)
+  RET_CHECK(port_id_to_port_key != nullptr)
       << "Unknown node " << node_id << ".";
   const auto* port_key = gtl::FindOrNull(*port_id_to_port_key, port_id);
-  CHECK_RETURN_IF_FALSE(port_key != nullptr)
+  RET_CHECK(port_key != nullptr)
       << "Unknown port " << port_id << " on node " << node_id << ".";
   const auto* bcm_port =
       gtl::FindPtrOrNull(singleton_port_key_to_bcm_port_, *port_key);
-  CHECK_RETURN_IF_FALSE(bcm_port != nullptr)
+  RET_CHECK(bcm_port != nullptr)
       << "Unknown singleton port key: " << port_key->ToString() << ".";
   return *bcm_port;
 }
@@ -290,7 +290,7 @@ void BcmChassisManager::SetUnitToBcmNodeMap(
     return MAKE_ERROR(ERR_NOT_INITIALIZED) << "Not initialized!";
   }
   const int* unit = gtl::FindOrNull(node_id_to_unit_, node_id);
-  CHECK_RETURN_IF_FALSE(unit != nullptr)
+  RET_CHECK(unit != nullptr)
       << "Node " << node_id << " is not configured or not known.";
 
   return *unit;
@@ -303,7 +303,7 @@ BcmChassisManager::GetPortIdToSdkPortMap(uint64 node_id) const {
   }
   const std::map<uint32, SdkPort>* port_id_to_sdk_port =
       gtl::FindOrNull(node_id_to_port_id_to_sdk_port_, node_id);
-  CHECK_RETURN_IF_FALSE(port_id_to_sdk_port != nullptr)
+  RET_CHECK(port_id_to_sdk_port != nullptr)
       << "Node " << node_id << " is not configured or not known.";
 
   return *port_id_to_sdk_port;
@@ -316,7 +316,7 @@ BcmChassisManager::GetTrunkIdToSdkTrunkMap(uint64 node_id) const {
   }
   const std::map<uint32, SdkTrunk>* trunk_id_to_sdk_trunk =
       gtl::FindOrNull(node_id_to_trunk_id_to_sdk_trunk_, node_id);
-  CHECK_RETURN_IF_FALSE(trunk_id_to_sdk_trunk != nullptr)
+  RET_CHECK(trunk_id_to_sdk_trunk != nullptr)
       << "Node " << node_id << " is not configured or not known.";
 
   return *trunk_id_to_sdk_trunk;
@@ -329,11 +329,11 @@ BcmChassisManager::GetTrunkIdToSdkTrunkMap(uint64 node_id) const {
   }
   const std::map<uint32, PortState>* port_id_to_port_state =
       gtl::FindOrNull(node_id_to_port_id_to_port_state_, node_id);
-  CHECK_RETURN_IF_FALSE(port_id_to_port_state != nullptr)
+  RET_CHECK(port_id_to_port_state != nullptr)
       << "Node " << node_id << " is not configured or not known.";
   const PortState* port_state =
       gtl::FindOrNull(*port_id_to_port_state, port_id);
-  CHECK_RETURN_IF_FALSE(port_state != nullptr)
+  RET_CHECK(port_state != nullptr)
       << "Port " << port_id << " is not known on node " << node_id << ".";
 
   return *port_state;
@@ -346,16 +346,16 @@ BcmChassisManager::GetTrunkIdToSdkTrunkMap(uint64 node_id) const {
   }
 
   auto* node_id = gtl::FindOrNull(unit_to_node_id_, sdk_port.unit);
-  CHECK_RETURN_IF_FALSE(node_id != nullptr)
+  RET_CHECK(node_id != nullptr)
       << "Attempting to query state of port on unknown unit " << sdk_port.unit
       << ".";
   auto* sdk_port_to_port_id =
       gtl::FindOrNull(node_id_to_sdk_port_to_port_id_, *node_id);
-  CHECK_RETURN_IF_FALSE(sdk_port_to_port_id != nullptr)
+  RET_CHECK(sdk_port_to_port_id != nullptr)
       << "Inconsistent state! No sdk_port_to_port_id map for unit "
       << sdk_port.unit << ", node " << *node_id << ".";
   auto* port_id = gtl::FindOrNull(*sdk_port_to_port_id, sdk_port);
-  CHECK_RETURN_IF_FALSE(port_id != nullptr)
+  RET_CHECK(port_id != nullptr)
       << "Attempting to retrieve state of unknown SDK port "
       << sdk_port.ToString() << ".";
   return GetPortState(*node_id, *port_id);
@@ -368,11 +368,11 @@ BcmChassisManager::GetTrunkIdToSdkTrunkMap(uint64 node_id) const {
   }
   const std::map<uint32, TrunkState>* trunk_id_to_trunk_state =
       gtl::FindOrNull(node_id_to_trunk_id_to_trunk_state_, node_id);
-  CHECK_RETURN_IF_FALSE(trunk_id_to_trunk_state != nullptr)
+  RET_CHECK(trunk_id_to_trunk_state != nullptr)
       << "Node " << node_id << " is not configured or not known.";
   const TrunkState* trunk_state =
       gtl::FindOrNull(*trunk_id_to_trunk_state, trunk_id);
-  CHECK_RETURN_IF_FALSE(trunk_state != nullptr)
+  RET_CHECK(trunk_state != nullptr)
       << "Trunk " << trunk_id << " is not known on node " << node_id << ".";
 
   return *trunk_state;
@@ -385,11 +385,11 @@ BcmChassisManager::GetTrunkIdToSdkTrunkMap(uint64 node_id) const {
   }
   const std::map<uint32, std::set<uint32>>* trunk_id_to_members =
       gtl::FindOrNull(node_id_to_trunk_id_to_members_, node_id);
-  CHECK_RETURN_IF_FALSE(trunk_id_to_members != nullptr)
+  RET_CHECK(trunk_id_to_members != nullptr)
       << "Node " << node_id << " is not configured or not known.";
   const std::set<uint32>* members =
       gtl::FindOrNull(*trunk_id_to_members, trunk_id);
-  CHECK_RETURN_IF_FALSE(members != nullptr)
+  RET_CHECK(members != nullptr)
       << "Trunk " << trunk_id << " is not known on node " << node_id << ".";
 
   return *members;
@@ -403,11 +403,11 @@ BcmChassisManager::GetTrunkIdToSdkTrunkMap(uint64 node_id) const {
   const std::map<uint32, TrunkMembershipInfo>*
       port_id_to_trunk_membership_info = gtl::FindOrNull(
           node_id_to_port_id_to_trunk_membership_info_, node_id);
-  CHECK_RETURN_IF_FALSE(port_id_to_trunk_membership_info != nullptr)
+  RET_CHECK(port_id_to_trunk_membership_info != nullptr)
       << "Node " << node_id << " is not configured or not known.";
   const TrunkMembershipInfo* membership_info =
       gtl::FindOrNull(*port_id_to_trunk_membership_info, port_id);
-  // We can't use CHECK_RETURN_IF_FALSE here, because we want without_logging()
+  // We can't use RET_CHECK here, because we want without_logging()
   if (membership_info == nullptr) {
     return MAKE_ERROR(ERR_INVALID_PARAM).without_logging()
            << "Port " << port_id
@@ -425,10 +425,10 @@ BcmChassisManager::GetTrunkIdToSdkTrunkMap(uint64 node_id) const {
   }
   const auto* port_id_to_admin_state =
       gtl::FindOrNull(node_id_to_port_id_to_admin_state_, node_id);
-  CHECK_RETURN_IF_FALSE(port_id_to_admin_state != nullptr)
+  RET_CHECK(port_id_to_admin_state != nullptr)
       << "Unknown node " << node_id << ".";
   const auto* admin_state = gtl::FindOrNull(*port_id_to_admin_state, port_id);
-  CHECK_RETURN_IF_FALSE(admin_state != nullptr)
+  RET_CHECK(admin_state != nullptr)
       << "Unknown port " << port_id << " on node " << node_id << ".";
   return *admin_state;
 }
@@ -440,11 +440,11 @@ BcmChassisManager::GetTrunkIdToSdkTrunkMap(uint64 node_id) const {
   }
   const auto* port_id_to_loopback_state =
       gtl::FindOrNull(node_id_to_port_id_to_loopback_state_, node_id);
-  CHECK_RETURN_IF_FALSE(port_id_to_loopback_state != nullptr)
+  RET_CHECK(port_id_to_loopback_state != nullptr)
       << "Unknown node " << node_id << ".";
   const auto* loopback_state =
       gtl::FindOrNull(*port_id_to_loopback_state, port_id);
-  CHECK_RETURN_IF_FALSE(loopback_state != nullptr)
+  RET_CHECK(loopback_state != nullptr)
       << "Unknown port " << port_id << " on node " << node_id << ".";
   return *loopback_state;
 }
@@ -503,10 +503,9 @@ BcmChassisManager::GetTrunkIdToSdkTrunkMap(uint64 node_id) const {
   // Update internal map.
   auto* port_id_to_loopback_state =
       gtl::FindOrNull(node_id_to_port_id_to_loopback_state_, node_id);
-  CHECK_RETURN_IF_FALSE(port_id_to_loopback_state)
-      << "Unknown node " << node_id << ".";
+  RET_CHECK(port_id_to_loopback_state) << "Unknown node " << node_id << ".";
   auto* loopback_state = gtl::FindOrNull(*port_id_to_loopback_state, port_id);
-  CHECK_RETURN_IF_FALSE(loopback_state)
+  RET_CHECK(loopback_state)
       << "Unknown port " << port_id << " on node " << node_id << ".";
   *loopback_state = state;
 
@@ -570,7 +569,7 @@ bool IsGePortOnTridentPlus(const BcmPort& bcm_port,
   }
 
   // Find the supported BCM chip types based on the given platform.
-  CHECK_RETURN_IF_FALSE(config.has_chassis() && config.chassis().platform())
+  RET_CHECK(config.has_chassis() && config.chassis().platform())
       << "Config needs a Chassis message with correct platform.";
   std::set<BcmChip::BcmChipType> supported_chip_types;
   switch (config.chassis().platform()) {
@@ -620,12 +619,10 @@ bool IsGePortOnTridentPlus(const BcmPort& bcm_port,
   // Validate Node messages. Make sure there is no two nodes with the same id.
   std::map<uint64, int> node_id_to_unit;
   for (const auto& node : config.nodes()) {
-    CHECK_RETURN_IF_FALSE(node.slot() > 0)
+    RET_CHECK(node.slot() > 0)
         << "No positive slot in " << node.ShortDebugString();
-    CHECK_RETURN_IF_FALSE(node.id() > 0)
-        << "No positive ID in " << node.ShortDebugString();
-    CHECK_RETURN_IF_FALSE(
-        gtl::InsertIfNotPresent(&node_id_to_unit, node.id(), -1))
+    RET_CHECK(node.id() > 0) << "No positive ID in " << node.ShortDebugString();
+    RET_CHECK(gtl::InsertIfNotPresent(&node_id_to_unit, node.id(), -1))
         << "The id for Node " << PrintNode(node) << " was already recorded "
         << "for another Node in the config.";
   }
@@ -654,30 +651,30 @@ bool IsGePortOnTridentPlus(const BcmPort& bcm_port,
   std::map<PortKey, std::set<uint64>> port_group_key_to_speed_bps;
   std::map<PortKey, std::set<bool>> port_group_key_to_internal;
   for (const auto& singleton_port : config.singleton_ports()) {
-    CHECK_RETURN_IF_FALSE(singleton_port.id() > 0)
+    RET_CHECK(singleton_port.id() > 0)
         << "No positive ID in " << PrintSingletonPort(singleton_port) << ".";
-    CHECK_RETURN_IF_FALSE(singleton_port.id() != kCpuPortId)
+    RET_CHECK(singleton_port.id() != kCpuPortId)
         << "SingletonPort " << PrintSingletonPort(singleton_port)
         << " has the reserved CPU port ID (" << kCpuPortId << ").";
-    CHECK_RETURN_IF_FALSE(singleton_port.slot() > 0)
+    RET_CHECK(singleton_port.slot() > 0)
         << "No valid slot in " << singleton_port.ShortDebugString() << ".";
-    CHECK_RETURN_IF_FALSE(singleton_port.port() > 0)
+    RET_CHECK(singleton_port.port() > 0)
         << "No valid port in " << singleton_port.ShortDebugString() << ".";
-    CHECK_RETURN_IF_FALSE(singleton_port.speed_bps() > 0)
+    RET_CHECK(singleton_port.speed_bps() > 0)
         << "No valid speed_bps in " << singleton_port.ShortDebugString() << ".";
     PortKey singleton_port_key(singleton_port.slot(), singleton_port.port(),
                                singleton_port.channel());
-    CHECK_RETURN_IF_FALSE(!singleton_port_keys.count(singleton_port_key))
+    RET_CHECK(!singleton_port_keys.count(singleton_port_key))
         << "The (slot, port, channel) tuple for SingletonPort "
         << PrintSingletonPort(singleton_port)
         << " was already recorded for another SingletonPort in the config.";
-    CHECK_RETURN_IF_FALSE(singleton_port.node() > 0)
+    RET_CHECK(singleton_port.node() > 0)
         << "No valid node ID in " << singleton_port.ShortDebugString() << ".";
-    CHECK_RETURN_IF_FALSE(node_id_to_unit.count(singleton_port.node()))
+    RET_CHECK(node_id_to_unit.count(singleton_port.node()))
         << "Node ID " << singleton_port.node() << " given for SingletonPort "
         << PrintSingletonPort(singleton_port)
         << " has not been given to any Node in the config.";
-    CHECK_RETURN_IF_FALSE(
+    RET_CHECK(
         !node_id_to_port_ids[singleton_port.node()].count(singleton_port.id()))
         << "The id for SingletonPort " << PrintSingletonPort(singleton_port)
         << " was already recorded for another SingletonPort for node with ID "
@@ -695,7 +692,7 @@ bool IsGePortOnTridentPlus(const BcmPort& bcm_port,
           // Make sure the (slot, port) for this port is not in
           // flex_port_group_keys. This is an invalid situation. We either have
           // all the channels of a transceiver port flex or all non-flex.
-          CHECK_RETURN_IF_FALSE(!flex_port_group_keys.count(port_group_key))
+          RET_CHECK(!flex_port_group_keys.count(port_group_key))
               << "The (slot, port) pair for the non-flex SingletonPort "
               << PrintSingletonPort(singleton_port)
               << " is in flex_port_group_keys.";
@@ -705,8 +702,7 @@ bool IsGePortOnTridentPlus(const BcmPort& bcm_port,
           // First time we are recording unit for this node.
           node_id_to_unit[singleton_port.node()] = bcm_port.unit();
         } else {
-          CHECK_RETURN_IF_FALSE(node_id_to_unit[singleton_port.node()] ==
-                                bcm_port.unit())
+          RET_CHECK(node_id_to_unit[singleton_port.node()] == bcm_port.unit())
               << "Inconsistent config. SingletonPort "
               << PrintSingletonPort(singleton_port) << " has Node ID "
               << singleton_port.node()
@@ -721,7 +717,7 @@ bool IsGePortOnTridentPlus(const BcmPort& bcm_port,
         break;
       }
     }
-    CHECK_RETURN_IF_FALSE(found)
+    RET_CHECK(found)
         << "Could not find any BcmPort in base_bcm_chassis_map whose (slot, "
         << "port, channel, speed_bps) tuple matches non-flex SingletonPort "
         << PrintSingletonPort(singleton_port) << ".";
@@ -734,7 +730,7 @@ bool IsGePortOnTridentPlus(const BcmPort& bcm_port,
   // found, it means there was no port for that unit in the config. This is
   // considered an error.
   for (const auto& e : node_id_to_unit) {
-    CHECK_RETURN_IF_FALSE(e.second >= 0)
+    RET_CHECK(e.second >= 0)
         << "No port found for Node with ID " << e.first << " in the config.";
   }
 
@@ -747,33 +743,30 @@ bool IsGePortOnTridentPlus(const BcmPort& bcm_port,
   //    ports.
   std::map<uint64, std::set<uint32>> node_id_to_trunk_ids;
   for (const auto& trunk_port : config.trunk_ports()) {
-    CHECK_RETURN_IF_FALSE(trunk_port.id() > 0)
+    RET_CHECK(trunk_port.id() > 0)
         << "No positive ID in " << PrintTrunkPort(trunk_port) << ".";
-    CHECK_RETURN_IF_FALSE(trunk_port.type() != TrunkPort::UNKNOWN_TRUNK)
+    RET_CHECK(trunk_port.type() != TrunkPort::UNKNOWN_TRUNK)
         << "No type in " << PrintTrunkPort(trunk_port) << ".";
-    CHECK_RETURN_IF_FALSE(trunk_port.id() != kCpuPortId)
+    RET_CHECK(trunk_port.id() != kCpuPortId)
         << "TrunkPort " << PrintTrunkPort(trunk_port)
         << " has the reserved CPU port ID (" << kCpuPortId << ").";
-    CHECK_RETURN_IF_FALSE(trunk_port.node() > 0)
+    RET_CHECK(trunk_port.node() > 0)
         << "No valid node ID in " << trunk_port.ShortDebugString() << ".";
-    CHECK_RETURN_IF_FALSE(node_id_to_unit.count(trunk_port.node()))
+    RET_CHECK(node_id_to_unit.count(trunk_port.node()))
         << "Node ID " << trunk_port.node() << " given for TrunkPort "
         << PrintTrunkPort(trunk_port)
         << " has not been given to any Node in the config.";
-    CHECK_RETURN_IF_FALSE(
-        !node_id_to_trunk_ids[trunk_port.node()].count(trunk_port.id()))
+    RET_CHECK(!node_id_to_trunk_ids[trunk_port.node()].count(trunk_port.id()))
         << "The id for TrunkPort " << PrintTrunkPort(trunk_port)
         << " was already recorded for another TrunkPort for node with ID "
         << trunk_port.node() << ".";
-    CHECK_RETURN_IF_FALSE(
-        !node_id_to_port_ids[trunk_port.node()].count(trunk_port.id()))
+    RET_CHECK(!node_id_to_port_ids[trunk_port.node()].count(trunk_port.id()))
         << "The id for TrunkPort " << PrintTrunkPort(trunk_port)
         << " was already recorded for another SingletonPort for node with ID "
         << trunk_port.node() << ".";
     node_id_to_trunk_ids[trunk_port.node()].insert(trunk_port.id());
     for (uint32 port_id : trunk_port.members()) {
-      CHECK_RETURN_IF_FALSE(
-          node_id_to_port_ids[trunk_port.node()].count(port_id))
+      RET_CHECK(node_id_to_port_ids[trunk_port.node()].count(port_id))
           << "Unknown member SingletonPort " << port_id << " for TrunkPort "
           << PrintTrunkPort(trunk_port) << ".";
     }
@@ -787,7 +780,7 @@ bool IsGePortOnTridentPlus(const BcmPort& bcm_port,
     bool found = false;  // set to true when we find BcmChip for this node.
     for (const auto& bcm_chip : base_bcm_chassis_map->bcm_chips()) {
       if (unit == bcm_chip.unit()) {
-        CHECK_RETURN_IF_FALSE(supported_chip_types.count(bcm_chip.type()))
+        RET_CHECK(supported_chip_types.count(bcm_chip.type()))
             << "Chip type " << BcmChip::BcmChipType_Name(bcm_chip.type())
             << " is not supported on platform "
             << Platform_Name(config.chassis().platform()) << ".";
@@ -796,13 +789,13 @@ bool IsGePortOnTridentPlus(const BcmPort& bcm_port,
         break;
       }
     }
-    CHECK_RETURN_IF_FALSE(found) << "Could not find any BcmChip for unit "
-                                 << unit << " in base_bcm_chassis_map.";
+    RET_CHECK(found) << "Could not find any BcmChip for unit " << unit
+                     << " in base_bcm_chassis_map.";
   }
 
   // Validate internal ports if any.
   for (const auto& e : port_group_key_to_internal) {
-    CHECK_RETURN_IF_FALSE(e.second.size() == 1)
+    RET_CHECK(e.second.size() == 1)
         << "For SingletonPorts with " << e.first.ToString()
         << " found both internal and external BCM ports. This is invalid.";
   }
@@ -815,19 +808,19 @@ bool IsGePortOnTridentPlus(const BcmPort& bcm_port,
       {kTenGigBps, {1, 2, 3, 4}}};
   for (const auto& e : port_group_key_to_speed_bps) {
     const PortKey& port_group_key = e.first;
-    CHECK_RETURN_IF_FALSE(e.second.size() == 1)
+    RET_CHECK(e.second.size() == 1)
         << "For SingletonPorts with " << e.first.ToString() << " found "
         << e.second.size() << " different speed_bps. This is invalid.";
     uint64 speed_bps = *e.second.begin();
     const std::set<int>* expected_channels =
         gtl::FindOrNull(speed_bps_to_expected_channels, speed_bps);
-    CHECK_RETURN_IF_FALSE(expected_channels != nullptr)
+    RET_CHECK(expected_channels != nullptr)
         << "Unsupported speed_bps: " << speed_bps << ".";
     const std::set<int>& existing_channels =
         port_group_key_to_channels[port_group_key];
-    CHECK_RETURN_IF_FALSE(
-        std::includes(expected_channels->begin(), expected_channels->end(),
-                      existing_channels.begin(), existing_channels.end()))
+    RET_CHECK(std::includes(expected_channels->begin(),
+                            expected_channels->end(), existing_channels.begin(),
+                            existing_channels.end()))
         << "For SingletonPorts with " << e.first.ToString()
         << " and speed_bps = " << speed_bps << " found invalid channels.";
   }
@@ -844,7 +837,7 @@ bool IsGePortOnTridentPlus(const BcmPort& bcm_port,
         units.insert(bcm_port.unit());
       }
     }
-    CHECK_RETURN_IF_FALSE(units.size() == 1U)
+    RET_CHECK(units.size() == 1U)
         << "Found ports with (slot, port) = (" << port_group_key.slot << ", "
         << port_group_key.port << ") that are on different chips.";
     int unit = *units.begin();
@@ -888,7 +881,7 @@ bool IsGePortOnTridentPlus(const BcmPort& bcm_port,
           break;
         }
       }
-      CHECK_RETURN_IF_FALSE(found)
+      RET_CHECK(found)
           << "Could not find any BcmPort in base_bcm_chassis_map whose (slot, "
           << "port, channel, speed_bps) tuple matches flex SingletonPort "
           << PrintSingletonPort(singleton_port);
@@ -927,8 +920,8 @@ bool IsGePortOnTridentPlus(const BcmPort& bcm_port,
       {BcmChip::TOMAHAWK3, kTomahawk3MaxBcmPortsPerChip},
   };
   for (const auto& e : unit_to_chip_type) {
-    CHECK_RETURN_IF_FALSE(unit_to_bcm_port_keys[e.first].size() <=
-                          chip_type_to_max_num_ports[e.second])
+    RET_CHECK(unit_to_bcm_port_keys[e.first].size() <=
+              chip_type_to_max_num_ports[e.second])
         << "Max num of BCM ports for a " << BcmChip::BcmChipType_Name(e.second)
         << " chip is " << chip_type_to_max_num_ports[e.second]
         << ", but we found " << unit_to_bcm_port_keys[e.first].size()
@@ -945,7 +938,7 @@ bool IsGePortOnTridentPlus(const BcmPort& bcm_port,
       PortKey bcm_port_key(bcm_port.slot(), bcm_port.port(),
                            bcm_port.channel());
       auto it = bcm_port_keys.find(bcm_port_key);
-      CHECK_RETURN_IF_FALSE(it != bcm_port_keys.end())
+      RET_CHECK(it != bcm_port_keys.end())
           << "Invalid state. " << bcm_port_key.ToString()
           << " is not found on unit " << bcm_port.unit() << ".";
       int idx = std::distance(bcm_port_keys.begin(), it);
@@ -978,7 +971,7 @@ bool IsGePortOnTridentPlus(const BcmPort& bcm_port,
           free_logical_ports.erase(p.logical_port());
         }
       }
-      CHECK_RETURN_IF_FALSE(!free_logical_ports.empty())
+      RET_CHECK(!free_logical_ports.empty())
           << "There is no empty logical_port in X pipeline of the T+ chip to "
           << "assign to GE port " << PrintBcmPort(bcm_port) << ".";
       bcm_port.set_logical_port(*free_logical_ports.rbegin());
@@ -997,15 +990,15 @@ bool IsGePortOnTridentPlus(const BcmPort& bcm_port,
   }
 
   for (const auto& bcm_port : target_bcm_chassis_map->bcm_ports()) {
-    CHECK_RETURN_IF_FALSE(
+    RET_CHECK(
         !unit_to_bcm_phy_ports[bcm_port.unit()].count(bcm_port.physical_port()))
         << "Duplicate BCM physcial_port for unit " << bcm_port.unit() << ": "
         << bcm_port.physical_port();
-    CHECK_RETURN_IF_FALSE(
+    RET_CHECK(
         !unit_to_bcm_diag_ports[bcm_port.unit()].count(bcm_port.diag_port()))
         << "Duplicate BCM diag_port for unit " << bcm_port.unit() << ": "
         << bcm_port.diag_port();
-    CHECK_RETURN_IF_FALSE(!unit_to_bcm_logical_ports[bcm_port.unit()].count(
+    RET_CHECK(!unit_to_bcm_logical_ports[bcm_port.unit()].count(
         bcm_port.logical_port()))
         << "Duplicate BCM logical_port for unit " << bcm_port.unit() << ": "
         << bcm_port.ShortDebugString();
@@ -1028,32 +1021,30 @@ bool IsGePortOnTridentPlus(const BcmPort& bcm_port,
 
   // Need to make sure target_bcm_chassis_map given here is a pruned version of
   // the base_bcm_chassis_map.
-  CHECK_RETURN_IF_FALSE(base_bcm_chassis_map.id() ==
-                        target_bcm_chassis_map.id())
+  RET_CHECK(base_bcm_chassis_map.id() == target_bcm_chassis_map.id())
       << "The value of 'id' in base_bcm_chassis_map and "
       << "target_bcm_chassis_map must match (" << base_bcm_chassis_map.id()
       << " != " << target_bcm_chassis_map.id() << ").";
-  CHECK_RETURN_IF_FALSE(base_bcm_chassis_map.auto_add_logical_ports() ==
-                        target_bcm_chassis_map.auto_add_logical_ports())
+  RET_CHECK(base_bcm_chassis_map.auto_add_logical_ports() ==
+            target_bcm_chassis_map.auto_add_logical_ports())
       << "The value of 'auto_add_logical_ports' in base_bcm_chassis_map and "
       << "target_bcm_chassis_map must match.";
-  CHECK_RETURN_IF_FALSE(base_bcm_chassis_map.has_bcm_chassis() ==
-                        target_bcm_chassis_map.has_bcm_chassis())
+  RET_CHECK(base_bcm_chassis_map.has_bcm_chassis() ==
+            target_bcm_chassis_map.has_bcm_chassis())
       << "Both base_bcm_chassis_map and target_bcm_chassis_map must either "
       << "have 'bcm_chassis' or miss it.";
   if (target_bcm_chassis_map.has_bcm_chassis()) {
-    CHECK_RETURN_IF_FALSE(ProtoEqual(target_bcm_chassis_map.bcm_chassis(),
-                                     base_bcm_chassis_map.bcm_chassis()))
+    RET_CHECK(ProtoEqual(target_bcm_chassis_map.bcm_chassis(),
+                         base_bcm_chassis_map.bcm_chassis()))
         << "BcmChassis in base_bcm_chassis_map and target_bcm_chassis_map do "
         << "not match.";
   }
   for (const auto& bcm_chip : target_bcm_chassis_map.bcm_chips()) {
-    CHECK_RETURN_IF_FALSE(
-        std::any_of(base_bcm_chassis_map.bcm_chips().begin(),
-                    base_bcm_chassis_map.bcm_chips().end(),
-                    [&bcm_chip](const ::google::protobuf::Message& x) {
-                      return ProtoEqual(x, bcm_chip);
-                    }))
+    RET_CHECK(std::any_of(base_bcm_chassis_map.bcm_chips().begin(),
+                          base_bcm_chassis_map.bcm_chips().end(),
+                          [&bcm_chip](const ::google::protobuf::Message& x) {
+                            return ProtoEqual(x, bcm_chip);
+                          }))
         << "BcmChip " << bcm_chip.ShortDebugString() << " was not found in "
         << "base_bcm_chassis_map.";
   }
@@ -1066,12 +1057,11 @@ bool IsGePortOnTridentPlus(const BcmPort& bcm_port,
       // The base comes with no logical_port assigned.
       p.clear_logical_port();
     }
-    CHECK_RETURN_IF_FALSE(
-        std::any_of(base_bcm_chassis_map.bcm_ports().begin(),
-                    base_bcm_chassis_map.bcm_ports().end(),
-                    [&p](const ::google::protobuf::Message& x) {
-                      return ProtoEqual(x, p);
-                    }))
+    RET_CHECK(std::any_of(base_bcm_chassis_map.bcm_ports().begin(),
+                          base_bcm_chassis_map.bcm_ports().end(),
+                          [&p](const ::google::protobuf::Message& x) {
+                            return ProtoEqual(x, p);
+                          }))
         << "BcmPort " << p.ShortDebugString() << " was not found in "
         << "base_bcm_chassis_map.";
     ss << absl::StrFormat("%3i, %3i, %3i\n", bcm_port.port(),
@@ -1222,8 +1212,7 @@ bool IsGePortOnTridentPlus(const BcmPort& bcm_port,
       if (IsSingletonPortMatchesBcmPort(singleton_port, bcm_port)) {
         PortKey singleton_port_key(singleton_port.slot(), singleton_port.port(),
                                    singleton_port.channel());
-        CHECK_RETURN_IF_FALSE(
-            !singleton_port_key_to_bcm_port_.count(singleton_port_key))
+        RET_CHECK(!singleton_port_key_to_bcm_port_.count(singleton_port_key))
             << "The (slot, port, channel) tuple for SingletonPort "
             << PrintSingletonPort(singleton_port)
             << " already exists as a key in singleton_port_key_to_bcm_port_. "
@@ -1243,7 +1232,7 @@ bool IsGePortOnTridentPlus(const BcmPort& bcm_port,
               break;
             }
           }
-          CHECK_RETURN_IF_FALSE(found)
+          RET_CHECK(found)
               << "Found no matching BcmPort in applied_bcm_chassis_map_ which "
               << "matches unit, physical_port and diag_port of BcmPort '"
               << p->ShortDebugString() << "'.";
@@ -1260,7 +1249,7 @@ bool IsGePortOnTridentPlus(const BcmPort& bcm_port,
         node_id_to_port_id_to_sdk_port_[node_id][port_id] = sdk_port;
         node_id_to_sdk_port_to_port_id_[node_id][sdk_port] = port_id;
         PortKey xcvr_port_key(singleton_port.slot(), singleton_port.port());
-        CHECK_RETURN_IF_FALSE(xcvr_port_key_to_xcvr_state_.count(xcvr_port_key))
+        RET_CHECK(xcvr_port_key_to_xcvr_state_.count(xcvr_port_key))
             << "Something is wrong. ChassisConfig contains a (slot, port) "
             << "which we dont know about: " << xcvr_port_key.ToString() << ".";
         // The xcvr_port_key can be also used as a key to identify the
@@ -1609,90 +1598,87 @@ void BcmChassisManager::CleanupInternalState() {
       break;
     }
   }
-  CHECK_RETURN_IF_FALSE(found)
-      << "Did not find a BcmChassisMap with id " << bcm_chassis_map_id << " in "
-      << FLAGS_base_bcm_chassis_map_file;
+  RET_CHECK(found) << "Did not find a BcmChassisMap with id "
+                   << bcm_chassis_map_id << " in "
+                   << FLAGS_base_bcm_chassis_map_file;
 
   // Verify the messages base_bcm_chassis_map.
   std::set<int> slots;
   std::set<int> units;
   std::set<int> modules;
   for (const auto& bcm_chip : base_bcm_chassis_map->bcm_chips()) {
-    CHECK_RETURN_IF_FALSE(bcm_chip.type())
+    RET_CHECK(bcm_chip.type())
         << "Invalid type in " << bcm_chip.ShortDebugString();
     if (base_bcm_chassis_map->auto_add_slot()) {
-      CHECK_RETURN_IF_FALSE(bcm_chip.slot() == 0)
+      RET_CHECK(bcm_chip.slot() == 0)
           << "auto_add_slot is True and slot is non-zero for chip "
           << bcm_chip.ShortDebugString();
     } else {
-      CHECK_RETURN_IF_FALSE(bcm_chip.slot() > 0)
+      RET_CHECK(bcm_chip.slot() > 0)
           << "Invalid slot in " << bcm_chip.ShortDebugString();
       slots.insert(bcm_chip.slot());
     }
-    CHECK_RETURN_IF_FALSE(bcm_chip.unit() >= 0 && !units.count(bcm_chip.unit()))
+    RET_CHECK(bcm_chip.unit() >= 0 && !units.count(bcm_chip.unit()))
         << "Invalid unit in " << bcm_chip.ShortDebugString();
-    CHECK_RETURN_IF_FALSE(bcm_chip.module() >= 0 &&
-                          !modules.count(bcm_chip.module()))
+    RET_CHECK(bcm_chip.module() >= 0 && !modules.count(bcm_chip.module()))
         << "Invalid module in " << bcm_chip.ShortDebugString();
-    CHECK_RETURN_IF_FALSE(bcm_chip.pci_bus() >= 0)
+    RET_CHECK(bcm_chip.pci_bus() >= 0)
         << "Invalid pci_bus in " << bcm_chip.ShortDebugString();
-    CHECK_RETURN_IF_FALSE(bcm_chip.pci_slot() >= 0)
+    RET_CHECK(bcm_chip.pci_slot() >= 0)
         << "Invalid pci_slot in " << bcm_chip.ShortDebugString();
     units.insert(bcm_chip.unit());
     modules.insert(bcm_chip.module());
   }
   for (const auto& bcm_port : base_bcm_chassis_map->bcm_ports()) {
-    CHECK_RETURN_IF_FALSE(bcm_port.type())
+    RET_CHECK(bcm_port.type())
         << "Invalid type in " << bcm_port.ShortDebugString();
     if (base_bcm_chassis_map->auto_add_slot()) {
-      CHECK_RETURN_IF_FALSE(bcm_port.slot() == 0)
+      RET_CHECK(bcm_port.slot() == 0)
           << "auto_add_slot is True and slot is non-zero for port "
           << bcm_port.ShortDebugString();
     } else {
-      CHECK_RETURN_IF_FALSE(bcm_port.slot() > 0 && slots.count(bcm_port.slot()))
+      RET_CHECK(bcm_port.slot() > 0 && slots.count(bcm_port.slot()))
           << "Invalid slot in " << bcm_port.ShortDebugString();
     }
-    CHECK_RETURN_IF_FALSE(bcm_port.port() > 0)
+    RET_CHECK(bcm_port.port() > 0)
         << "Invalid port in " << bcm_port.ShortDebugString();
-    CHECK_RETURN_IF_FALSE(bcm_port.channel() >= 0 && bcm_port.channel() <= 4)
+    RET_CHECK(bcm_port.channel() >= 0 && bcm_port.channel() <= 4)
         << "Invalid channel in " << bcm_port.ShortDebugString();
-    CHECK_RETURN_IF_FALSE(bcm_port.unit() >= 0 && units.count(bcm_port.unit()))
+    RET_CHECK(bcm_port.unit() >= 0 && units.count(bcm_port.unit()))
         << "Invalid unit in " << bcm_port.ShortDebugString();
-    CHECK_RETURN_IF_FALSE(bcm_port.speed_bps() > 0 &&
-                          bcm_port.speed_bps() % kBitsPerGigabit == 0)
+    RET_CHECK(bcm_port.speed_bps() > 0 &&
+              bcm_port.speed_bps() % kBitsPerGigabit == 0)
         << "Invalid speed_bps in " << bcm_port.ShortDebugString();
-    CHECK_RETURN_IF_FALSE(bcm_port.physical_port() >= 0)
+    RET_CHECK(bcm_port.physical_port() >= 0)
         << "Invalid physical_port in " << bcm_port.ShortDebugString();
-    CHECK_RETURN_IF_FALSE(bcm_port.diag_port() >= 0)
+    RET_CHECK(bcm_port.diag_port() >= 0)
         << "Invalid diag_port in " << bcm_port.ShortDebugString();
-    CHECK_RETURN_IF_FALSE(bcm_port.module() >= 0 &&
-                          modules.count(bcm_port.module()))
+    RET_CHECK(bcm_port.module() >= 0 && modules.count(bcm_port.module()))
         << "Invalid module in " << bcm_port.ShortDebugString();
-    CHECK_RETURN_IF_FALSE(bcm_port.serdes_core() >= 0)
+    RET_CHECK(bcm_port.serdes_core() >= 0)
         << "Invalid serdes_core in " << bcm_port.ShortDebugString();
-    CHECK_RETURN_IF_FALSE(bcm_port.serdes_lane() >= 0 &&
-                          bcm_port.serdes_lane() <= 3)
+    RET_CHECK(bcm_port.serdes_lane() >= 0 && bcm_port.serdes_lane() <= 3)
         << "Invalid serdes_lane in " << bcm_port.ShortDebugString();
     if (bcm_port.type() != BcmPort::MGMT) {
-      CHECK_RETURN_IF_FALSE(bcm_port.num_serdes_lanes() >= 1 &&
-                            bcm_port.num_serdes_lanes() <= 4)
+      RET_CHECK(bcm_port.num_serdes_lanes() >= 1 &&
+                bcm_port.num_serdes_lanes() <= 4)
           << "Invalid num_serdes_lanes in " << bcm_port.ShortDebugString();
     }
-    CHECK_RETURN_IF_FALSE(bcm_port.tx_lane_map() >= 0)
+    RET_CHECK(bcm_port.tx_lane_map() >= 0)
         << "Invalid tx_lane_map in " << bcm_port.ShortDebugString();
-    CHECK_RETURN_IF_FALSE(bcm_port.rx_lane_map() >= 0)
+    RET_CHECK(bcm_port.rx_lane_map() >= 0)
         << "Invalid rx_lane_map in " << bcm_port.ShortDebugString();
-    CHECK_RETURN_IF_FALSE(bcm_port.tx_polarity_flip() >= 0)
+    RET_CHECK(bcm_port.tx_polarity_flip() >= 0)
         << "Invalid tx_polarity_flip in " << bcm_port.ShortDebugString();
-    CHECK_RETURN_IF_FALSE(bcm_port.rx_polarity_flip() >= 0)
+    RET_CHECK(bcm_port.rx_polarity_flip() >= 0)
         << "Invalid rx_polarity_flip in " << bcm_port.ShortDebugString();
     if (base_bcm_chassis_map->auto_add_logical_ports() ||
         IsGePortOnTridentPlus(bcm_port, *base_bcm_chassis_map)) {
-      CHECK_RETURN_IF_FALSE(bcm_port.logical_port() == 0)
+      RET_CHECK(bcm_port.logical_port() == 0)
           << "auto_add_logical_ports is True and logical_port is non-zero: "
           << bcm_port.ShortDebugString();
     } else {
-      CHECK_RETURN_IF_FALSE(bcm_port.logical_port() > 0)
+      RET_CHECK(bcm_port.logical_port() > 0)
           << "auto_add_logical_ports is False and port is not a GE port, yet "
           << "logical_port is not positive: " << bcm_port.ShortDebugString();
     }
@@ -1710,7 +1696,7 @@ void BcmChassisManager::CleanupInternalState() {
   for (const auto& singleton_port : config.singleton_ports()) {
     slots.insert(singleton_port.slot());
   }
-  CHECK_RETURN_IF_FALSE(slots.size() == 1U)
+  RET_CHECK(slots.size() == 1U)
       << "Cannot support a case where auto_add_slot is true and we have more "
       << "than one slot number specified in the ChassisConfig.";
   int slot = *slots.begin();
@@ -1995,7 +1981,7 @@ void BcmChassisManager::TransceiverEventHandler(int slot, int port,
   // First check to see if this is a flex port group.
   const std::vector<BcmPort*>* bcm_ports =
       gtl::FindOrNull(port_group_key_to_flex_bcm_ports_, port_group_key);
-  CHECK_RETURN_IF_FALSE(bcm_ports != nullptr)
+  RET_CHECK(bcm_ports != nullptr)
       << "Ports with (slot, port) = (" << port_group_key.slot << ", "
       << port_group_key.port << ") is not a flex port.";
 
@@ -2008,7 +1994,7 @@ void BcmChassisManager::TransceiverEventHandler(int slot, int port,
   for (const auto& bcm_port : applied_bcm_chassis_map_->bcm_ports()) {
     if (bcm_port.slot() == port_group_key.slot &&
         bcm_port.port() == port_group_key.port) {
-      CHECK_RETURN_IF_FALSE(bcm_port.flex_port())
+      RET_CHECK(bcm_port.flex_port())
           << "Detected unexpected non-flex SingletonPort: "
           << PrintBcmPort(bcm_port);
       units_set.insert(bcm_port.unit());
@@ -2023,21 +2009,20 @@ void BcmChassisManager::TransceiverEventHandler(int slot, int port,
   }
 
   // Check to see everythin makes sense.
-  CHECK_RETURN_IF_FALSE(units_set.size() == 1U)
+  RET_CHECK(units_set.size() == 1U)
       << "Found ports with (slot, port) = (" << port_group_key.slot << ", "
       << port_group_key.port << ") are on different chips.";
-  CHECK_RETURN_IF_FALSE(config_num_serdes_lanes_set.size() == 1U)
+  RET_CHECK(config_num_serdes_lanes_set.size() == 1U)
       << "Found ports with (slot, port) = (" << port_group_key.slot << ", "
       << port_group_key.port << ") have different num_serdes_lanes.";
-  CHECK_RETURN_IF_FALSE(config_speed_bps_set.size() == 1U)
+  RET_CHECK(config_speed_bps_set.size() == 1U)
       << "Found ports with (slot, port) = (" << port_group_key.slot << ", "
       << port_group_key.port << ") have different speed_bps.";
   int unit = *units_set.begin();
   int control_logical_port = *min_speed_logical_ports_set.begin();
   int config_num_serdes_lanes = *config_num_serdes_lanes_set.begin();
   uint64 config_speed_bps = *config_speed_bps_set.begin();
-  CHECK_RETURN_IF_FALSE(*config_speed_logical_ports_set.begin() ==
-                        control_logical_port)
+  RET_CHECK(*config_speed_logical_ports_set.begin() == control_logical_port)
       << "Control logical port mismatch: " << control_logical_port
       << " != " << *config_speed_logical_ports_set.begin() << ".";
 
@@ -2152,23 +2137,21 @@ void BcmChassisManager::TransceiverEventHandler(int slot, int port,
     BcmPortOptions applied_options = options;
     // Check if AdminState is set and override options.
     auto* node_id = gtl::FindOrNull(unit_to_node_id_, bcm_port->unit());
-    CHECK_RETURN_IF_FALSE(node_id)
-        << "Unable to find unit " << bcm_port->unit() << ".";
+    RET_CHECK(node_id) << "Unable to find unit " << bcm_port->unit() << ".";
     auto* sdk_port_to_port_id =
         gtl::FindOrNull(node_id_to_sdk_port_to_port_id_, *node_id);
-    CHECK_RETURN_IF_FALSE(sdk_port_to_port_id)
-        << "Unable to find node " << *node_id << ".";
+    RET_CHECK(sdk_port_to_port_id) << "Unable to find node " << *node_id << ".";
     SdkPort sdk_port(bcm_port->unit(), bcm_port->logical_port());
     auto* port_id = gtl::FindOrNull(*sdk_port_to_port_id, sdk_port);
-    CHECK_RETURN_IF_FALSE(port_id)
-        << "Unable to find SdkPort " << sdk_port.ToString() << ".";
+    RET_CHECK(port_id) << "Unable to find SdkPort " << sdk_port.ToString()
+                       << ".";
     const auto* port_id_to_admin_state =
         gtl::FindOrNull(node_id_to_port_id_to_admin_state_, *node_id);
-    CHECK_RETURN_IF_FALSE(port_id_to_admin_state != nullptr)
+    RET_CHECK(port_id_to_admin_state != nullptr)
         << "Unknown node " << node_id << ".";
     const auto* admin_state =
         gtl::FindOrNull(*port_id_to_admin_state, *port_id);
-    CHECK_RETURN_IF_FALSE(admin_state != nullptr)
+    RET_CHECK(admin_state != nullptr)
         << "Unknown port " << port_id << " on node " << node_id << ".";
     if (*admin_state == ADMIN_STATE_DISABLED) {
       applied_options.set_enabled(TRI_STATE_FALSE);

--- a/stratum/hal/lib/bcm/bcm_chassis_manager_test.cc
+++ b/stratum/hal/lib/bcm/bcm_chassis_manager_test.cc
@@ -113,53 +113,38 @@ class BcmChassisManagerTest : public ::testing::TestWithParam<OperationMode> {
   }
 
   ::util::Status CheckCleanInternalState() {
-    CHECK_RETURN_IF_FALSE(bcm_chassis_manager_->unit_to_bcm_chip_.empty());
-    CHECK_RETURN_IF_FALSE(
-        bcm_chassis_manager_->singleton_port_key_to_bcm_port_.empty());
-    CHECK_RETURN_IF_FALSE(
-        bcm_chassis_manager_->port_group_key_to_flex_bcm_ports_.empty());
-    CHECK_RETURN_IF_FALSE(
+    RET_CHECK(bcm_chassis_manager_->unit_to_bcm_chip_.empty());
+    RET_CHECK(bcm_chassis_manager_->singleton_port_key_to_bcm_port_.empty());
+    RET_CHECK(bcm_chassis_manager_->port_group_key_to_flex_bcm_ports_.empty());
+    RET_CHECK(
         bcm_chassis_manager_->port_group_key_to_non_flex_bcm_ports_.empty());
-    CHECK_RETURN_IF_FALSE(bcm_chassis_manager_->node_id_to_unit_.empty());
-    CHECK_RETURN_IF_FALSE(bcm_chassis_manager_->unit_to_node_id_.empty());
-    CHECK_RETURN_IF_FALSE(bcm_chassis_manager_->node_id_to_port_ids_.empty());
-    CHECK_RETURN_IF_FALSE(bcm_chassis_manager_->node_id_to_trunk_ids_.empty());
-    CHECK_RETURN_IF_FALSE(
-        bcm_chassis_manager_->node_id_to_port_id_to_singleton_port_key_
-            .empty());
-    CHECK_RETURN_IF_FALSE(
-        bcm_chassis_manager_->node_id_to_port_id_to_sdk_port_.empty());
-    CHECK_RETURN_IF_FALSE(
-        bcm_chassis_manager_->node_id_to_trunk_id_to_sdk_trunk_.empty());
-    CHECK_RETURN_IF_FALSE(
-        bcm_chassis_manager_->node_id_to_sdk_port_to_port_id_.empty());
-    CHECK_RETURN_IF_FALSE(
-        bcm_chassis_manager_->node_id_to_sdk_trunk_to_trunk_id_.empty());
-    CHECK_RETURN_IF_FALSE(
-        bcm_chassis_manager_->xcvr_port_key_to_xcvr_state_.empty());
+    RET_CHECK(bcm_chassis_manager_->node_id_to_unit_.empty());
+    RET_CHECK(bcm_chassis_manager_->unit_to_node_id_.empty());
+    RET_CHECK(bcm_chassis_manager_->node_id_to_port_ids_.empty());
+    RET_CHECK(bcm_chassis_manager_->node_id_to_trunk_ids_.empty());
+    RET_CHECK(bcm_chassis_manager_->node_id_to_port_id_to_singleton_port_key_
+                  .empty());
+    RET_CHECK(bcm_chassis_manager_->node_id_to_port_id_to_sdk_port_.empty());
+    RET_CHECK(bcm_chassis_manager_->node_id_to_trunk_id_to_sdk_trunk_.empty());
+    RET_CHECK(bcm_chassis_manager_->node_id_to_sdk_port_to_port_id_.empty());
+    RET_CHECK(bcm_chassis_manager_->node_id_to_sdk_trunk_to_trunk_id_.empty());
+    RET_CHECK(bcm_chassis_manager_->xcvr_port_key_to_xcvr_state_.empty());
 
-    CHECK_RETURN_IF_FALSE(
-        bcm_chassis_manager_->node_id_to_port_id_to_port_state_.empty());
-    CHECK_RETURN_IF_FALSE(
+    RET_CHECK(bcm_chassis_manager_->node_id_to_port_id_to_port_state_.empty());
+    RET_CHECK(
         bcm_chassis_manager_->node_id_to_trunk_id_to_trunk_state_.empty());
-    CHECK_RETURN_IF_FALSE(
-        bcm_chassis_manager_->node_id_to_trunk_id_to_members_.empty());
-    CHECK_RETURN_IF_FALSE(
-        bcm_chassis_manager_->node_id_to_port_id_to_trunk_membership_info_
-            .empty());
-    CHECK_RETURN_IF_FALSE(
-        bcm_chassis_manager_->node_id_to_port_id_to_admin_state_.empty());
-    CHECK_RETURN_IF_FALSE(
+    RET_CHECK(bcm_chassis_manager_->node_id_to_trunk_id_to_members_.empty());
+    RET_CHECK(bcm_chassis_manager_->node_id_to_port_id_to_trunk_membership_info_
+                  .empty());
+    RET_CHECK(bcm_chassis_manager_->node_id_to_port_id_to_admin_state_.empty());
+    RET_CHECK(
         bcm_chassis_manager_->node_id_to_port_id_to_health_state_.empty());
-    CHECK_RETURN_IF_FALSE(
+    RET_CHECK(
         bcm_chassis_manager_->node_id_to_port_id_to_loopback_state_.empty());
-    CHECK_RETURN_IF_FALSE(bcm_chassis_manager_->base_bcm_chassis_map_ ==
-                          nullptr);
-    CHECK_RETURN_IF_FALSE(bcm_chassis_manager_->applied_bcm_chassis_map_ ==
-                          nullptr);
-    CHECK_RETURN_IF_FALSE(bcm_chassis_manager_->xcvr_event_channel_ == nullptr);
-    CHECK_RETURN_IF_FALSE(bcm_chassis_manager_->linkscan_event_channel_ ==
-                          nullptr);
+    RET_CHECK(bcm_chassis_manager_->base_bcm_chassis_map_ == nullptr);
+    RET_CHECK(bcm_chassis_manager_->applied_bcm_chassis_map_ == nullptr);
+    RET_CHECK(bcm_chassis_manager_->xcvr_event_channel_ == nullptr);
+    RET_CHECK(bcm_chassis_manager_->linkscan_event_channel_ == nullptr);
 
     return ::util::OkStatus();
   }
@@ -457,11 +442,9 @@ class BcmChassisManagerTest : public ::testing::TestWithParam<OperationMode> {
     RETURN_IF_ERROR(ParseProtoFromString(kConfigText, config));
 
     // Call PushChassisConfig() verify the results.
-    CHECK_RETURN_IF_FALSE(!Initialized())
-        << "Class is initialized before push!";
+    RET_CHECK(!Initialized()) << "Class is initialized before push!";
     RETURN_IF_ERROR(PushChassisConfig(*config));
-    CHECK_RETURN_IF_FALSE(Initialized())
-        << "Class is not initialized after push!";
+    RET_CHECK(Initialized()) << "Class is not initialized after push!";
 
     return ::util::OkStatus();
   }

--- a/stratum/hal/lib/bcm/bcm_l3_manager.cc
+++ b/stratum/hal/lib/bcm/bcm_l3_manager.cc
@@ -72,7 +72,7 @@ BcmL3Manager::~BcmL3Manager() {}
 
 ::util::StatusOr<int> BcmL3Manager::FindOrCreateNonMultipathNexthop(
     const BcmNonMultipathNexthop& nexthop) {
-  CHECK_RETURN_IF_FALSE(nexthop.unit() == unit_)
+  RET_CHECK(nexthop.unit() == unit_)
       << "Received non-multipath nexthop for unit " << nexthop.unit()
       << " on unit " << unit_ << ".";
   int vlan = nexthop.vlan();
@@ -152,7 +152,7 @@ BcmL3Manager::~BcmL3Manager() {}
 
 ::util::StatusOr<int> BcmL3Manager::FindOrCreateMultipathNexthop(
     const BcmMultipathNexthop& nexthop) {
-  CHECK_RETURN_IF_FALSE(nexthop.unit() == unit_)
+  RET_CHECK(nexthop.unit() == unit_)
       << "Received multipath nexthop for unit " << nexthop.unit() << " on unit "
       << unit_ << ".";
   ASSIGN_OR_RETURN(std::vector<int> member_ids, FindEcmpGroupMembers(nexthop));
@@ -185,7 +185,7 @@ BcmL3Manager::~BcmL3Manager() {}
     return MAKE_ERROR(ERR_INVALID_PARAM)
            << "Invalid egress_intf_id: " << egress_intf_id << ".";
   }
-  CHECK_RETURN_IF_FALSE(nexthop.unit() == unit_)
+  RET_CHECK(nexthop.unit() == unit_)
       << "Received non-multipath nexthop for unit " << nexthop.unit()
       << " on unit " << unit_ << ".";
   int vlan = nexthop.vlan();
@@ -272,7 +272,7 @@ BcmL3Manager::~BcmL3Manager() {}
     return MAKE_ERROR(ERR_INVALID_PARAM)
            << "Invalid egress_intf_id: " << egress_intf_id << ".";
   }
-  CHECK_RETURN_IF_FALSE(nexthop.unit() == unit_)
+  RET_CHECK(nexthop.unit() == unit_)
       << "Received multipath nexthop for unit " << nexthop.unit() << " on unit "
       << unit_ << ".";
   ASSIGN_OR_RETURN(std::vector<int> member_ids, FindEcmpGroupMembers(nexthop));
@@ -335,7 +335,7 @@ BcmL3Manager::~BcmL3Manager() {}
 
 ::util::Status BcmL3Manager::InsertLpmOrHostFlow(
     const BcmFlowEntry& bcm_flow_entry) {
-  CHECK_RETURN_IF_FALSE(bcm_flow_entry.unit() == unit_)
+  RET_CHECK(bcm_flow_entry.unit() == unit_)
       << "Received L3 flow for unit " << bcm_flow_entry.unit() << " on unit "
       << unit_ << ".";
   const auto bcm_table_type = bcm_flow_entry.bcm_table_type();
@@ -439,7 +439,7 @@ BcmL3Manager::~BcmL3Manager() {}
 
 ::util::Status BcmL3Manager::DeleteLpmOrHostFlow(
     const BcmFlowEntry& bcm_flow_entry) {
-  CHECK_RETURN_IF_FALSE(bcm_flow_entry.unit() == unit_)
+  RET_CHECK(bcm_flow_entry.unit() == unit_)
       << "Received L3 flow for unit " << bcm_flow_entry.unit() << " on unit "
       << unit_ << ".";
   const auto bcm_table_type = bcm_flow_entry.bcm_table_type();
@@ -704,10 +704,10 @@ std::unique_ptr<BcmL3Manager> BcmL3Manager::CreateInstance(
 
 ::util::Status BcmL3Manager::DecrementRefCount(int router_intf_id) {
   uint32* ref_count = gtl::FindOrNull(router_intf_ref_count_, router_intf_id);
-  CHECK_RETURN_IF_FALSE(ref_count != nullptr)
+  RET_CHECK(ref_count != nullptr)
       << "Inconsistent state. router_intf_id: " << router_intf_id
       << " not in router_intf_ref_count_ map.";
-  CHECK_RETURN_IF_FALSE(*ref_count > 0)
+  RET_CHECK(*ref_count > 0)
       << "Inconsistent state. router_intf_id: " << router_intf_id
       << " has zero ref count.";
   (*ref_count)--;

--- a/stratum/hal/lib/bcm/bcm_sdk_sim.cc
+++ b/stratum/hal/lib/bcm/bcm_sdk_sim.cc
@@ -88,8 +88,8 @@ BcmSdkSim::~BcmSdkSim() { ShutdownAllUnits().IgnoreError(); }
   {
     absl::WriterMutexLock l(&sim_lock_);
     BcmSimDeviceInfo* info = gtl::FindPtrOrNull(unit_to_dev_info_, unit);
-    CHECK_RETURN_IF_FALSE(info != nullptr) << "Unit " << unit << " not found!";
-    CHECK_RETURN_IF_FALSE(info->chip_type == chip_type)
+    RET_CHECK(info != nullptr) << "Unit " << unit << " not found!";
+    RET_CHECK(info->chip_type == chip_type)
         << "Inconsistent state. Unit " << unit << " must be " << chip_type
         << " but got " << info->chip_type;
     info->pci_bus = pci_bus;
@@ -197,7 +197,7 @@ BcmSdkSim* BcmSdkSim::CreateSingleton(const std::string& bcm_sdk_sim_bin) {
 ::util::Status BcmSdkSim::GetPciInfo(int unit, uint32* bus, uint32* slot) {
   absl::ReaderMutexLock l(&sim_lock_);
   BcmSimDeviceInfo* info = gtl::FindPtrOrNull(unit_to_dev_info_, unit);
-  CHECK_RETURN_IF_FALSE(info != nullptr) << "Unit " << unit << " not found!";
+  RET_CHECK(info != nullptr) << "Unit " << unit << " not found!";
   *bus = static_cast<uint32>(info->pci_bus);
   *slot = static_cast<uint32>(info->pci_slot);
 
@@ -278,7 +278,7 @@ BcmSdkSim* BcmSdkSim::CreateSingleton(const std::string& bcm_sdk_sim_bin) {
               << " and has PID " << pid << ".";
     // Keep track of the RPC port and PID for the simulator.
     absl::WriterMutexLock l(&sim_lock_);
-    CHECK_RETURN_IF_FALSE(unit_to_dev_info_.count(unit) == 0)
+    RET_CHECK(unit_to_dev_info_.count(unit) == 0)
         << "Unit " << unit << " already exists!";
     unit_to_dev_info_[unit] = new BcmSimDeviceInfo();
     unit_to_dev_info_[unit]->chip_type = chip_type;

--- a/stratum/hal/lib/bcm/bcm_serdes_db_manager.cc
+++ b/stratum/hal/lib/bcm/bcm_serdes_db_manager.cc
@@ -66,30 +66,30 @@ BcmSerdesDbManager::~BcmSerdesDbManager() {}
       const auto& serdes_chip_configs =
           e.bcm_serdes_board_config().bcm_serdes_chip_configs();
       auto i = serdes_chip_configs.find(bcm_port.unit());
-      CHECK_RETURN_IF_FALSE(i != serdes_chip_configs.end())
+      RET_CHECK(i != serdes_chip_configs.end())
           << "Unit " << bcm_port.unit() << " not found in serdes DB for "
           << PrintBcmPort(bcm_port) << " with following front panel port info: "
           << fp_port_info.ShortDebugString();
       const auto& serdes_core_configs = i->second.bcm_serdes_core_configs();
       auto j = serdes_core_configs.find(bcm_port.serdes_core());
-      CHECK_RETURN_IF_FALSE(j != serdes_core_configs.end())
+      RET_CHECK(j != serdes_core_configs.end())
           << "Serdes core " << bcm_port.serdes_core() << " not found in serdes "
           << "DB for " << PrintBcmPort(bcm_port) << " with following front "
           << "panel port info: " << fp_port_info.ShortDebugString();
       const auto& serdes_lane_configs = j->second.bcm_serdes_lane_configs();
       auto k = serdes_lane_configs.find(bcm_port.serdes_lane());
-      CHECK_RETURN_IF_FALSE(k != serdes_lane_configs.end())
+      RET_CHECK(k != serdes_lane_configs.end())
           << "Serdes lane " << bcm_port.serdes_lane() << " not found in "
           << "serdes DB for " << PrintBcmPort(bcm_port) << " with following "
           << "front panel port info: " << fp_port_info.ShortDebugString();
       *bcm_serdes_lane_config = k->second;
       for (int l = 1; l < bcm_port.num_serdes_lanes(); ++l) {
         auto k = serdes_lane_configs.find(bcm_port.serdes_lane() + l);
-        CHECK_RETURN_IF_FALSE(k != serdes_lane_configs.end())
+        RET_CHECK(k != serdes_lane_configs.end())
             << "Serdes lane " << bcm_port.serdes_lane() + l << " not found in "
             << "serdes DB for " << PrintBcmPort(bcm_port) << " with following "
             << "front panel port info: " << fp_port_info.ShortDebugString();
-        CHECK_RETURN_IF_FALSE(ProtoEqual(*bcm_serdes_lane_config, k->second))
+        RET_CHECK(ProtoEqual(*bcm_serdes_lane_config, k->second))
             << "Serdes lane configs found for " << PrintBcmPort(bcm_port)
             << " do not have the same value for all the lanes: "
             << j->second.ShortDebugString();

--- a/stratum/hal/lib/bcm/bcm_switch.cc
+++ b/stratum/hal/lib/bcm/bcm_switch.cc
@@ -158,8 +158,8 @@ BcmSwitch::~BcmSwitch() {}
 ::util::Status BcmSwitch::WriteForwardingEntries(
     const ::p4::v1::WriteRequest& req, std::vector<::util::Status>* results) {
   if (!req.updates_size()) return ::util::OkStatus();  // nothing to do.
-  CHECK_RETURN_IF_FALSE(req.device_id()) << "No device_id in WriteRequest.";
-  CHECK_RETURN_IF_FALSE(results != nullptr)
+  RET_CHECK(req.device_id()) << "No device_id in WriteRequest.";
+  RET_CHECK(results != nullptr)
       << "Need to provide non-null results pointer for non-empty updates.";
 
   absl::ReaderMutexLock l(&chassis_lock);
@@ -175,9 +175,9 @@ BcmSwitch::~BcmSwitch() {}
     const ::p4::v1::ReadRequest& req,
     WriterInterface<::p4::v1::ReadResponse>* writer,
     std::vector<::util::Status>* details) {
-  CHECK_RETURN_IF_FALSE(req.device_id()) << "No device_id in ReadRequest.";
-  CHECK_RETURN_IF_FALSE(writer) << "Channel writer must be non-null.";
-  CHECK_RETURN_IF_FALSE(details) << "Details pointer must be non-null.";
+  RET_CHECK(req.device_id()) << "No device_id in ReadRequest.";
+  RET_CHECK(writer) << "Channel writer must be non-null.";
+  RET_CHECK(details) << "Details pointer must be non-null.";
 
   absl::ReaderMutexLock l(&chassis_lock);
   if (shutdown) {

--- a/stratum/hal/lib/bcm/sdklt/bcm_sdk_wrapper.cc
+++ b/stratum/hal/lib/bcm/sdklt/bcm_sdk_wrapper.cc
@@ -120,7 +120,7 @@ DEFINE_int32(max_num_linkscan_writers, 10,
              "Max number of linkscan event Writers supported.");
 DECLARE_string(bcm_sdk_checkpoint_dir);
 
-// TODO: There are many CHECK_RETURN_IF_FALSE in this file which will
+// TODO: There are many RET_CHECK in this file which will
 // need to be changed to return ERR_INTERNAL as opposed to ERR_INVALID_PARAM.
 
 namespace stratum {
@@ -1714,7 +1714,7 @@ BcmSdkWrapper::~BcmSdkWrapper() { ShutdownAllUnits().IgnoreError(); }
   }
   // MTU
   if (options.max_frame_size() > 0) {
-    CHECK_RETURN_IF_FALSE(options.max_frame_size() > 0);
+    RET_CHECK(options.max_frame_size() > 0);
     RETURN_IF_BCM_ERROR(
         GetFieldMinMaxValue(unit, PC_PORTs, MAX_FRAME_SIZEs, &min, &max));
     if ((options.max_frame_size() > static_cast<int>(max)) ||
@@ -1928,7 +1928,7 @@ BcmSdkWrapper::~BcmSdkWrapper() { ShutdownAllUnits().IgnoreError(); }
   // Check if port is valid
   RETURN_IF_BCM_ERROR(CheckIfPortExists(unit, port))
       << "Port " << port << " does not exit on unit " << unit << ".";
-  CHECK_RETURN_IF_FALSE(pc != nullptr);
+  RET_CHECK(pc != nullptr);
 
   uint64 value;
   // Read good counters
@@ -2037,7 +2037,7 @@ BcmSdkWrapper::~BcmSdkWrapper() { ShutdownAllUnits().IgnoreError(); }
   absl::WriterMutexLock l(&data_lock_);
   // // Get logical ports for this unit
   auto logical_ports_map = gtl::FindOrNull(unit_to_logical_ports_, unit);
-  CHECK_RETURN_IF_FALSE(logical_ports_map != nullptr)
+  RET_CHECK(logical_ports_map != nullptr)
       << "Logical ports are not identified on the Unit " << unit << ".";
 
   // Set linkscan mode for all the ports
@@ -2109,7 +2109,7 @@ BcmSdkWrapper::~BcmSdkWrapper() { ShutdownAllUnits().IgnoreError(); }
 
   absl::WriterMutexLock l(&data_lock_);
   auto logical_ports_map = gtl::FindOrNull(unit_to_logical_ports_, unit);
-  CHECK_RETURN_IF_FALSE(logical_ports_map != nullptr)
+  RET_CHECK(logical_ports_map != nullptr)
       << "Logical ports are not identified on the Unit " << unit << ".";
 
   // Disable linkscan mode for all the ports
@@ -2141,8 +2141,8 @@ BcmSdkWrapper::~BcmSdkWrapper() { ShutdownAllUnits().IgnoreError(); }
 ::util::StatusOr<int> BcmSdkWrapper::RegisterLinkscanEventWriter(
     std::unique_ptr<ChannelWriter<LinkscanEvent>> writer, int priority) {
   absl::WriterMutexLock l(&linkscan_writers_lock_);
-  CHECK_RETURN_IF_FALSE(linkscan_event_writers_.size() <
-                        static_cast<size_t>(FLAGS_max_num_linkscan_writers))
+  RET_CHECK(linkscan_event_writers_.size() <
+            static_cast<size_t>(FLAGS_max_num_linkscan_writers))
       << "Can only support " << FLAGS_max_num_linkscan_writers
       << " linkscan event Writers.";
 
@@ -2159,7 +2159,7 @@ BcmSdkWrapper::~BcmSdkWrapper() { ShutdownAllUnits().IgnoreError(); }
       break;
     }
   }
-  CHECK_RETURN_IF_FALSE(next_id != kInvalidWriterId)
+  RET_CHECK(next_id != kInvalidWriterId)
       << "Could not find a new ID for the Writer. next_id=" << next_id << ".";
 
   linkscan_event_writers_.insert({std::move(writer), priority, next_id});
@@ -2172,7 +2172,7 @@ BcmSdkWrapper::~BcmSdkWrapper() { ShutdownAllUnits().IgnoreError(); }
   auto it = std::find_if(
       linkscan_event_writers_.begin(), linkscan_event_writers_.end(),
       [id](const BcmLinkscanEventWriter& h) { return h.id == id; });
-  CHECK_RETURN_IF_FALSE(it != linkscan_event_writers_.end())
+  RET_CHECK(it != linkscan_event_writers_.end())
       << "Could not find a linkscan event Writer with ID " << id << ".";
 
   linkscan_event_writers_.erase(it);
@@ -2229,9 +2229,9 @@ BcmSdkWrapper::GetPortLinkscanMode(int unit, int port) {
   }
   absl::WriterMutexLock l(&data_lock_);
   auto logical_ports_map = gtl::FindOrNull(unit_to_logical_ports_, unit);
-  CHECK_RETURN_IF_FALSE(logical_ports_map != nullptr)
+  RET_CHECK(logical_ports_map != nullptr)
       << "Logical ports are not identified on the Unit " << unit << ".";
-  CHECK_RETURN_IF_FALSE(unit_to_mtu_.count(unit));
+  RET_CHECK(unit_to_mtu_.count(unit));
   // Modify mtu for all the interfaces on this unit.
   RETURN_IF_BCM_ERROR(bcmlt_entry_allocate(unit, PC_PORTs, &entry_hdl));
   for (const auto& port : *logical_ports_map) {
@@ -2255,10 +2255,10 @@ BcmSdkWrapper::GetPortLinkscanMode(int unit, int port) {
   int mtu = 0;
   {
     absl::ReaderMutexLock l(&data_lock_);
-    CHECK_RETURN_IF_FALSE(unit_to_mtu_.count(unit));
+    RET_CHECK(unit_to_mtu_.count(unit));
     mtu = unit_to_mtu_[unit];
   }
-  CHECK_RETURN_IF_FALSE(router_mac);
+  RET_CHECK(router_mac);
 
   // check if unit is valid
   RETURN_IF_BCM_ERROR(CheckIfUnitExists(unit));
@@ -2271,7 +2271,7 @@ BcmSdkWrapper::GetPortLinkscanMode(int unit, int port) {
 
   L3Interfaces entry(router_mac, vlan);
   auto unit_to_l3_intf = gtl::FindOrNull(l3_interface_ids_, unit);
-  CHECK_RETURN_IF_FALSE(unit_to_l3_intf != nullptr)
+  RET_CHECK(unit_to_l3_intf != nullptr)
       << "Unit " << unit << "  is not found in l3_interface_ids. Have you "
       << "called InitializeUnit for this unit before?";
   l3_intf_t l3_interface = {0, router_mac, vlan, 0xff, mtu};
@@ -2339,7 +2339,7 @@ BcmSdkWrapper::GetPortLinkscanMode(int unit, int port) {
   // Check if the unit is valid
   RETURN_IF_BCM_ERROR(CheckIfUnitExists(unit));
   auto unit_to_l3_intf = gtl::FindOrNull(l3_interface_ids_, unit);
-  CHECK_RETURN_IF_FALSE(unit_to_l3_intf != nullptr)
+  RET_CHECK(unit_to_l3_intf != nullptr)
       << "Unit " << unit << "  is not found in l3_interface_ids. Have you "
       << "called InitializeUnit for this unit before?";
   const L3Interfaces* entry = FindIndexOrNull(*unit_to_l3_intf, router_intf_id);
@@ -2368,7 +2368,7 @@ BcmSdkWrapper::GetPortLinkscanMode(int unit, int port) {
   // Check if the unit is valid
   RETURN_IF_BCM_ERROR(CheckIfUnitExists(unit));
   InUseMap* l3_intfs = gtl::FindOrNull(l3_egress_interface_ids_, unit);
-  CHECK_RETURN_IF_FALSE(l3_intfs != nullptr)
+  RET_CHECK(l3_intfs != nullptr)
       << "Unit " << unit << " not initialized yet. Call InitializeUnit first.";
   // get next free slot
   ASSIGN_OR_RETURN(
@@ -2398,8 +2398,8 @@ BcmSdkWrapper::GetPortLinkscanMode(int unit, int port) {
   bool found;
   uint64_t max;
   uint64_t min;
-  CHECK_RETURN_IF_FALSE(nexthop_mac);
-  CHECK_RETURN_IF_FALSE(router_intf_id > 0);
+  RET_CHECK(nexthop_mac);
+  RET_CHECK(router_intf_id > 0);
 
   // Check if the unit is valid
   RETURN_IF_BCM_ERROR(CheckIfUnitExists(unit));
@@ -2413,7 +2413,7 @@ BcmSdkWrapper::GetPortLinkscanMode(int unit, int port) {
 
   InUseMap* l3_intfs = gtl::FindOrNull(l3_egress_interface_ids_, unit);
   auto unit_to_l3_intf = gtl::FindOrNull(l3_interface_ids_, unit);
-  CHECK_RETURN_IF_FALSE(l3_intfs != nullptr && unit_to_l3_intf != nullptr)
+  RET_CHECK(l3_intfs != nullptr && unit_to_l3_intf != nullptr)
       << "Unit " << unit << " not initialized yet. Call InitializeUnit first.";
   // Check if port is valid
   RETURN_IF_BCM_ERROR(CheckIfPortExists(unit, port));
@@ -2467,8 +2467,8 @@ BcmSdkWrapper::GetPortLinkscanMode(int unit, int port) {
   uint64_t max;
   uint64_t min;
 
-  CHECK_RETURN_IF_FALSE(nexthop_mac);
-  CHECK_RETURN_IF_FALSE(router_intf_id > 0);
+  RET_CHECK(nexthop_mac);
+  RET_CHECK(router_intf_id > 0);
   // Check if the unit is valid
   RETURN_IF_BCM_ERROR(CheckIfUnitExists(unit));
   RETURN_IF_BCM_ERROR(
@@ -2487,7 +2487,7 @@ BcmSdkWrapper::GetPortLinkscanMode(int unit, int port) {
   }
   InUseMap* l3_intfs = gtl::FindOrNull(l3_egress_interface_ids_, unit);
   auto unit_to_l3_intf = gtl::FindOrNull(l3_interface_ids_, unit);
-  CHECK_RETURN_IF_FALSE(l3_intfs != nullptr && unit_to_l3_intf != nullptr)
+  RET_CHECK(l3_intfs != nullptr && unit_to_l3_intf != nullptr)
       << "Unit " << unit << " not initialized yet. Call InitializeUnit first.";
   // get next free slot
   ASSIGN_OR_RETURN(
@@ -2528,7 +2528,7 @@ BcmSdkWrapper::GetPortLinkscanMode(int unit, int port) {
   // Check if the unit is valid
   RETURN_IF_BCM_ERROR(CheckIfUnitExists(unit));
   InUseMap* l3_intfs = gtl::FindOrNull(l3_egress_interface_ids_, unit);
-  CHECK_RETURN_IF_FALSE(l3_intfs != nullptr)
+  RET_CHECK(l3_intfs != nullptr)
       << "Unit " << unit << " not initialized yet. Call InitializeUnit first.";
   // get next free slot
   ASSIGN_OR_RETURN(
@@ -2567,7 +2567,7 @@ BcmSdkWrapper::GetPortLinkscanMode(int unit, int port) {
   RETURN_IF_BCM_ERROR(CheckIfUnitExists(unit));
 
   InUseMap* l3_egress_intf = gtl::FindOrNull(l3_egress_interface_ids_, unit);
-  CHECK_RETURN_IF_FALSE(l3_egress_intf != nullptr)
+  RET_CHECK(l3_egress_intf != nullptr)
       << "Unit " << unit << " not initialized yet. Call InitializeUnit first.";
   // Check if egress interface is valid
   it = l3_egress_intf->find(egress_intf_id);
@@ -2630,8 +2630,8 @@ BcmSdkWrapper::GetPortLinkscanMode(int unit, int port) {
   bool found;
   uint64_t max;
   uint64_t min;
-  CHECK_RETURN_IF_FALSE(nexthop_mac);
-  CHECK_RETURN_IF_FALSE(router_intf_id > 0);
+  RET_CHECK(nexthop_mac);
+  RET_CHECK(router_intf_id > 0);
   // Check if unit is valid
   RETURN_IF_BCM_ERROR(CheckIfUnitExists(unit));
   RETURN_IF_BCM_ERROR(
@@ -2643,7 +2643,7 @@ BcmSdkWrapper::GetPortLinkscanMode(int unit, int port) {
   }
   auto unit_to_l3_intf = gtl::FindOrNull(l3_interface_ids_, unit);
   InUseMap* l3_egress_intf = gtl::FindOrNull(l3_egress_interface_ids_, unit);
-  CHECK_RETURN_IF_FALSE(l3_egress_intf != nullptr && unit_to_l3_intf != nullptr)
+  RET_CHECK(l3_egress_intf != nullptr && unit_to_l3_intf != nullptr)
       << "Unit " << unit << " not initialized yet. Call InitializeUnit first.";
   // Check if port is valid
   RETURN_IF_BCM_ERROR(CheckIfPortExists(unit, port));
@@ -2701,8 +2701,8 @@ BcmSdkWrapper::GetPortLinkscanMode(int unit, int port) {
   bool found;
   uint64_t max;
   uint64_t min;
-  CHECK_RETURN_IF_FALSE(nexthop_mac);
-  CHECK_RETURN_IF_FALSE(router_intf_id > 0);
+  RET_CHECK(nexthop_mac);
+  RET_CHECK(router_intf_id > 0);
   // Check if the unit is valid
   RETURN_IF_BCM_ERROR(CheckIfUnitExists(unit));
   RETURN_IF_BCM_ERROR(
@@ -2721,7 +2721,7 @@ BcmSdkWrapper::GetPortLinkscanMode(int unit, int port) {
   }
   InUseMap* l3_egress_intf = gtl::FindOrNull(l3_egress_interface_ids_, unit);
   auto unit_to_l3_intf = gtl::FindOrNull(l3_interface_ids_, unit);
-  CHECK_RETURN_IF_FALSE(l3_egress_intf != nullptr && unit_to_l3_intf != nullptr)
+  RET_CHECK(l3_egress_intf != nullptr && unit_to_l3_intf != nullptr)
       << "Unit " << unit << " not initialized yet. Call InitializeUnit first.";
   // Check if egress interface is valid
   it = l3_egress_intf->find(egress_intf_id);
@@ -2783,7 +2783,7 @@ BcmSdkWrapper::GetPortLinkscanMode(int unit, int port) {
   // Check if the unit is valid
   RETURN_IF_BCM_ERROR(CheckIfUnitExists(unit));
   InUseMap* l3_egress_intf = gtl::FindOrNull(l3_egress_interface_ids_, unit);
-  CHECK_RETURN_IF_FALSE(l3_egress_intf != nullptr)
+  RET_CHECK(l3_egress_intf != nullptr)
       << "Unit " << unit << " not initialized yet. Call InitializeUnit first.";
   // Check if egress interface is valid
   it = l3_egress_intf->find(egress_intf_id);
@@ -2843,7 +2843,7 @@ BcmSdkWrapper::GetPortLinkscanMode(int unit, int port) {
   // Check if the unit is valid
   RETURN_IF_BCM_ERROR(CheckIfUnitExists(unit));
   InUseMap* l3_egress_intf = gtl::FindOrNull(l3_egress_interface_ids_, unit);
-  CHECK_RETURN_IF_FALSE(l3_egress_intf != nullptr)
+  RET_CHECK(l3_egress_intf != nullptr)
       << "Unit " << unit << " not initialized yet. Call InitializeUnit first.";
   // Check if egress interface is valid
   it = l3_egress_intf->find(egress_intf_id);
@@ -2881,7 +2881,7 @@ BcmSdkWrapper::GetPortLinkscanMode(int unit, int port) {
   // Check if the unit is valid
   RETURN_IF_BCM_ERROR(CheckIfUnitExists(unit));
   InUseMap* l3_egress_intf = gtl::FindOrNull(l3_egress_interface_ids_, unit);
-  CHECK_RETURN_IF_FALSE(l3_egress_intf != nullptr)
+  RET_CHECK(l3_egress_intf != nullptr)
       << "Unit " << unit << " not initialized yet. Call InitializeUnit first.";
   // Check if egress interface is valid
   it = l3_egress_intf->find(egress_intf_id);
@@ -2932,7 +2932,7 @@ BcmSdkWrapper::GetPortLinkscanMode(int unit, int port) {
   int members_count = static_cast<int>(member_ids.size());
 
   InUseMap* ecmp_intfs = gtl::FindOrNull(l3_ecmp_egress_interface_ids_, unit);
-  CHECK_RETURN_IF_FALSE(ecmp_intfs != nullptr)
+  RET_CHECK(ecmp_intfs != nullptr)
       << "Unit " << unit << " not initialized yet. Call InitializeUnit first.";
   // get next free slot
   ASSIGN_OR_RETURN(
@@ -2971,7 +2971,7 @@ BcmSdkWrapper::GetPortLinkscanMode(int unit, int port) {
   int members_count = static_cast<int>(member_ids.size());
 
   InUseMap* ecmp_intfs = gtl::FindOrNull(l3_ecmp_egress_interface_ids_, unit);
-  CHECK_RETURN_IF_FALSE(ecmp_intfs != nullptr)
+  RET_CHECK(ecmp_intfs != nullptr)
       << "Unit " << unit << " not initialized yet. Call InitializeUnit first.";
   // Check if egress interface is valid
   it = ecmp_intfs->find(egress_intf_id);
@@ -3010,7 +3010,7 @@ BcmSdkWrapper::GetPortLinkscanMode(int unit, int port) {
   // Check if the unit is valid
   RETURN_IF_BCM_ERROR(CheckIfUnitExists(unit));
   InUseMap* ecmp_intfs = gtl::FindOrNull(l3_ecmp_egress_interface_ids_, unit);
-  CHECK_RETURN_IF_FALSE(ecmp_intfs != nullptr)
+  RET_CHECK(ecmp_intfs != nullptr)
       << "Unit " << unit << " not initialized yet. Call InitializeUnit first.";
   // Check if egress interface is valid
   it = ecmp_intfs->find(egress_intf_id);
@@ -3047,7 +3047,7 @@ BcmSdkWrapper::GetPortLinkscanMode(int unit, int port) {
   InUseMap::iterator it;
   l3_route_t route = {false,  vrf,  class_id, egress_intf_id,
                       subnet, mask, "",       ""};
-  CHECK_RETURN_IF_FALSE(egress_intf_id > 0);
+  RET_CHECK(egress_intf_id > 0);
   // Check if the unit is valid
   RETURN_IF_BCM_ERROR(CheckIfUnitExists(unit));
   RETURN_IF_BCM_ERROR(
@@ -3069,7 +3069,7 @@ BcmSdkWrapper::GetPortLinkscanMode(int unit, int port) {
     }
   }
   InUseMap* l3_egress_intf = gtl::FindOrNull(l3_egress_interface_ids_, unit);
-  CHECK_RETURN_IF_FALSE(l3_egress_intf != nullptr)
+  RET_CHECK(l3_egress_intf != nullptr)
       << "Unit " << unit << " not initialized yet. Call InitializeUnit first.";
   // Check if egress interface is valid
   it = l3_egress_intf->find(egress_intf_id);
@@ -3124,14 +3124,12 @@ BcmSdkWrapper::GetPortLinkscanMode(int unit, int port) {
   InUseMap::iterator it;
   l3_route_t route = {true, vrf, class_id, egress_intf_id, 0, 0, "", ""};
 
-  CHECK_RETURN_IF_FALSE(egress_intf_id > 0);
+  RET_CHECK(egress_intf_id > 0);
 
-  CHECK_RETURN_IF_FALSE(subnet.size() ==
-                        16);  // TODO(max): is there a constant for that?
+  RET_CHECK(subnet.size() == 16);  // TODO(max): is there a constant for that?
   uint64 ipv6_upper = ByteStreamToUint<uint64>(subnet.substr(0, 8));
   uint64 ipv6_lower = ByteStreamToUint<uint64>(subnet.substr(8, 16));
-  CHECK_RETURN_IF_FALSE(mask.size() ==
-                        16);  // TODO(max): is there a constant for that?
+  RET_CHECK(mask.size() == 16);  // TODO(max): is there a constant for that?
   uint64 ipv6_upper_mask = ByteStreamToUint<uint64>(mask.substr(0, 8));
   uint64 ipv6_lower_mask = ByteStreamToUint<uint64>(mask.substr(8, 16));
 
@@ -3154,7 +3152,7 @@ BcmSdkWrapper::GetPortLinkscanMode(int unit, int port) {
     }
   }
   InUseMap* l3_egress_intf = gtl::FindOrNull(l3_egress_interface_ids_, unit);
-  CHECK_RETURN_IF_FALSE(l3_egress_intf != nullptr)
+  RET_CHECK(l3_egress_intf != nullptr)
       << "Unit " << unit << " not initialized yet. Call InitializeUnit first.";
   // Check if egress interface is valid
   it = l3_egress_intf->find(egress_intf_id);
@@ -3209,7 +3207,7 @@ BcmSdkWrapper::GetPortLinkscanMode(int unit, int port) {
   bcmlt_entry_handle_t entry_hdl;
   uint64_t max;
   uint64_t min;
-  CHECK_RETURN_IF_FALSE(egress_intf_id > 0);
+  RET_CHECK(egress_intf_id > 0);
   l3_host_t host = {false, vrf, class_id, egress_intf_id, ipv4};
   RETURN_IF_BCM_ERROR(
       GetFieldMinMaxValue(unit, L3_IPV4_UC_HOSTs, NHOP_IDs, &min, &max));
@@ -3257,11 +3255,10 @@ BcmSdkWrapper::GetPortLinkscanMode(int unit, int port) {
   bcmlt_entry_handle_t entry_hdl;
   uint64_t max;
   uint64_t min;
-  CHECK_RETURN_IF_FALSE(egress_intf_id > 0);
+  RET_CHECK(egress_intf_id > 0);
   l3_host_t host = {true, vrf, class_id, egress_intf_id, 0, ipv6};
 
-  CHECK_RETURN_IF_FALSE(ipv6.size() ==
-                        16);  // TODO(max): is there a constant for that?
+  RET_CHECK(ipv6.size() == 16);  // TODO(max): is there a constant for that?
   uint64 ipv6_upper = ByteStreamToUint<uint64>(ipv6.substr(0, 8));
   uint64 ipv6_lower = ByteStreamToUint<uint64>(ipv6.substr(8, 16));
 
@@ -3321,7 +3318,7 @@ BcmSdkWrapper::GetPortLinkscanMode(int unit, int port) {
   InUseMap::iterator it;
   l3_route_t route = {false,  vrf,  class_id, egress_intf_id,
                       subnet, mask, "",       ""};
-  CHECK_RETURN_IF_FALSE(egress_intf_id > 0);
+  RET_CHECK(egress_intf_id > 0);
   // Check if the unit is valid
   RETURN_IF_BCM_ERROR(CheckIfUnitExists(unit));
   RETURN_IF_BCM_ERROR(
@@ -3343,7 +3340,7 @@ BcmSdkWrapper::GetPortLinkscanMode(int unit, int port) {
     }
   }
   InUseMap* l3_egress_intf = gtl::FindOrNull(l3_egress_interface_ids_, unit);
-  CHECK_RETURN_IF_FALSE(l3_egress_intf != nullptr)
+  RET_CHECK(l3_egress_intf != nullptr)
       << "Unit " << unit << " not initialized yet. Call InitializeUnit first.";
   // Check if egress interface is valid
   it = l3_egress_intf->find(egress_intf_id);
@@ -3410,13 +3407,11 @@ BcmSdkWrapper::GetPortLinkscanMode(int unit, int port) {
   InUseMap::iterator it;
   // TODO(BRCM): fix ipv6, convert string to ipv6 address
   l3_route_t route = {true, vrf, class_id, egress_intf_id, 0, 0, subnet, mask};
-  CHECK_RETURN_IF_FALSE(egress_intf_id > 0);
-  CHECK_RETURN_IF_FALSE(subnet.size() ==
-                        16);  // TODO(max): is there a constant for that?
+  RET_CHECK(egress_intf_id > 0);
+  RET_CHECK(subnet.size() == 16);  // TODO(max): is there a constant for that?
   uint64 ipv6_upper = ByteStreamToUint<uint64>(subnet.substr(0, 8));
   uint64 ipv6_lower = ByteStreamToUint<uint64>(subnet.substr(8, 16));
-  CHECK_RETURN_IF_FALSE(mask.size() ==
-                        16);  // TODO(max): is there a constant for that?
+  RET_CHECK(mask.size() == 16);  // TODO(max): is there a constant for that?
   uint64 ipv6_upper_mask = ByteStreamToUint<uint64>(mask.substr(0, 8));
   uint64 ipv6_lower_mask = ByteStreamToUint<uint64>(mask.substr(8, 16));
   // Check if the unit is valid
@@ -3441,7 +3436,7 @@ BcmSdkWrapper::GetPortLinkscanMode(int unit, int port) {
     }
   }
   InUseMap* l3_egress_intf = gtl::FindOrNull(l3_egress_interface_ids_, unit);
-  CHECK_RETURN_IF_FALSE(l3_egress_intf != nullptr)
+  RET_CHECK(l3_egress_intf != nullptr)
       << "Unit " << unit << " not initialized yet. Call InitializeUnit first.";
   // Check if egress interface is valid
   it = l3_egress_intf->find(egress_intf_id);
@@ -3509,7 +3504,7 @@ BcmSdkWrapper::GetPortLinkscanMode(int unit, int port) {
   bcmlt_entry_info_t entry_info;
   bcmlt_entry_handle_t entry_hdl;
   l3_host_t host = {false, vrf, class_id, egress_intf_id, ipv4};
-  CHECK_RETURN_IF_FALSE(egress_intf_id > 0);
+  RET_CHECK(egress_intf_id > 0);
   RETURN_IF_BCM_ERROR(CheckIfUnitExists(unit));
   RETURN_IF_BCM_ERROR(
       GetFieldMinMaxValue(unit, L3_IPV4_UC_HOSTs, VRF_IDs, &min, &max));
@@ -3569,12 +3564,11 @@ BcmSdkWrapper::GetPortLinkscanMode(int unit, int port) {
   bcmlt_entry_info_t entry_info;
   bcmlt_entry_handle_t entry_hdl;
   l3_host_t host = {true, vrf, class_id, egress_intf_id, 0, ipv6};
-  CHECK_RETURN_IF_FALSE(egress_intf_id > 0);
+  RET_CHECK(egress_intf_id > 0);
   // Check if the unit is valid
   RETURN_IF_BCM_ERROR(CheckIfUnitExists(unit));
 
-  CHECK_RETURN_IF_FALSE(ipv6.size() ==
-                        16);  // TODO(max): is there a constant for that?
+  RET_CHECK(ipv6.size() == 16);  // TODO(max): is there a constant for that?
   uint64 ipv6_upper = ByteStreamToUint<uint64>(ipv6.substr(0, 8));
   uint64 ipv6_lower = ByteStreamToUint<uint64>(ipv6.substr(8, 16));
 
@@ -3694,12 +3688,10 @@ BcmSdkWrapper::GetPortLinkscanMode(int unit, int port) {
   bool entry_delete = false;
   // TODO(BRCM): fix ipv6, convert string to ipv6 address
   l3_route_t route = {true, vrf, 0, 0, 0, 0, subnet, mask};
-  CHECK_RETURN_IF_FALSE(subnet.size() ==
-                        16);  // TODO(max): is there a constant for that?
+  RET_CHECK(subnet.size() == 16);  // TODO(max): is there a constant for that?
   uint64 ipv6_upper = ByteStreamToUint<uint64>(subnet.substr(0, 8));
   uint64 ipv6_lower = ByteStreamToUint<uint64>(subnet.substr(8, 16));
-  CHECK_RETURN_IF_FALSE(mask.size() ==
-                        16);  // TODO(max): is there a constant for that?
+  RET_CHECK(mask.size() == 16);  // TODO(max): is there a constant for that?
   uint64 ipv6_upper_mask = ByteStreamToUint<uint64>(mask.substr(0, 8));
   uint64 ipv6_lower_mask = ByteStreamToUint<uint64>(mask.substr(8, 16));
 
@@ -3820,8 +3812,7 @@ BcmSdkWrapper::GetPortLinkscanMode(int unit, int port) {
   // TODO(BRCM): fix ipv6, convert string to ipv6 address
   l3_host_t host = {true, vrf, 0, 0, 0, ipv6};
 
-  CHECK_RETURN_IF_FALSE(ipv6.size() ==
-                        16);  // TODO(max): is there a constant for that?
+  RET_CHECK(ipv6.size() == 16);  // TODO(max): is there a constant for that?
   uint64 ipv6_upper = ByteStreamToUint<uint64>(ipv6.substr(0, 8));
   uint64 ipv6_lower = ByteStreamToUint<uint64>(ipv6.substr(8, 16));
 
@@ -3914,7 +3905,7 @@ BcmSdkWrapper::GetPortLinkscanMode(int unit, int port) {
   // Check if entry already exists.
   MyStationEntry entry(vlan, vlan_mask, dst_mac, dst_mac_mask);
   auto unit_to_my_stations = gtl::FindOrNull(my_station_ids_, unit);
-  CHECK_RETURN_IF_FALSE(unit_to_my_stations != nullptr)
+  RET_CHECK(unit_to_my_stations != nullptr)
       << "Unit " << unit << "  is not found in unit_to_my_stations. Have you "
       << "called InitializeUnit for this unit before?";
   auto id = gtl::FindOrNull(*unit_to_my_stations, entry);
@@ -3963,7 +3954,7 @@ BcmSdkWrapper::GetPortLinkscanMode(int unit, int port) {
   // Check if the unit is valid
   RETURN_IF_BCM_ERROR(CheckIfUnitExists(unit));
   auto unit_to_my_stations = gtl::FindOrNull(my_station_ids_, unit);
-  CHECK_RETURN_IF_FALSE(unit_to_my_stations != nullptr)
+  RET_CHECK(unit_to_my_stations != nullptr)
       << "Unit " << unit << "  is not found in unit_to_my_stations. Have you "
       << "called InitializeUnit for this unit before?";
   const MyStationEntry* entry =
@@ -4412,12 +4403,11 @@ BcmSdkWrapper::GetPortLinkscanMode(int unit, int port) {
 ::util::Status BcmSdkWrapper::CreateKnetIntf(int unit, int vlan,
                                              std::string* netif_name,
                                              int* netif_id) {
-  CHECK_RETURN_IF_FALSE(netif_name != nullptr && netif_id != nullptr)
+  RET_CHECK(netif_name != nullptr && netif_id != nullptr)
       << "Null netif_name or netif_id pointers.";
-  CHECK_RETURN_IF_FALSE(!netif_name->empty())
+  RET_CHECK(!netif_name->empty())
       << "Empty netif name for unit " << unit << ".";
-  CHECK_RETURN_IF_FALSE(netif_name->length() <=
-                        static_cast<size_t>(BCMPKT_DEV_NAME_MAX))
+  RET_CHECK(netif_name->length() <= static_cast<size_t>(BCMPKT_DEV_NAME_MAX))
       << "Oversize netif name for unit " << unit << ": " << *netif_name << ".";
   RETURN_IF_BCM_ERROR(CheckIfUnitExists(unit));
 
@@ -4586,7 +4576,7 @@ BcmSdkWrapper::GetPortLinkscanMode(int unit, int port) {
                                           &min, &max));
   // Sanity checking.
   for (const auto& e : rate_limit_config.per_cos_rate_limit_configs) {
-    CHECK_RETURN_IF_FALSE(e.first <= static_cast<int32_t>(max));
+    RET_CHECK(e.first <= static_cast<int32_t>(max));
   }
 
   RETURN_IF_BCM_ERROR(bcmlt_entry_allocate(unit, TM_SHAPER_PORTs, &entry_hdl));
@@ -4657,7 +4647,7 @@ BcmSdkWrapper::GetPortLinkscanMode(int unit, int port) {
   // Check if port is valid
   RETURN_IF_BCM_ERROR(CheckIfPortExists(unit, port));
 
-  CHECK_RETURN_IF_FALSE(header != nullptr);
+  RET_CHECK(header != nullptr);
   header->clear();
 
   // TODO(max): update this comment
@@ -4716,7 +4706,7 @@ BcmSdkWrapper::GetPortLinkscanMode(int unit, int port) {
   // The rest of the code is chip-dependent. Need to see which chip we are
   // talking about
   ASSIGN_OR_RETURN(auto chip_type, GetChipType(unit));
-  CHECK_RETURN_IF_FALSE(chip_type == BcmChip::TOMAHAWK)
+  RET_CHECK(chip_type == BcmChip::TOMAHAWK)
       << "Un-supported BCM chip type: " << BcmChip::BcmChipType_Name(chip_type);
 
   uint32 meta[BCMPKT_TXPMD_SIZE_WORDS];
@@ -4745,7 +4735,7 @@ BcmSdkWrapper::GetPortLinkscanMode(int unit, int port) {
 
 ::util::Status BcmSdkWrapper::GetKnetHeaderForIngressPipelineTx(
     int unit, uint64 smac, size_t packet_len, std::string* header) {
-  CHECK_RETURN_IF_FALSE(header != nullptr);
+  RET_CHECK(header != nullptr);
   header->clear();
 
   // Try to find the headers for the packet that goes to ingress pipeline.
@@ -4819,32 +4809,29 @@ static void dumpRxpmdHeaderRaw(const void* rxpmd) {
   //  ----------------------------------
   // Note that the total length of RX meta is fixed. The header passed to this
   // method will contain RCPU header + RX meta.
-  CHECK_RETURN_IF_FALSE(header.length() == sizeof(RcpuHeader) + kRcpuRxMetaSize)
+  RET_CHECK(header.length() == sizeof(RcpuHeader) + kRcpuRxMetaSize)
       << "Invalid KNET header size for RX (" << header.length()
       << " != " << sizeof(RcpuHeader) + kRcpuRxMetaSize << ").";
 
   // Valid RCPU header. We dont care about src/dst MACs in RCPU header here.
   const struct RcpuHeader* rcpu_header =
       reinterpret_cast<const struct RcpuHeader*>(header.data());
-  CHECK_RETURN_IF_FALSE(ntohs(rcpu_header->ether_header.ether_type) ==
-                        kRcpuVlanEthertype)
+  RET_CHECK(ntohs(rcpu_header->ether_header.ether_type) == kRcpuVlanEthertype)
       << ntohs(rcpu_header->ether_header.ether_type)
       << " != " << kRcpuVlanEthertype;
-  CHECK_RETURN_IF_FALSE((ntohs(rcpu_header->vlan_tag.vlan_id) & kVlanIdMask) ==
-                        kRcpuVlanId)
+  RET_CHECK((ntohs(rcpu_header->vlan_tag.vlan_id) & kVlanIdMask) == kRcpuVlanId)
       << (ntohs(rcpu_header->vlan_tag.vlan_id) & kVlanIdMask)
       << " != " << kRcpuVlanId;
-  CHECK_RETURN_IF_FALSE(ntohs(rcpu_header->vlan_tag.type) == kRcpuEthertype)
+  RET_CHECK(ntohs(rcpu_header->vlan_tag.type) == kRcpuEthertype)
       << ntohs(rcpu_header->vlan_tag.type) << " != " << kRcpuEthertype;
-  CHECK_RETURN_IF_FALSE(rcpu_header->rcpu_data.rcpu_opcode ==
-                        kRcpuOpcodeToCpuPkt)
+  RET_CHECK(rcpu_header->rcpu_data.rcpu_opcode == kRcpuOpcodeToCpuPkt)
       << rcpu_header->rcpu_data.rcpu_opcode << " != " << kRcpuOpcodeToCpuPkt;
-  CHECK_RETURN_IF_FALSE(rcpu_header->rcpu_data.rcpu_flags == kRcpuFlagModhdr)
+  RET_CHECK(rcpu_header->rcpu_data.rcpu_flags == kRcpuFlagModhdr)
       << rcpu_header->rcpu_data.rcpu_flags << " != " << kRcpuFlagModhdr;
 
   // Parse RX meta. The rest of the code is chip-dependent.
   ASSIGN_OR_RETURN(auto chip_type, GetChipType(unit));
-  CHECK_RETURN_IF_FALSE(chip_type == BcmChip::TOMAHAWK)
+  RET_CHECK(chip_type == BcmChip::TOMAHAWK)
       << "Un-supported BCM chip type: " << BcmChip::BcmChipType_Name(chip_type);
 
   // TODO(max): this is broken the same way parseKnetHeaderForTx is/was
@@ -4916,7 +4903,7 @@ static void dumpRxpmdHeaderRaw(const void* rxpmd) {
   // add a check here to make sure this assumption is always correct. Second,
   // for the (dst_module, dst_port) the value received after parsing the header
   // depends on the op_code.
-  CHECK_RETURN_IF_FALSE(src_module == module)
+  RET_CHECK(src_module == module)
       << "Invalid src_module: (op_code=" << op_code
       << ", src_mod=" << src_module << ", dst_mod=" << dst_module
       << ", base_mod=" << module << ", src_port=" << src_port
@@ -4924,7 +4911,7 @@ static void dumpRxpmdHeaderRaw(const void* rxpmd) {
   switch (op_code) {
     // TODO(max): use the defines instead of numbers?
     case 1:  // BCMPKT_OPCODE_UC
-      CHECK_RETURN_IF_FALSE(dst_module == module)
+      RET_CHECK(dst_module == module)
           << "Invalid dst_module: (op_code=" << op_code
           << ", src_mod=" << src_module << ", dst_mod=" << dst_module
           << ", base_mod=" << module << ", src_port=" << src_port
@@ -5940,10 +5927,9 @@ std::string HalAclFieldToBcm(BcmAclStage stage, BcmField::Type field) {
           // TODO(BRCM): for the below fields, 2 qualifiers
           // need to be configured, however this map returns only
           // one qualifier, need to address this
+          //{BcmField::IPV6_SRC, ??}, // QUAL_DST_IP6_BITMAP_UPPER,
+          // QUAL_DST_IP6_BITMAP_LOWER {BcmField::IPV6_DST, ??}, //
           // QUAL_DST_IP6_BITMAP_UPPER, QUAL_DST_IP6_BITMAP_LOWER
-          // {BcmField::IPV6_SRC, ??},
-          // QUAL_DST_IP6_BITMAP_UPPER, QUAL_DST_IP6_BITMAP_LOWER
-          // {BcmField::IPV6_DST, ??},
           {BcmField::IPV6_SRC_UPPER_64, QUAL_SRC_IP6_BITMAP_UPPERs},
           {BcmField::IPV6_DST_UPPER_64, QUAL_DST_IP6_BITMAP_UPPERs},
           {BcmField::VRF, QUAL_VRF_BITMAPs},
@@ -6189,8 +6175,8 @@ std::string HalAclFieldToBcm(BcmAclStage stage, BcmField::Type field) {
   }
   AclGroupIds* table_ids = gtl::FindPtrOrNull(fp_group_ids_, unit);
   auto it = unit_to_fp_groups_max_limit_.find(unit);
-  CHECK_RETURN_IF_FALSE(group_ids != nullptr && table_ids != nullptr &&
-                        it != unit_to_fp_groups_max_limit_.end())
+  RET_CHECK(group_ids != nullptr && table_ids != nullptr &&
+            it != unit_to_fp_groups_max_limit_.end())
       << "Unit " << unit << " not initialized yet. Call InitializeUnit first.";
   int maxEntries = it->second;
   int requested_table_id = (table.id()) ? table.id() : -1;
@@ -6217,7 +6203,7 @@ std::string HalAclFieldToBcm(BcmAclStage stage, BcmField::Type field) {
   // check if unit is valid
   RETURN_IF_BCM_ERROR(CheckIfUnitExists(unit));
   auto* table_ids = gtl::FindPtrOrNull(fp_group_ids_, unit);
-  CHECK_RETURN_IF_FALSE(table_ids != nullptr)
+  RET_CHECK(table_ids != nullptr)
       << "Unit " << unit << " not initialized yet. Call InitializeUnit first.";
 
   ASSIGN_OR_RETURN(found, FindAndReturnEntry(table_ids, table_id, &entry));
@@ -6250,7 +6236,7 @@ std::string HalAclFieldToBcm(BcmAclStage stage, BcmField::Type field) {
            << "ACL table with invalid pipeline stage: "
            << BcmAclStage_Name(stage) << ".";
   }
-  CHECK_RETURN_IF_FALSE(group_ids != nullptr)
+  RET_CHECK(group_ids != nullptr)
       << "Unit " << unit << " not initialized yet. Call InitializeUnit first.";
 
   if (SlotExists(group_ids, stage_id)) {
@@ -7171,7 +7157,7 @@ namespace {
            << "ACL Table id " << flow.bcm_acl_table_id() << " not found.";
   }
   BcmAclStage stage = flow.acl_stage();
-  CHECK_RETURN_IF_FALSE(stage == entry.first)
+  RET_CHECK(stage == entry.first)
       << "Invalid valid group, stage used for group is "
       << BcmAclStage_Name(entry.first) << " stage used for the flow is "
       << BcmAclStage_Name(stage);
@@ -7549,8 +7535,7 @@ namespace {
   }
 
   BcmAclStage stage = flow.acl_stage();
-  CHECK_RETURN_IF_FALSE(stage == entry.first)
-      << "Stage used for the folw is not matching.";
+  RET_CHECK(stage == entry.first) << "Stage used for the folw is not matching.";
   int acl_entry_id = entry.second;
 
   auto* group_ids = gtl::FindPtrOrNull(fp_group_ids_, unit);
@@ -7561,7 +7546,7 @@ namespace {
     return MAKE_ERROR(ERR_INVALID_PARAM)
            << "ACL Table id " << flow.bcm_acl_table_id() << " not found.";
   }
-  CHECK_RETURN_IF_FALSE(stage == entry.first)
+  RET_CHECK(stage == entry.first)
       << "Stage used for the group is not matching with the flow stage.";
 
   int group_id = entry.second;
@@ -7788,8 +7773,7 @@ namespace {
            << "Flow id " << flow_id << " not found.";
   }
   BcmAclStage stage = entry.first;
-  CHECK_RETURN_IF_FALSE((stage == BCM_ACL_STAGE_IFP) ||
-                        (stage == BCM_ACL_STAGE_EFP))
+  RET_CHECK((stage == BCM_ACL_STAGE_IFP) || (stage == BCM_ACL_STAGE_EFP))
       << "Meters can not be created/modified in the stage "
       << BcmAclStage_Name(stage) << ".";
 
@@ -7927,12 +7911,12 @@ namespace {
 ::util::Status BcmSdkWrapper::InsertPacketReplicationEntry(
     const BcmPacketReplicationEntry& entry) {
   // Check pre-conditions
-  CHECK_RETURN_IF_FALSE(entry.has_multicast_group_entry())
+  RET_CHECK(entry.has_multicast_group_entry())
       << "Bcm does only support multicast groups for now";
   RETURN_IF_BCM_ERROR(CheckIfUnitExists(entry.unit()));
   auto mcast_entry = entry.multicast_group_entry();
-  CHECK_RETURN_IF_FALSE(!gtl::ContainsKey(multicast_group_id_to_replicas_,
-                                          mcast_entry.multicast_group_id()))
+  RET_CHECK(!gtl::ContainsKey(multicast_group_id_to_replicas_,
+                              mcast_entry.multicast_group_id()))
       << "multicast group already exists";
   std::vector<int> ports;
   for (auto const& port : mcast_entry.ports()) {
@@ -7948,12 +7932,12 @@ namespace {
 ::util::Status BcmSdkWrapper::DeletePacketReplicationEntry(
     const BcmPacketReplicationEntry& entry) {
   // Check pre-conditions
-  CHECK_RETURN_IF_FALSE(entry.has_multicast_group_entry());
+  RET_CHECK(entry.has_multicast_group_entry());
   RETURN_IF_BCM_ERROR(CheckIfUnitExists(entry.unit()));
   auto mcast_entry = entry.multicast_group_entry();
   auto ports = gtl::FindOrNull(multicast_group_id_to_replicas_,
                                mcast_entry.multicast_group_id());
-  CHECK_RETURN_IF_FALSE(ports != nullptr);
+  RET_CHECK(ports != nullptr);
 
   multicast_group_id_to_replicas_.erase(mcast_entry.multicast_group_id());
   return ::util::OkStatus();
@@ -8050,7 +8034,7 @@ namespace {
   // check if unit is valid
   RETURN_IF_BCM_ERROR(CheckIfUnitExists(unit));
   auto* table_ids = gtl::FindPtrOrNull(fp_group_ids_, unit);
-  CHECK_RETURN_IF_FALSE(table_ids != nullptr)
+  RET_CHECK(table_ids != nullptr)
       << "Unit " << unit << " not initialized yet. Call InitializeUnit first.";
   ASSIGN_OR_RETURN(found, FindAndReturnEntry(table_ids, table_id, &entry));
   if (!found) {
@@ -8107,7 +8091,7 @@ inline int bcm_get_field_u32(F func, int unit, int flow_id, uint32* value,
                                                  std::vector<int>* flow_ids) {
   RETURN_IF_BCM_ERROR(CheckIfUnitExists(unit));
   auto* table_ids = gtl::FindPtrOrNull(fp_group_ids_, unit);
-  CHECK_RETURN_IF_FALSE(table_ids != nullptr)
+  RET_CHECK(table_ids != nullptr)
       << "Unit " << unit << " not initialized yet. Call InitializeUnit first.";
 
   std::pair<BcmAclStage, int> entry;

--- a/stratum/hal/lib/bcm/sdklt/bcm_sdk_wrapper.h
+++ b/stratum/hal/lib/bcm/sdklt/bcm_sdk_wrapper.h
@@ -1,7 +1,6 @@
 // Copyright 2018 Google LLC
 // Copyright 2018-present Open Networking Foundation
-// Copyright 2019 Broadcom. All rights reserved. The term "Broadcom" refers to
-// Broadcom Inc. and/or its subsidiaries.
+// Copyright 2019 Broadcom
 // SPDX-License-Identifier: Apache-2.0
 
 #ifndef STRATUM_HAL_LIB_BCM_SDKLT_BCM_SDK_WRAPPER_H_

--- a/stratum/hal/lib/bmv2/bmv2_chassis_manager.cc
+++ b/stratum/hal/lib/bmv2/bmv2_chassis_manager.cc
@@ -105,14 +105,14 @@ namespace {
   for (auto singleton_port : config.singleton_ports()) {
     uint32 port_id = singleton_port.id();
     uint64 node_id = singleton_port.node();
-    CHECK_RETURN_IF_FALSE(node_id_to_bmv2_runner_.count(node_id) > 0)
+    RET_CHECK(node_id_to_bmv2_runner_.count(node_id) > 0)
         << "Node " << node_id << " is not known.";
     node_id_to_port_id_to_port_state[node_id][port_id] = PORT_STATE_UNKNOWN;
     node_id_to_port_id_to_port_config[node_id][port_id] = singleton_port;
   }
 
-  CHECK_RETURN_IF_FALSE(static_cast<size_t>(config.nodes_size()) ==
-                        node_id_to_bmv2_runner_.size())
+  RET_CHECK(static_cast<size_t>(config.nodes_size()) ==
+            node_id_to_bmv2_runner_.size())
       << "Missing nodes in ChassisConfig";
 
   // Compare ports in old config and new config and perform the necessary
@@ -121,7 +121,7 @@ namespace {
     VLOG(1) << "Updating config for node " << node.id() << ".";
 
     auto* runner = gtl::FindOrNull(node_id_to_bmv2_runner_, node.id());
-    CHECK_RETURN_IF_FALSE(runner != nullptr)
+    RET_CHECK(runner != nullptr)
         << "Cannot find runner for node " << node.id() << ".";
     auto dev_mgr = (*runner)->get_dev_mgr();
 
@@ -210,11 +210,11 @@ namespace {
     uint64 node_id, uint32 port_id) const {
   auto* port_id_to_singleton =
       gtl::FindOrNull(node_id_to_port_id_to_port_config_, node_id);
-  CHECK_RETURN_IF_FALSE(port_id_to_singleton != nullptr)
+  RET_CHECK(port_id_to_singleton != nullptr)
       << "Node " << node_id << " is not configured or not known.";
   const SingletonPort* singleton =
       gtl::FindOrNull(*port_id_to_singleton, port_id);
-  CHECK_RETURN_IF_FALSE(singleton != nullptr)
+  RET_CHECK(singleton != nullptr)
       << "Port " << port_id << " is not configured or not known for node "
       << node_id << ".";
   return singleton;
@@ -324,11 +324,11 @@ namespace {
   }
   auto* port_id_to_port_state =
       gtl::FindOrNull(node_id_to_port_id_to_port_state_, node_id);
-  CHECK_RETURN_IF_FALSE(port_id_to_port_state != nullptr)
+  RET_CHECK(port_id_to_port_state != nullptr)
       << "Node " << node_id << " is not configured or not known.";
   const PortState* port_state_ptr =
       gtl::FindOrNull(*port_id_to_port_state, port_id);
-  CHECK_RETURN_IF_FALSE(port_state_ptr != nullptr)
+  RET_CHECK(port_state_ptr != nullptr)
       << "Port " << port_id << " is not configured or not known for node "
       << node_id << ".";
   if (*port_state_ptr != PORT_STATE_UNKNOWN) return *port_state_ptr;
@@ -367,7 +367,7 @@ namespace {
     return ::util::OkStatus();
   }
   auto* runner = gtl::FindOrNull(node_id_to_bmv2_runner_, node_id);
-  CHECK_RETURN_IF_FALSE(runner != nullptr)
+  RET_CHECK(runner != nullptr)
       << "Node " << node_id << " is not configured or not known.";
   auto dev_mgr = (*runner)->get_dev_mgr();
   auto port_stats = dev_mgr->get_port_stats(

--- a/stratum/hal/lib/bmv2/bmv2_switch.cc
+++ b/stratum/hal/lib/bmv2/bmv2_switch.cc
@@ -117,8 +117,8 @@ Bmv2Switch::~Bmv2Switch() {}
 ::util::Status Bmv2Switch::WriteForwardingEntries(
     const ::p4::v1::WriteRequest& req, std::vector<::util::Status>* results) {
   if (!req.updates_size()) return ::util::OkStatus();  // nothing to do.
-  CHECK_RETURN_IF_FALSE(req.device_id()) << "No device_id in WriteRequest.";
-  CHECK_RETURN_IF_FALSE(results != nullptr)
+  RET_CHECK(req.device_id()) << "No device_id in WriteRequest.";
+  RET_CHECK(results != nullptr)
       << "Need to provide non-null results pointer for non-empty updates.";
 
   ASSIGN_OR_RETURN(auto* pi_node, GetPINodeFromNodeId(req.device_id()));
@@ -129,9 +129,9 @@ Bmv2Switch::~Bmv2Switch() {}
     const ::p4::v1::ReadRequest& req,
     WriterInterface<::p4::v1::ReadResponse>* writer,
     std::vector<::util::Status>* details) {
-  CHECK_RETURN_IF_FALSE(req.device_id()) << "No device_id in ReadRequest.";
-  CHECK_RETURN_IF_FALSE(writer) << "Channel writer must be non-null.";
-  CHECK_RETURN_IF_FALSE(details) << "Details pointer must be non-null.";
+  RET_CHECK(req.device_id()) << "No device_id in ReadRequest.";
+  RET_CHECK(writer) << "Channel writer must be non-null.";
+  RET_CHECK(details) << "Details pointer must be non-null.";
 
   ASSIGN_OR_RETURN(auto* pi_node, GetPINodeFromNodeId(req.device_id()));
   return pi_node->ReadForwardingEntries(req, writer, details);

--- a/stratum/hal/lib/np4intel/np4_chassis_manager.cc
+++ b/stratum/hal/lib/np4intel/np4_chassis_manager.cc
@@ -168,11 +168,11 @@ namespace {
     uint64 node_id, uint32 port_id) const {
   auto* port_id_to_singleton =
       gtl::FindOrNull(node_id_to_port_id_to_port_config_, node_id);
-  CHECK_RETURN_IF_FALSE(port_id_to_singleton != nullptr)
+  RET_CHECK(port_id_to_singleton != nullptr)
       << "Node " << node_id << " is not configured or not known.";
   const SingletonPort* singleton =
       gtl::FindOrNull(*port_id_to_singleton, port_id);
-  CHECK_RETURN_IF_FALSE(singleton != nullptr)
+  RET_CHECK(singleton != nullptr)
       << "Port " << port_id << " is not configured or not known for node "
       << node_id << ".";
   return singleton;
@@ -281,11 +281,11 @@ namespace {
   }
   auto* port_id_to_port_state =
       gtl::FindOrNull(node_id_to_port_id_to_port_state_, node_id);
-  CHECK_RETURN_IF_FALSE(port_id_to_port_state != nullptr)
+  RET_CHECK(port_id_to_port_state != nullptr)
       << "Node " << node_id << " is not configured or not known.";
   const PortState* port_state_ptr =
       gtl::FindOrNull(*port_id_to_port_state, port_id);
-  CHECK_RETURN_IF_FALSE(port_state_ptr != nullptr)
+  RET_CHECK(port_state_ptr != nullptr)
       << "Port " << port_id << " is not configured or not known for node "
       << node_id << ".";
   if (*port_state_ptr != PORT_STATE_UNKNOWN) return *port_state_ptr;

--- a/stratum/hal/lib/np4intel/np4_chassis_manager_test.cc
+++ b/stratum/hal/lib/np4intel/np4_chassis_manager_test.cc
@@ -96,12 +96,10 @@ class NP4ChassisManagerTest : public ::testing::Test {
   }
 
   ::util::Status CheckCleanInternalState() {
-    CHECK_RETURN_IF_FALSE(
-        np4_chassis_manager_->node_id_to_port_id_to_port_state_.empty());
-    CHECK_RETURN_IF_FALSE(
-        np4_chassis_manager_->node_id_to_port_id_to_port_config_.empty());
-    CHECK_RETURN_IF_FALSE(
-        np4_chassis_manager_->port_status_change_event_channel_ == nullptr);
+    RET_CHECK(np4_chassis_manager_->node_id_to_port_id_to_port_state_.empty());
+    RET_CHECK(np4_chassis_manager_->node_id_to_port_id_to_port_config_.empty());
+    RET_CHECK(np4_chassis_manager_->port_status_change_event_channel_ ==
+              nullptr);
     return ::util::OkStatus();
   }
 
@@ -118,7 +116,7 @@ class NP4ChassisManagerTest : public ::testing::Test {
   }
 
   ::util::Status PushBaseChassisConfig(ChassisConfigBuilder* builder) {
-    CHECK_RETURN_IF_FALSE(!Initialized())
+    RET_CHECK(!Initialized())
         << "Can only call PushBaseChassisConfig() for first ChassisConfig!";
     builder->AddPort(kPortId, kPort, ADMIN_STATE_ENABLED);
 
@@ -131,8 +129,7 @@ class NP4ChassisManagerTest : public ::testing::Test {
     //     .WillOnce(Return(::util::OkStatus()));
 
     RETURN_IF_ERROR(PushChassisConfig(builder->Get()));
-    CHECK_RETURN_IF_FALSE(Initialized())
-        << "Class is not initialized after push!";
+    RET_CHECK(Initialized()) << "Class is not initialized after push!";
     return ::util::OkStatus();
   }
 

--- a/stratum/hal/lib/np4intel/np4_switch.cc
+++ b/stratum/hal/lib/np4intel/np4_switch.cc
@@ -125,8 +125,8 @@ NP4Switch::~NP4Switch() {}
 ::util::Status NP4Switch::WriteForwardingEntries(
     const ::p4::v1::WriteRequest& req, std::vector<::util::Status>* results) {
   if (!req.updates_size()) return ::util::OkStatus();  // nothing to do.
-  CHECK_RETURN_IF_FALSE(req.device_id()) << "No device_id in WriteRequest.";
-  CHECK_RETURN_IF_FALSE(results != nullptr)
+  RET_CHECK(req.device_id()) << "No device_id in WriteRequest.";
+  RET_CHECK(results != nullptr)
       << "Need to provide non-null results pointer for non-empty updates.";
 
   ASSIGN_OR_RETURN(auto* pi_node, GetPINodeFromNodeId(req.device_id()));
@@ -137,9 +137,9 @@ NP4Switch::~NP4Switch() {}
     const ::p4::v1::ReadRequest& req,
     WriterInterface<::p4::v1::ReadResponse>* writer,
     std::vector<::util::Status>* details) {
-  CHECK_RETURN_IF_FALSE(req.device_id()) << "No device_id in ReadRequest.";
-  CHECK_RETURN_IF_FALSE(writer) << "Channel writer must be non-null.";
-  CHECK_RETURN_IF_FALSE(details) << "Details pointer must be non-null.";
+  RET_CHECK(req.device_id()) << "No device_id in ReadRequest.";
+  RET_CHECK(writer) << "Channel writer must be non-null.";
+  RET_CHECK(details) << "Details pointer must be non-null.";
 
   ASSIGN_OR_RETURN(auto* pi_node, GetPINodeFromNodeId(req.device_id()));
   return pi_node->ReadForwardingEntries(req, writer, details);

--- a/stratum/hal/lib/p4/utils.cc
+++ b/stratum/hal/lib/p4/utils.cc
@@ -118,20 +118,20 @@ std::string ByteStringToP4RuntimeByteString(std::string bytes) {
 }
 
 ::util::Status IsValidMeterConfig(const ::p4::v1::MeterConfig& meter_config) {
-  CHECK_RETURN_IF_FALSE(meter_config.cir() >= 0)
+  RET_CHECK(meter_config.cir() >= 0)
       << "Meter configuration " << meter_config.ShortDebugString()
       << " is invalid: committed rate cannot be less than zero.";
-  CHECK_RETURN_IF_FALSE(meter_config.pir() >= 0)
+  RET_CHECK(meter_config.pir() >= 0)
       << "Meter configuration " << meter_config.ShortDebugString()
       << " is invalid: peak rate cannot be less than zero.";
-  CHECK_RETURN_IF_FALSE(meter_config.cburst() > 0)
+  RET_CHECK(meter_config.cburst() > 0)
       << "Meter configuration " << meter_config.ShortDebugString()
       << " is invalid: committed burst size cannot be less than or equal to"
       << " zero.";
-  CHECK_RETURN_IF_FALSE(meter_config.pburst() > 0)
+  RET_CHECK(meter_config.pburst() > 0)
       << "Meter configuration " << meter_config.ShortDebugString()
       << " is invalid: peak burst size cannot be less than or equal to zero.";
-  CHECK_RETURN_IF_FALSE(meter_config.pir() >= meter_config.cir())
+  RET_CHECK(meter_config.pir() >= meter_config.cir())
       << "Meter configuration " << meter_config.ShortDebugString()
       << " is invalid: committed rate cannot be greater than peak rate.";
 

--- a/stratum/hal/lib/phal/regex_datasource.h
+++ b/stratum/hal/lib/phal/regex_datasource.h
@@ -11,7 +11,6 @@
 #include <utility>
 #include <vector>
 
-// FIXME(boc) google only #include "base/basictypes.h"
 #include "absl/memory/memory.h"
 #include "re2/re2.h"
 #include "stratum/glue/status/status.h"

--- a/stratum/lib/macros.h
+++ b/stratum/lib/macros.h
@@ -7,21 +7,12 @@
 
 #include <string>
 
-/* START GOOGLE ONLY
-#include "stratum/glue/status/status_builder.h"
-   END GOOGLE ONLY */
 #include "stratum/glue/logging.h"
+#include "stratum/glue/status/status.h"
 #include "stratum/glue/status/status_macros.h"
 #include "stratum/public/lib/error.h"
 
 namespace stratum {
-
-// A macro for simplify checking and logging a condition. The error code
-// return here is the one that matches the most of the uses.
-#define CHECK_RETURN_IF_FALSE(cond) \
-  if (ABSL_PREDICT_TRUE(cond)) {    \
-  } else /* NOLINT */               \
-    return MAKE_ERROR(ERR_INVALID_PARAM) << "'" << #cond << "' is false. "
 
 // A simple class to explicitly cast the return value of an ::util::Status
 // to bool.

--- a/stratum/procmon/procmon_main.cc
+++ b/stratum/procmon/procmon_main.cc
@@ -30,7 +30,7 @@ static ::util::Status Main(int argc, char** argv) {
   InitStratumLogging();
 
   // Read the procmon config.
-  CHECK_RETURN_IF_FALSE(!FLAGS_procmon_config_file.empty())
+  RET_CHECK(!FLAGS_procmon_config_file.empty())
       << "Flag procmon_config_file must be specified.";
   ProcmonConfig config;
   RETURN_IF_ERROR(ReadProtoFromTextFile(FLAGS_procmon_config_file, &config));

--- a/stratum/tools/p4_pipeline_pusher/p4_pipeline_pusher.cc
+++ b/stratum/tools/p4_pipeline_pusher/p4_pipeline_pusher.cc
@@ -38,8 +38,8 @@ const char kUsage[] =
   InitGoogle(argv[0], &argc, &argv, true);
   stratum::InitStratumLogging();
 
-  CHECK_RETURN_IF_FALSE(!FLAGS_p4_info_file.empty());
-  CHECK_RETURN_IF_FALSE(!FLAGS_p4_pipeline_config_file.empty());
+  RET_CHECK(!FLAGS_p4_info_file.empty());
+  RET_CHECK(!FLAGS_p4_pipeline_config_file.empty());
   ::p4::config::v1::P4Info p4info;
   RETURN_IF_ERROR(ReadProtoFromTextFile(FLAGS_p4_info_file, &p4info));
   std::string p4_device_config;


### PR DESCRIPTION
This CL integrates a single upstream PR:

Replace `CHECK_RETURN_IF_FALSE` with `RET_CHECK` (#902)

- This PR replaces the home-grown `CHECK_RETURN_IF_FALSE` macro with the more common `RET_CHECK` one. Semantics and behavior stay the same, no user-code changes needed. Code readability is improved a little, as the new macro is shorter, leading to less line splits.
- We hope that this will make migration to `absl::Status` easier eventually, as we will probably go with whatever solution Google comes up with.

The Stratum team ran clang-format on the files, to reflow the lines that had been changed. This resulted in a couple of unrelated format changes.

All that's really needed is a cursory check for any changes that fall outside the pattern.

I've run the usual test builds and unit tests, plus the bcm unit tests.

Note that this CL is based on the second PR (`dgf/downstream-2`). The plan is to change the base branch to `main` after the preceding PR is integrated. The GitHub workflows (pre-commit checks) should run at this time.