### PR TITLE
Simplify cmake listfiles for stratum tools

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,6 +131,8 @@ add_library(stratum_static STATIC)
 add_stratum_object_libs(stratum_static)
 add_stratum_libraries(stratum_static)
 
+target_include_directories(stratum_static PUBLIC ${STRATUM_INCLUDES})
+
 #####################
 # libstratum_shared #
 #####################
@@ -138,3 +140,5 @@ add_stratum_libraries(stratum_static)
 add_library(stratum_shared SHARED)
 add_stratum_object_libs(stratum_shared)
 add_stratum_libraries(stratum_shared)
+
+target_include_directories(stratum_shared PUBLIC ${STRATUM_INCLUDES})

--- a/stratum/lib/p4runtime/CMakeLists.txt
+++ b/stratum/lib/p4runtime/CMakeLists.txt
@@ -29,7 +29,7 @@ add_library(p4runtime_session_o OBJECT
     p4runtime_session.h
 )
 
-target_include_directories(p4runtime_session_o PRIVATE
+target_include_directories(p4runtime_session_o PUBLIC
     ${STRATUM_INCLUDES}
     ${PB_OUT_DIR}
 )

--- a/stratum/tools/gnmi/CMakeLists.txt
+++ b/stratum/tools/gnmi/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Build file for //stratum/tools/gnmi
 #
-# Copyright 2022-2023 Intel Corporation
+# Copyright 2022-2024 Intel Corporation
 # SPDX-License-Identifier: Apache 2.0
 #
 
@@ -27,11 +27,6 @@ target_link_libraries(gnmi_cli PUBLIC
 if(HAVE_POSIX_AIO)
     target_link_libraries(gnmi_cli PUBLIC rt)
 endif()
-
-target_include_directories(gnmi_cli PRIVATE
-    ${STRATUM_SOURCE_DIR}
-    ${PB_OUT_DIR}
-)
 
 if(NOT DPDK_TARGET)
     install(TARGETS gnmi_cli RUNTIME)

--- a/stratum/tools/p4_pipeline_pusher/CMakeLists.txt
+++ b/stratum/tools/p4_pipeline_pusher/CMakeLists.txt
@@ -19,11 +19,6 @@ target_link_libraries(p4_pipeline_pusher PUBLIC
     $<TARGET_OBJECTS:p4runtime_session_o>
 )
 
-target_include_directories(p4_pipeline_pusher PRIVATE
-    ${STRATUM_SOURCE_DIR}
-    ${PB_OUT_DIR}
-)
-
 target_link_libraries(p4_pipeline_pusher PUBLIC p4_role_config)
 
 install(TARGETS p4_pipeline_pusher RUNTIME)

--- a/stratum/tools/stratum_replay/CMakeLists.txt
+++ b/stratum/tools/stratum_replay/CMakeLists.txt
@@ -1,4 +1,4 @@
-# CMake build file for //stratum/tools/p4_pipeline_pusher
+# CMake build file for //stratum/tools/stratum_replay
 #
 # Copyright 2024 Intel Corporation
 # SPDX-License-Identifier: Apache 2.0
@@ -16,11 +16,6 @@ set_install_rpath(stratum_replay ${EXEC_ELEMENT} ${DEP_ELEMENT})
 
 target_link_libraries(stratum_replay PUBLIC
     stratum_static
-)
-
-target_include_directories(stratum_replay PRIVATE
-    ${STRATUM_SOURCE_DIR}
-    ${PB_OUT_DIR}
 )
 
 install(TARGETS stratum_replay RUNTIME)


### PR DESCRIPTION
- Made target_include_directories for the stratum_static, stratum_shared, and p4runtime_session_o libraries PUBLIC, removing the need to specify them when building gnmi_cli, p4_runtime_pusher, and stratum_replay.

This is a proof of concept for future changes to the cmake build system.