### PR TITLE
Move p4_role_config cmake build to stratum

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,7 @@ function(add_stratum_object_libs _TGT)
         $<TARGET_OBJECTS:stratum_lib_p4runtime_o>
         $<TARGET_OBJECTS:stratum_lib_security_o>
         $<TARGET_OBJECTS:stratum_main_o>
-        $<TARGET_OBJECTS:stratum_public_o>
+        $<TARGET_OBJECTS:stratum_public_lib_o>
         $<TARGET_OBJECTS:stratum_tdi_common_o>
         $<TARGET_OBJECTS:stratum_tdi_target_o>
         $<TARGET_OBJECTS:stratum_yang_parse_tree_o>

--- a/stratum/glue/CMakeLists.txt
+++ b/stratum/glue/CMakeLists.txt
@@ -31,7 +31,7 @@ add_subdirectory(status)
 
 add_library(stratum_utils SHARED
     $<TARGET_OBJECTS:stratum_glue_o>
-    $<TARGET_OBJECTS:stratum_public_o>
+    $<TARGET_OBJECTS:stratum_public_lib_o>
 )
 
 target_link_libraries(stratum_utils PUBLIC

--- a/stratum/public/CMakeLists.txt
+++ b/stratum/public/CMakeLists.txt
@@ -1,14 +1,8 @@
 # Build file for //stratum/public
 #
-# Copyright 2022-2023 Intel Corporation
+# Copyright 2024 Intel Corporation
 # SPDX-License-Identifier: Apache 2.0
 #
 
-add_library(stratum_public_o OBJECT
-    lib/error.cc
-    lib/error.h
-)
-
-target_include_directories(stratum_public_o PRIVATE ${STRATUM_INCLUDES})
-
-add_dependencies(stratum_public_o stratum_proto gnmi_proto)
+add_subdirectory(lib)
+add_subdirectory(proto)

--- a/stratum/public/lib/CMakeLists.txt
+++ b/stratum/public/lib/CMakeLists.txt
@@ -1,0 +1,18 @@
+# Build file for //stratum/public/lib
+#
+# Copyright 2022-2024 Intel Corporation
+# SPDX-License-Identifier: Apache 2.0
+#
+
+##############################
+# Build stratum_public_lib_o #
+##############################
+
+add_library(stratum_public_lib_o OBJECT
+    error.cc
+    error.h
+)
+
+target_include_directories(stratum_public_lib_o PUBLIC ${STRATUM_INCLUDES})
+
+add_dependencies(stratum_public_lib_o stratum_proto gnmi_proto)

--- a/stratum/public/proto/CMakeLists.txt
+++ b/stratum/public/proto/CMakeLists.txt
@@ -1,0 +1,24 @@
+# Build file for //stratum/public/proto
+#
+# Copyright 2024 Intel Corporation
+# SPDX-License-Identifier: Apache 2.0
+#
+
+########################
+# Build p4_role_config #
+########################
+
+generate_proto_files(
+    "stratum/public/proto/p4_role_config.proto"
+    "${STRATUM_SOURCE_DIR}"
+)
+
+add_library(p4_role_config SHARED
+    ${PB_OUT_DIR}/stratum/public/proto/p4_role_config.pb.cc
+    ${PB_OUT_DIR}/stratum/public/proto/p4_role_config.pb.h
+)
+
+target_include_directories(p4_role_config PUBLIC ${PB_OUT_DIR})
+
+install(TARGETS p4_role_config LIBRARY)
+


### PR DESCRIPTION
Moved the cmake code to build p4_role_config from networking-recipe to the stratum repository.

This is the first step toward relocating the remainder of the cmake build system for stratum from `networking-recipe` to the `stratum` repository. This should make it easier to make changes (especially adding new files), since we would only have to update one repository, instead of having to coordinate updates to both networking-recipe and stratum.

Paired with https://github.com/ipdk-io/networking-recipe/pull/417