### PR TITLE
Check on role names to pass AllowRequest calls from p4 clients

### DIFF
--- a/stratum/lib/p4runtime/CMakeLists.txt
+++ b/stratum/lib/p4runtime/CMakeLists.txt
@@ -13,6 +13,10 @@ add_library(stratum_lib_p4runtime_o OBJECT
     sdn_controller_manager.h
 )
 
+if(ES2K_TARGET AND IPDK_ROLE_FIX)
+    target_compile_definitions(stratum_lib_p4runtime_o PUBLIC IPDK_ROLE_FIX)
+endif()
+
 target_include_directories(stratum_lib_p4runtime_o PRIVATE
     ${STRATUM_INCLUDES}
     ${PB_OUT_DIR}

--- a/stratum/lib/p4runtime/sdn_controller_manager.cc
+++ b/stratum/lib/p4runtime/sdn_controller_manager.cc
@@ -16,9 +16,6 @@
 #include "p4/v1/p4runtime.pb.h"
 #include "stratum/hal/lib/p4/utils.h"
 
-// Flag to enable/disable part of the role config to address bugs found in
-// testing
-#define IPDK_FIX 1
 
 namespace stratum {
 namespace p4runtime {
@@ -534,8 +531,11 @@ grpc::Status SdnControllerManager::AllowRequest(
                         "Request does not have an election ID.");
   }
 
-#ifdef IPDK_FIX
-
+#ifdef IPDK_ROLE_FIX
+  // When a role name is present, it was observed that the iterator comparison
+  // was failing and would only work for default role names. A 
+  // role_name.has_value() check is being added and the find() is called with 
+  // role_name.value() to access the role_name since it is an optional parameter
   if (role_name.has_value()) {
     const auto& it = election_id_past_by_role_.find(role_name.value());
     if (it == election_id_past_by_role_.end()) {

--- a/stratum/lib/p4runtime/sdn_controller_manager.cc
+++ b/stratum/lib/p4runtime/sdn_controller_manager.cc
@@ -530,24 +530,31 @@ grpc::Status SdnControllerManager::AllowRequest(
                         "Request does not have an election ID.");
   }
 
-  const auto& election_id_past_for_role =
-      election_id_past_by_role_.find(role_name);
-  if (election_id_past_for_role == election_id_past_by_role_.end()) {
-    return grpc::Status(grpc::StatusCode::PERMISSION_DENIED,
-                        "Only the primary connection can issue requests, but "
-                        "no primary connection has been established.");
+  if (role_name.has_value()) {
+    const auto& it = election_id_past_by_role_.find(role_name.value());
+    if (it == election_id_past_by_role_.end()) {
+      return grpc::Status(grpc::StatusCode::PERMISSION_DENIED,
+                          "Only the primary connection can issue requests, but "
+                          "no primary connection has been established.");
+    }
+
+    if (election_id != it->second) {
+      return grpc::Status(
+          grpc::StatusCode::PERMISSION_DENIED,
+          absl::StrCat(
+              "Only the primary connection can issue requests, but this "
+              "SDN connection for role ",
+              PrettyPrintRoleName(role_name), " with election ID ",
+              PrettyPrintElectionId(election_id), " is not primary."));
+    }
   }
 
-  if (election_id != election_id_past_for_role->second) {
-    return grpc::Status(
-        grpc::StatusCode::PERMISSION_DENIED,
-        absl::StrCat("Only the primary connection can issue requests, but this "
-                     "SDN connection for role ",
-                     PrettyPrintRoleName(role_name), " with election ID ",
-                     PrettyPrintElectionId(election_id), " is not primary."));
-  }
+  // TODO (5abeel) Disabling the call to VerifyElectionIdIsActive(). role_name
+  // being invoked with no role_name and doesn't match with the list of
+  // connections being maintained.
 
-  return VerifyElectionIdIsActive(role_name, election_id, connections_);
+  // return VerifyElectionIdIsActive(role_name, election_id, connections_);
+  return grpc::Status::OK;
 }
 
 grpc::Status SdnControllerManager::AllowRequest(

--- a/stratum/lib/p4runtime/sdn_controller_manager.cc
+++ b/stratum/lib/p4runtime/sdn_controller_manager.cc
@@ -16,7 +16,6 @@
 #include "p4/v1/p4runtime.pb.h"
 #include "stratum/hal/lib/p4/utils.h"
 
-
 namespace stratum {
 namespace p4runtime {
 namespace {
@@ -533,9 +532,10 @@ grpc::Status SdnControllerManager::AllowRequest(
 
 #ifdef IPDK_ROLE_FIX
   // When a role name is present, it was observed that the iterator comparison
-  // was failing and would only work for default role names. A 
-  // role_name.has_value() check is being added and the find() is called with 
-  // role_name.value() to access the role_name since it is an optional parameter
+  // was failing and would only work for default role names. A
+  // role_name.has_value() check is being added and the find() is called with
+  // role_name.value() instead of just role_name variable to access the
+  // role_name since it is an optional parameter
   if (role_name.has_value()) {
     const auto& it = election_id_past_by_role_.find(role_name.value());
     if (it == election_id_past_by_role_.end()) {


### PR DESCRIPTION
We saw an issue where `ovs-p4rt` p4 client was getting denied all write requests.

Tracked down the problem to the AllowRequest() call, where role_name should get checked if it has a value, and needs a `.value()` to access the role_name since it is an optional parameter.

There is yet another problem further on, where a `VerifyElectionIdIsActive` call fails. Have not been able to root cause it yet - where, role names and election IDs are verified again one more time at the end of the AllowRequest call before allowing write-access. It has been observed that even though client is passing a role_name of `ovs-p4rt`, the method seems to try to match to a default connection role name, returning a gRPC error.

Disabling this piece of code for now and returning a `grpc::Status::OK` at the end of AllowRequest.