### PR TITLE
Remove unnecessary error logging for meters

### DIFF
--- a/stratum/hal/lib/tdi/es2k/es2k_sde_meter.cc
+++ b/stratum/hal/lib/tdi/es2k/es2k_sde_meter.cc
@@ -112,6 +112,9 @@ using namespace stratum::hal::tdi::helpers;
 ::util::Status GetMeterField(
     TdiPktModMeterConfig& cfg, const std::string field_name,
     const std::unique_ptr<::tdi::TableData>& table_data, tdi_id_t field_id) {
+  // We only return a value if field_name specifies one of the meter
+  // fields we're interested in. If it isn't, just fall through and
+  // return OK.
   if (field_name == kEs2kMeterProfileIdKPps) {
     uint64 prof_id;
     RETURN_IF_TDI_ERROR(table_data->getValue(field_id, &prof_id));
@@ -175,8 +178,6 @@ using namespace stratum::hal::tdi::helpers;
     uint64 redPackets;
     RETURN_IF_TDI_ERROR(table_data->getValue(field_id, &redPackets));
     cfg.redPackets = redPackets;
-  } else {
-    LOG(WARNING) << "Unknown meter field " << field_name << " in meter table ";
   }
 
   return ::util::OkStatus();

--- a/stratum/hal/lib/tdi/es2k/es2k_sde_meter.cc
+++ b/stratum/hal/lib/tdi/es2k/es2k_sde_meter.cc
@@ -176,8 +176,7 @@ using namespace stratum::hal::tdi::helpers;
     RETURN_IF_TDI_ERROR(table_data->getValue(field_id, &redPackets));
     cfg.redPackets = redPackets;
   } else {
-    MAKE_ERROR(ERR_INVALID_PARAM)
-        << "Unknown meter field " << field_name << " in meter table ";
+    LOG(WARNING) << "Unknown meter field " << field_name << " in meter table ";
   }
 
   return ::util::OkStatus();


### PR DESCRIPTION


get-packet-mod-meter operation throws error for certain meter fields. Since we allow a set operation on certain meter fields, it makes sense to do a get operation only on those meter fields and avoid fetching meter fields for unset attributes.

Changing the log verbosity to warning feels appropriate as it doesn't throw an error on infrap4d console which gives an impression that something has failed.

