### PR TITLE
Handle no space left error message from TDI

### DIFF
--- a/stratum/hal/lib/tdi/tdi_sde_table_entry.cc
+++ b/stratum/hal/lib/tdi/tdi_sde_table_entry.cc
@@ -71,7 +71,7 @@ using namespace stratum::hal::tdi::helpers;
            << "Duplicate table entry with " << dump_args();
   } else if (status == BF_NO_SPACE) {
     return MAKE_ERROR(::util::error::Code::RESOURCE_EXHAUSTED)
-           << "Table is full with " << dump_args();
+           << "Table is already full. No space for " << dump_args();
   } else if (status != BF_SUCCESS) {
     return MAKE_ERROR(::util::error::Code::INTERNAL)
            << "Error adding table entry with " << dump_args();

--- a/stratum/hal/lib/tdi/tdi_sde_table_entry.cc
+++ b/stratum/hal/lib/tdi/tdi_sde_table_entry.cc
@@ -71,7 +71,7 @@ using namespace stratum::hal::tdi::helpers;
            << "Duplicate table entry with " << dump_args();
   } else if (status == BF_NO_SPACE) {
     return MAKE_ERROR(::util::error::Code::RESOURCE_EXHAUSTED)
-           << "Table is full, resource exhausted " << dump_args();
+           << "Table is full with " << dump_args();
   } else if (status != BF_SUCCESS) {
     return MAKE_ERROR(::util::error::Code::INTERNAL)
            << "Error adding table entry with " << dump_args();

--- a/stratum/hal/lib/tdi/tdi_sde_table_entry.cc
+++ b/stratum/hal/lib/tdi/tdi_sde_table_entry.cc
@@ -69,6 +69,9 @@ using namespace stratum::hal::tdi::helpers;
   if (status == BF_ALREADY_EXISTS) {
     return MAKE_ERROR(::util::error::Code::ALREADY_EXISTS)
            << "Duplicate table entry with " << dump_args();
+  } else if (status == BF_NO_SPACE) {
+    return MAKE_ERROR(::util::error::Code::RESOURCE_EXHAUSTED)
+           << "Table is full, resource exhausted " << dump_args();
   } else if (status != BF_SUCCESS) {
     return MAKE_ERROR(::util::error::Code::INTERNAL)
            << "Error adding table entry with " << dump_args();


### PR DESCRIPTION
When we program an entry to a table and if the table is full, SDE/TDI returns an error message as BF_NO_SPACE.
Handle this error message similar to barefoot (BooleanBfStatus), where BF_NO_SPACE is considered as RESOURCE_EXHAUSTED.