### PR TITLE
Move cmake protobuf build code to stratum

### DIFF
--- a/stratum/hal/lib/common/CMakeLists.txt
+++ b/stratum/hal/lib/common/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Build file for //stratum/hal/lib/common
 #
-# Copyright 2022-2023 Intel Corporation
+# Copyright 2022-2024 Intel Corporation
 # SPDX-License-Identifier: Apache 2.0
 #
 
@@ -43,3 +43,19 @@ add_dependencies(stratum_hal_lib_common_o
     openconfig_proto
     stratum_proto
 )
+
+########################
+# Build common_proto_o #
+########################
+
+generate_proto_files(
+    "stratum/hal/lib/common/common.proto"
+    "${STRATUM_SOURCE_DIR}"
+)
+
+add_library(common_proto_o OBJECT
+    ${PB_OUT_DIR}/stratum/hal/lib/common/common.pb.cc
+    ${PB_OUT_DIR}/stratum/hal/lib/common/common.pb.h
+)
+
+target_include_directories(common_proto_o PUBLIC ${PB_OUT_DIR})

--- a/stratum/hal/lib/p4/CMakeLists.txt
+++ b/stratum/hal/lib/p4/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Build file for //stratum/hal/lib/p4
 #
-# Copyright 2022-2023 Intel Corporation
+# Copyright 2022-2024 Intel Corporation
 # SPDX-License-Identifier: Apache 2.0
 #
 
@@ -17,3 +17,112 @@ add_dependencies(stratum_hal_lib_p4_o
     stratum_proto
     p4runtime_proto
 )
+
+###################################
+# Build common_flow_entry_proto_o #
+###################################
+
+generate_proto_files(
+    "stratum/hal/lib/p4/common_flow_entry.proto"
+    "${STRATUM_SOURCE_DIR}"
+)
+
+add_library(common_flow_entry_proto_o OBJECT
+    ${PB_OUT_DIR}/stratum/hal/lib/p4/common_flow_entry.pb.cc
+    ${PB_OUT_DIR}/stratum/hal/lib/p4/common_flow_entry.pb.h
+)
+
+target_link_libraries(common_flow_entry_proto_o PRIVATE
+    p4_annotation_proto_o
+    p4_table_defs_proto_o
+    p4runtime_proto_o
+)
+
+target_include_directories(common_flow_entry_proto_o PUBLIC ${PB_OUT_DIR})
+
+#############################################
+# Build forwarding_pipeline_configs_proto_o #
+#############################################
+
+generate_proto_files(
+    "stratum/hal/lib/p4/forwarding_pipeline_configs.proto"
+    "${STRATUM_SOURCE_DIR}"
+)
+
+add_library(forwarding_pipeline_configs_proto_o OBJECT
+    ${PB_OUT_DIR}/stratum/hal/lib/p4/forwarding_pipeline_configs.pb.cc
+    ${PB_OUT_DIR}/stratum/hal/lib/p4/forwarding_pipeline_configs.pb.h
+)
+
+add_dependencies(forwarding_pipeline_configs_proto_o
+    p4runtime_proto_o
+)
+
+target_include_directories(forwarding_pipeline_configs_proto_o PUBLIC ${PB_OUT_DIR})
+
+############################
+# Build p4_control_proto_o #
+############################
+
+generate_proto_files(
+    "stratum/hal/lib/p4/p4_control.proto"
+    "${STRATUM_SOURCE_DIR}"
+)
+
+add_library(p4_control_proto_o OBJECT
+    ${PB_OUT_DIR}/stratum/hal/lib/p4/p4_control.pb.cc
+    ${PB_OUT_DIR}/stratum/hal/lib/p4/p4_control.pb.h
+)
+
+add_dependencies(p4_control_proto_o
+    p4_annotation_proto_o
+    p4_table_defs_proto_o
+)
+
+target_include_directories(p4_control_proto_o PUBLIC ${PB_OUT_DIR})
+
+#####################################
+# Build p4_pipeline_configs_proto_o #
+#####################################
+
+generate_proto_files(
+    "stratum/hal/lib/p4/p4_pipeline_configs.proto"
+    "${STRATUM_SOURCE_DIR}"
+)
+
+add_library(p4_pipeline_configs_proto_o OBJECT
+    ${PB_OUT_DIR}/stratum/hal/lib/p4/p4_pipeline_configs.pb.cc
+    ${PB_OUT_DIR}/stratum/hal/lib/p4/p4_pipeline_configs.pb.h
+)
+
+add_dependencies(p4_pipeline_configs_proto_o
+    p4_annotation_proto_o
+    p4_control_proto_o
+    p4_table_map_proto_o
+    p4runtime_proto_o
+)
+
+target_include_directories(p4_pipeline_configs_proto_o PUBLIC ${PB_OUT_DIR})
+
+##############################
+# Build p4_table_map_proto_o #
+##############################
+
+generate_proto_files(
+    "stratum/hal/lib/p4/p4_table_map.proto"
+    "${STRATUM_SOURCE_DIR}"
+)
+
+add_library(p4_table_map_proto_o OBJECT
+    ${PB_OUT_DIR}/stratum/hal/lib/p4/p4_table_map.pb.cc
+    ${PB_OUT_DIR}/stratum/hal/lib/p4/p4_table_map.pb.h
+)
+
+add_dependencies(p4_table_map_proto_o
+    common_flow_entry_proto_o
+    p4_annotation_proto_o
+    p4_table_defs_proto_o
+    p4info_proto_o
+)
+
+target_include_directories(p4_table_map_proto_o PUBLIC ${PB_OUT_DIR})

