### PR TITLE
Set up stratum-updates branch

### DIFF
--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -2,9 +2,13 @@ name: "clang-format check"
 
 on:
   push:
-    branches: [split-arch]
+    branches:
+      - split-arch
+      - stratum-updates
   pull_request:
-    branches: [split-arch]
+    branches:
+      - split-arch
+      - stratum-updates
 
 concurrency:
   # If workflow for PR or push is already running, stop it and start a new one.

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -2,9 +2,13 @@ name: "Stratum CI Pipeline"
 
 on:
   push:
-    branches: [split-arch]
+    branches:
+      - split-arch
+      - stratum-updates
   pull_request:
-    branches: [split-arch]
+    branches:
+      - split-arch
+      - stratum-updates
 
   workflow_dispatch:
 


### PR DESCRIPTION
- Create stratum-updates branch to be used when downstreaming updates from the parent project.
- Add it to the GitHub workflows.