### PR TITLE
Update pre-submit pipeline

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -58,15 +58,16 @@ jobs:
           export SDE_INSTALL=$SDE_INSTALL_DIR
           xargs -a .github/dpdk-tests.txt bazel test --define target=dpdk --test_tag_filters=-broken,-flaky
 
-      - name: Collect unit test logs
-        if: failure()
+  cdlang_tests:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Clone stratum repository
+        uses: actions/checkout@v4
+        with:
+          path: stratum
+
+      - name: Run cdlang tests
         working-directory: stratum
         run: |
-          cd bazel-testlogs
-          tar czf $GITHUB_WORKSPACE/$DPDK_TESTLOGS stratum/
-
-      - name: Upload unit test logs
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          path: $DPDK_TESTLOGS
+          bazel test //stratum/testing/cdlang/...


### PR DESCRIPTION
- Remove steps to collect and upload the unit test logs. They don't work correctly, and thanks to changes in .bazelrc, logs of failing unit tests are now part of the console output.

- Add a separate job to run the cdlang tests (a gNMI test suite that is part of the Stratum CircleCI workflow).