--- a/stratum/hal/lib/p4/CMakeLists.txt
+++ b/stratum/hal/lib/p4/CMakeLists.txt
@@ -18,48 +18,6 @@ add_dependencies(stratum_hal_lib_p4_o
     p4runtime_proto
 )
 
-###################################
-# Build common_flow_entry_proto_o #
-###################################
-
-generate_proto_files(
-    "stratum/hal/lib/p4/common_flow_entry.proto"
-    "${STRATUM_SOURCE_DIR}"
-)
-
-add_library(common_flow_entry_proto_o OBJECT
-    ${PB_OUT_DIR}/stratum/hal/lib/p4/common_flow_entry.pb.cc
-    ${PB_OUT_DIR}/stratum/hal/lib/p4/common_flow_entry.pb.h
-)
-
-target_link_libraries(common_flow_entry_proto_o PRIVATE
-    p4_annotation_proto_o
-    p4_table_defs_proto_o
-    p4runtime_proto_o
-)
-
-target_include_directories(common_flow_entry_proto_o PUBLIC ${PB_OUT_DIR})
-
-#############################################
-# Build forwarding_pipeline_configs_proto_o #
-#############################################
-
-generate_proto_files(
-    "stratum/hal/lib/p4/forwarding_pipeline_configs.proto"
-    "${STRATUM_SOURCE_DIR}"
-)
-
-add_library(forwarding_pipeline_configs_proto_o OBJECT
-    ${PB_OUT_DIR}/stratum/hal/lib/p4/forwarding_pipeline_configs.pb.cc
-    ${PB_OUT_DIR}/stratum/hal/lib/p4/forwarding_pipeline_configs.pb.h
-)
-
-add_dependencies(forwarding_pipeline_configs_proto_o
-    p4runtime_proto_o
-)
-
-target_include_directories(forwarding_pipeline_configs_proto_o PUBLIC ${PB_OUT_DIR})
-
 ############################
 # Build p4_control_proto_o #
 ############################
@@ -80,49 +38,3 @@ add_dependencies(p4_control_proto_o
 )
 
 target_include_directories(p4_control_proto_o PUBLIC ${PB_OUT_DIR})
-
-#####################################
-# Build p4_pipeline_configs_proto_o #
-#####################################
-
-generate_proto_files(
-    "stratum/hal/lib/p4/p4_pipeline_configs.proto"
-    "${STRATUM_SOURCE_DIR}"
-)
-
-add_library(p4_pipeline_configs_proto_o OBJECT
-    ${PB_OUT_DIR}/stratum/hal/lib/p4/p4_pipeline_configs.pb.cc
-    ${PB_OUT_DIR}/stratum/hal/lib/p4/p4_pipeline_configs.pb.h
-)
-
-add_dependencies(p4_pipeline_configs_proto_o
-    p4_annotation_proto_o
-    p4_control_proto_o
-    p4_table_map_proto_o
-    p4runtime_proto_o
-)
-
-target_include_directories(p4_pipeline_configs_proto_o PUBLIC ${PB_OUT_DIR})
-
-##############################
-# Build p4_table_map_proto_o #
-##############################
-
-generate_proto_files(
-    "stratum/hal/lib/p4/p4_table_map.proto"
-    "${STRATUM_SOURCE_DIR}"
-)
-
-add_library(p4_table_map_proto_o OBJECT
-    ${PB_OUT_DIR}/stratum/hal/lib/p4/p4_table_map.pb.cc
-    ${PB_OUT_DIR}/stratum/hal/lib/p4/p4_table_map.pb.h
-)
-
-add_dependencies(p4_table_map_proto_o
-    common_flow_entry_proto_o
-    p4_annotation_proto_o
-    p4_table_defs_proto_o
-    p4info_proto_o
-)
-
-target_include_directories(p4_table_map_proto_o PUBLIC ${PB_OUT_DIR})

