### PR TITLE
Make -client_cert_req_type case-insensitive

### DIFF
--- a/stratum/lib/security/BUILD
+++ b/stratum/lib/security/BUILD
@@ -133,6 +133,7 @@ stratum_cc_library(
         "@com_github_google_glog//:glog",
         "@com_github_grpc_grpc//:grpc++",
         "@com_google_absl//absl/memory",
+        "@com_google_absl//absl/strings",
     ],
 )
 

--- a/stratum/lib/security/CMakeLists.txt
+++ b/stratum/lib/security/CMakeLists.txt
@@ -15,5 +15,8 @@ add_library(stratum_lib_security_o OBJECT
     credentials_manager.h
 )
 
+target_link_libraries(stratum_lib_security_o PUBLIC absl::strings)
+
 target_include_directories(stratum_lib_security_o PRIVATE ${STRATUM_INCLUDES})
+
 add_dependencies(stratum_lib_security_o stratum_proto) # gnmi_proto?

--- a/stratum/lib/security/credentials_manager.cc
+++ b/stratum/lib/security/credentials_manager.cc
@@ -27,7 +27,7 @@ DEFINE_string(server_key_file, "", "Path to gRPC server private key file");
 DEFINE_string(server_cert_file, "", "Path to gRPC server certificate file");
 DEFINE_string(client_key_file, "", "Path to gRPC client key file");
 DEFINE_string(client_cert_file, "", "Path to gRPC client certificate file");
-DEFINE_string(client_cert_req_type, "NO_REQUEST",
+DEFINE_string(client_cert_req_type, "no_request",
               "Client certificate request type");
 
 namespace stratum {
@@ -41,7 +41,7 @@ constexpr unsigned int CredentialsManager::kFileRefreshIntervalSeconds;
 
 namespace {
 
-const std::map<std::string, grpc_ssl_client_certificate_request_type>
+const std::map<const std::string, grpc_ssl_client_certificate_request_type>
     client_cert_req_type_map = {
         {"no_request", GRPC_SSL_DONT_REQUEST_CLIENT_CERTIFICATE},
         {"request_no_verify",

--- a/stratum/lib/security/credentials_manager.cc
+++ b/stratum/lib/security/credentials_manager.cc
@@ -58,7 +58,7 @@ static std::string ToLower(std::string text) {
   // - This is alleged to be the best way to lowercase a string.
   //   It works for all character sets, not just ascii.
   std::transform(text.begin(), text.end(), text.begin(),
-      [](unsigned char c){ return std::tolower(c); });
+                 [](unsigned char c) { return std::tolower(c); });
   return text;
 }
 
@@ -66,8 +66,7 @@ static std::string ToLower(std::string text) {
 ::util::StatusOr<grpc_ssl_client_certificate_request_type>
 GetCertRequestType() {
   std::string flag_value = ToLower(FLAGS_client_cert_req_type);
-  auto option =
-      gtl::FindOrNull(client_cert_req_type_map, flag_value);
+  auto option = gtl::FindOrNull(client_cert_req_type_map, flag_value);
   if (option == nullptr) {
     return MAKE_ERROR(ERR_INVALID_PARAM)
            << "--client_cert_req_type '" << FLAGS_client_cert_req_type

--- a/stratum/lib/security/credentials_manager.cc
+++ b/stratum/lib/security/credentials_manager.cc
@@ -5,14 +5,13 @@
 
 #include "stratum/lib/security/credentials_manager.h"
 
-#include <algorithm>
-#include <cctype>
 #include <map>
 #include <memory>
 #include <string>
 #include <utility>
 
 #include "absl/memory/memory.h"
+#include "absl/strings/ascii.h"
 #include "absl/time/clock.h"
 #include "absl/time/time.h"
 #include "gflags/gflags.h"
@@ -52,20 +51,10 @@ const std::map<const std::string, grpc_ssl_client_certificate_request_type>
         {"require_and_verify",
          GRPC_SSL_REQUEST_AND_REQUIRE_CLIENT_CERTIFICATE_AND_VERIFY}};
 
-static std::string ToLower(std::string text) {
-  // - We pass 'text' by value because std::transform modifies its input,
-  //   and we need to work on a copy.
-  // - This is alleged to be the best way to lowercase a string.
-  //   It works for all character sets, not just ascii.
-  std::transform(text.begin(), text.end(), text.begin(),
-                 [](unsigned char c) { return std::tolower(c); });
-  return text;
-}
-
 // Returns the value of the client_cert_req_type command-line flag.
 ::util::StatusOr<grpc_ssl_client_certificate_request_type>
 GetCertRequestType() {
-  std::string flag_value = ToLower(FLAGS_client_cert_req_type);
+  std::string flag_value = absl::AsciiStrToLower(FLAGS_client_cert_req_type);
   auto option = gtl::FindOrNull(client_cert_req_type_map, flag_value);
   if (option == nullptr) {
     return MAKE_ERROR(ERR_INVALID_PARAM)


### PR DESCRIPTION
- Having to change case in the middle of typing a command is a nuisance. "Be liberal in what you accept from others."