### PR TITLE
Reimplement secure-only CredentialsManager mode

### DIFF
--- a/stratum/hal/lib/common/config_monitoring_service.cc
+++ b/stratum/hal/lib/common/config_monitoring_service.cc
@@ -22,7 +22,6 @@
 #include "stratum/hal/lib/common/gnmi_publisher.h"
 #include "stratum/hal/lib/common/openconfig_converter.h"
 #include "stratum/hal/lib/common/target_options.h"
-#include "stratum/hal/lib/common/utils.h"
 #include "stratum/lib/macros.h"
 #include "stratum/lib/utils.h"
 #include "stratum/public/lib/error.h"

--- a/stratum/hal/lib/common/utils.cc
+++ b/stratum/hal/lib/common/utils.cc
@@ -1,11 +1,8 @@
 // Copyright 2018 Google LLC
 // Copyright 2018-present Open Networking Foundation
-// Copyright 2023 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 #include "stratum/hal/lib/common/utils.h"
-
-#include <sys/stat.h>
 
 #include <cfenv>  // NOLINT
 #include <cmath>
@@ -481,12 +478,6 @@ std::string ConvertLogSeverityToString(const LoggingConfig& logging_config) {
   } else {
     return "UNKNOWN";
   }
-}
-
-bool IsRegularFile(const std::string& filename) {
-  struct stat buf;
-  int rc = lstat(filename.c_str(), &buf);
-  return (rc == 0 && S_ISREG(buf.st_mode));
 }
 
 }  // namespace hal

--- a/stratum/hal/lib/common/utils.h
+++ b/stratum/hal/lib/common/utils.h
@@ -245,9 +245,6 @@ std::string ConvertLogSeverityToString(const LoggingConfig& logging_config);
 ::util::Status ConvertStringToLogSeverity(const std::string& severity_string,
                                           LoggingConfig* logging_config);
 
-// Checks whether filename is a regular file and not a symlink
-bool IsRegularFile(const std::string& filename);
-
 }  // namespace hal
 }  // namespace stratum
 

--- a/stratum/lib/security/BUILD
+++ b/stratum/lib/security/BUILD
@@ -126,6 +126,7 @@ stratum_cc_library(
     hdrs = ["credentials_manager.h"],
     deps = [
         "//stratum/glue:logging",
+        "//stratum/glue/gtl:map_util",
         "//stratum/glue/status:statusor",
         "//stratum/lib:macros",
         "//stratum/lib:utils",

--- a/stratum/lib/security/credentials_manager.h
+++ b/stratum/lib/security/credentials_manager.h
@@ -54,7 +54,7 @@ class CredentialsManager {
  protected:
   // Default constructor. To be called by the Mock class instance as well as
   // CreateInstance().
-  CredentialsManager();
+  explicit CredentialsManager(bool secure_only = false);
 
  private:
   static constexpr unsigned int kFileRefreshIntervalSeconds = 1;
@@ -67,6 +67,9 @@ class CredentialsManager {
 
   std::shared_ptr<::grpc::ServerCredentials> server_credentials_;
   std::shared_ptr<::grpc::ChannelCredentials> client_credentials_;
+
+  // Whether connections must be secure.
+  bool secure_only_;
 
   friend class CredentialsManagerTest;
 };

--- a/stratum/lib/security/credentials_manager.h
+++ b/stratum/lib/security/credentials_manager.h
@@ -61,6 +61,10 @@ class CredentialsManager {
 
   // Function to initialize the credentials manager.
   ::util::Status Initialize();
+
+  void InitializeServerCredentials();
+  void InitializeClientCredentials();
+
   std::shared_ptr<::grpc::ServerCredentials> server_credentials_;
   std::shared_ptr<::grpc::ChannelCredentials> client_credentials_;
 

--- a/stratum/lib/security/credentials_manager.h
+++ b/stratum/lib/security/credentials_manager.h
@@ -62,8 +62,8 @@ class CredentialsManager {
   // Function to initialize the credentials manager.
   ::util::Status Initialize();
 
-  void InitializeServerCredentials();
-  void InitializeClientCredentials();
+  ::util::Status InitializeServerCredentials();
+  ::util::Status InitializeClientCredentials();
 
   std::shared_ptr<::grpc::ServerCredentials> server_credentials_;
   std::shared_ptr<::grpc::ChannelCredentials> client_credentials_;

--- a/stratum/lib/utils.h
+++ b/stratum/lib/utils.h
@@ -155,6 +155,12 @@ inline bool IsDir(const std::string& path) {
   return S_ISDIR(stbuf.st_mode);
 }
 
+inline bool IsRegularFile(const std::string& path) {
+  struct stat buf;
+  int rc = lstat(path.c_str(), &buf);
+  return (rc == 0 && S_ISREG(buf.st_mode));
+}
+
 // Breaks a path string into directory and filename components and returns the
 // directory.
 inline std::string DirName(const std::string& path) {


### PR DESCRIPTION
This implementation differs from its predecessor in that:

- The `IsRegularFile()` checks are only performed if the `secure_only` option is in effect.

- The request type flag is named `client_cert_req_type`, instead of `grpc_client_cert_req_type`, to be consistent with the other credentials manager flags.

- `CLIENT_CERT` has been omitted from the flag value names, to make them more user-friendly.