--- a/stratum/public/lib/CMakeLists.txt
+++ b/stratum/public/lib/CMakeLists.txt
@@ -15,4 +15,4 @@ add_library(stratum_public_lib_o OBJECT
 
 target_include_directories(stratum_public_lib_o PUBLIC ${STRATUM_INCLUDES})
 
-add_dependencies(stratum_public_lib_o stratum_proto gnmi_proto)
+add_dependencies(stratum_public_lib_o error_proto_o)

--- a/stratum/public/proto/CMakeLists.txt
+++ b/stratum/public/proto/CMakeLists.txt
@@ -39,6 +39,24 @@ add_library(error_proto_o OBJECT
 target_include_directories(error_proto_o PUBLIC ${PB_OUT_DIR})
 
 ###############################
+# Build p4_annotation_proto_o #
+###############################
+
+generate_proto_files(
+  "stratum/public/proto/p4_annotation.proto"
+  "${STRATUM_SOURCE_DIR}"
+)
+
+add_library(p4_annotation_proto_o OBJECT
+  ${PB_OUT_DIR}/stratum/public/proto/p4_annotation.pb.cc
+  ${PB_OUT_DIR}/stratum/public/proto/p4_annotation.pb.h
+)
+
+add_dependencies(p4_annotation_proto_o p4_table_defs_proto_o)
+
+target_include_directories(p4_annotation_proto_o PUBLIC ${PB_OUT_DIR})
+
+###############################
 # Build p4_table_defs_proto_o #
 ###############################
 

--- a/stratum/public/proto/CMakeLists.txt
+++ b/stratum/public/proto/CMakeLists.txt
@@ -9,16 +9,31 @@
 ########################
 
 generate_proto_files(
-    "stratum/public/proto/p4_role_config.proto"
-    "${STRATUM_SOURCE_DIR}"
+  "stratum/public/proto/p4_role_config.proto"
+  "${STRATUM_SOURCE_DIR}"
 )
 
 add_library(p4_role_config SHARED
-    ${PB_OUT_DIR}/stratum/public/proto/p4_role_config.pb.cc
-    ${PB_OUT_DIR}/stratum/public/proto/p4_role_config.pb.h
+  ${PB_OUT_DIR}/stratum/public/proto/p4_role_config.pb.cc
+  ${PB_OUT_DIR}/stratum/public/proto/p4_role_config.pb.h
 )
 
 target_include_directories(p4_role_config PUBLIC ${PB_OUT_DIR})
 
 install(TARGETS p4_role_config LIBRARY)
 
+#######################
+# Build error_proto_o #
+#######################
+
+generate_proto_files(
+  "stratum/public/proto/error.proto"
+  "${STRATUM_SOURCE_DIR}"
+)
+
+add_library(error_proto_o OBJECT
+  ${PB_OUT_DIR}/stratum/public/proto/error.pb.cc
+  ${PB_OUT_DIR}/stratum/public/proto/error.pb.h
+)
+
+target_include_directories(error_proto_o PUBLIC ${PB_OUT_DIR})

--- a/stratum/public/proto/CMakeLists.txt
+++ b/stratum/public/proto/CMakeLists.txt
@@ -37,3 +37,19 @@ add_library(error_proto_o OBJECT
 )
 
 target_include_directories(error_proto_o PUBLIC ${PB_OUT_DIR})
+
+###############################
+# Build p4_table_defs_proto_o #
+###############################
+
+generate_proto_files(
+  "stratum/public/proto/p4_table_defs.proto"
+  "${STRATUM_SOURCE_DIR}"
+)
+
+add_library(p4_table_defs_proto_o OBJECT
+  ${PB_OUT_DIR}/stratum/public/proto/p4_table_defs.pb.cc
+  ${PB_OUT_DIR}/stratum/public/proto/p4_table_defs.pb.h
+)
+
+target_include_directories(p4_table_defs_proto_o PUBLIC ${PB_OUT_DIR})


### PR DESCRIPTION
Continue moving the cmake logic to build the stratum protobufs from `networking-recipe` to `stratum`.

The following protobuf builds have been relocated:

- common.proto
- error.proto
- p4_annotation.proto
- p4_control.proto
- p4_table_defs.proto

In addition to being moved into stratum itself, the protobuf builds are being disaggregated. Each protobuf is built individually and compiled into an object library. Explicit dependencies are used to ensure that the protobuf headers needed to compile the source files are generated before the library is built. This gives us finer granularity, on par with what the Bazel build does.

Paired with https://github.com/ipdk-io/networking-recipe/pull/418

This PR will need to be rebased after https://github.com/ipdk-io/stratum-dev/pull/206 is merged.