### PR TITLE
Integrate idpf extensions to p4runtime

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -37,7 +37,8 @@ git_repository(
     patch_cmds = ["mv proto/* ."],  # Workaround since strip_prefix is broken.
     # tag: 2023.11.0 (3-Oct-2023)
     # descended from v1.4.0-rc.5 (23-Mar-2020)
-    commit = "40e36a3fdef7781f090436e6c5739768b7be05f8",
+    # replaced with SHA from pending PR
+    commit = "7464b4b4db7bb00e442084af4e3ee7e35fd52213",
 )
 
 # ---------------------------------------------------------------------------

--- a/stratum/hal/lib/p4/BUILD
+++ b/stratum/hal/lib/p4/BUILD
@@ -79,7 +79,6 @@ stratum_cc_test(
         "//stratum/public/proto:p4_annotation_cc_proto",
         "//stratum/public/proto:p4_table_defs_cc_proto",
         "@com_github_p4lang_p4runtime//:p4info_cc_proto",
-        "@com_github_p4lang_p4runtime//:idpf_p4info_cc_proto",
         "@com_google_absl//absl/memory",
         "@com_google_absl//absl/strings",
         "@com_google_googletest//:gtest_main",

--- a/stratum/hal/lib/p4/BUILD
+++ b/stratum/hal/lib/p4/BUILD
@@ -147,6 +147,7 @@ stratum_cc_library(
         "//stratum/lib:utils",
         "//stratum/public/proto:p4_annotation_cc_proto",
         "@com_github_google_glog//:glog",
+        "@com_github_p4lang_p4runtime//:idpf_p4info_cc_proto",
         "@com_github_p4lang_p4runtime//:p4info_cc_proto",
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/container:flat_hash_set",

--- a/stratum/hal/lib/p4/BUILD
+++ b/stratum/hal/lib/p4/BUILD
@@ -79,6 +79,7 @@ stratum_cc_test(
         "//stratum/public/proto:p4_annotation_cc_proto",
         "//stratum/public/proto:p4_table_defs_cc_proto",
         "@com_github_p4lang_p4runtime//:p4info_cc_proto",
+        "@com_github_p4lang_p4runtime//:idpf_p4info_cc_proto",
         "@com_google_absl//absl/memory",
         "@com_google_absl//absl/strings",
         "@com_google_googletest//:gtest_main",

--- a/stratum/hal/lib/p4/p4_info_manager.cc
+++ b/stratum/hal/lib/p4/p4_info_manager.cc
@@ -13,6 +13,7 @@
 #include "absl/strings/strip.h"
 #include "absl/strings/substitute.h"
 #include "gflags/gflags.h"
+#include "idpf/p4info.pb.h"
 #include "p4/config/v1/p4info.pb.h"
 #include "stratum/glue/gtl/map_util.h"
 #include "stratum/lib/macros.h"
@@ -126,7 +127,7 @@ void P4InfoManager::InitDirectPacketModMeters(
       std::bind(&P4InfoManager::ProcessPreamble, this, std::placeholders::_1,
                 std::placeholders::_2);
   for (const auto& extern_instance : extern_instances) {
-    p4::config::v1::DirectPacketModMeter direct_pkt_mod_meter;
+    ::idpf::DirectPacketModMeter direct_pkt_mod_meter;
     *direct_pkt_mod_meter.mutable_preamble() = extern_instance.preamble();
     p4::config::v1::MeterSpec meter_spec;
     meter_spec.set_unit(p4::config::v1::MeterSpec::BYTES);
@@ -143,7 +144,7 @@ void P4InfoManager::InitPacketModMeters(
       std::bind(&P4InfoManager::ProcessPreamble, this, std::placeholders::_1,
                 std::placeholders::_2);
   for (const auto& extern_instance : extern_instances) {
-    p4::config::v1::PacketModMeter pkt_mod_meter;
+    ::idpf::PacketModMeter pkt_mod_meter;
     *pkt_mod_meter.mutable_preamble() = extern_instance.preamble();
     p4::config::v1::MeterSpec meter_spec;
     meter_spec.set_unit(p4::config::v1::MeterSpec::PACKETS);
@@ -233,23 +234,23 @@ P4InfoManager::FindDirectMeterByName(const std::string& meter_name) const {
 }
 
 // FindPktModMeter
-::util::StatusOr<const ::p4::config::v1::PacketModMeter>
+::util::StatusOr<const ::idpf::PacketModMeter>
 P4InfoManager::FindPktModMeterByID(uint32 meter_id) const {
   return pkt_mod_meter_map_.FindByID(meter_id);
 }
 
-::util::StatusOr<const ::p4::config::v1::PacketModMeter>
+::util::StatusOr<const ::idpf::PacketModMeter>
 P4InfoManager::FindPktModMeterByName(const std::string& meter_name) const {
   return pkt_mod_meter_map_.FindByName(meter_name);
 }
 
 // FindDirectPktModMeter
-::util::StatusOr<const ::p4::config::v1::DirectPacketModMeter>
+::util::StatusOr<const ::idpf::DirectPacketModMeter>
 P4InfoManager::FindDirectPktModMeterByID(uint32 meter_id) const {
   return direct_pkt_mod_meter_map_.FindByID(meter_id);
 }
 
-::util::StatusOr<const ::p4::config::v1::DirectPacketModMeter>
+::util::StatusOr<const ::idpf::DirectPacketModMeter>
 P4InfoManager::FindDirectPktModMeterByName(
     const std::string& meter_name) const {
   return direct_pkt_mod_meter_map_.FindByName(meter_name);

--- a/stratum/hal/lib/p4/p4_info_manager.h
+++ b/stratum/hal/lib/p4/p4_info_manager.h
@@ -105,10 +105,10 @@ class P4InfoManager {
   virtual ::util::StatusOr<const ::p4::config::v1::DirectMeter>
   FindDirectMeterByName(const std::string& meter_name) const;
 
-  virtual ::util::StatusOr<const ::idpf::PacketModMeter>
-  FindPktModMeterByID(uint32 meter_id) const;
-  virtual ::util::StatusOr<const ::idpf::PacketModMeter>
-  FindPktModMeterByName(const std::string& meter_name) const;
+  virtual ::util::StatusOr<const ::idpf::PacketModMeter> FindPktModMeterByID(
+      uint32 meter_id) const;
+  virtual ::util::StatusOr<const ::idpf::PacketModMeter> FindPktModMeterByName(
+      const std::string& meter_name) const;
 
   virtual ::util::StatusOr<const ::idpf::DirectPacketModMeter>
   FindDirectPktModMeterByID(uint32 meter_id) const;
@@ -308,8 +308,7 @@ class P4InfoManager {
   P4ResourceMap<::p4::config::v1::Meter> meter_map_;
   P4ResourceMap<::p4::config::v1::DirectMeter> direct_meter_map_;
   P4ResourceMap<::idpf::PacketModMeter> pkt_mod_meter_map_;
-  P4ResourceMap<::idpf::DirectPacketModMeter>
-      direct_pkt_mod_meter_map_;
+  P4ResourceMap<::idpf::DirectPacketModMeter> direct_pkt_mod_meter_map_;
   P4ResourceMap<::p4::config::v1::ValueSet> value_set_map_;
   P4ResourceMap<::p4::config::v1::Register> register_map_;
   P4ResourceMap<::p4::config::v1::Digest> digest_map_;
@@ -321,8 +320,7 @@ class P4InfoManager {
       all_resource_names_;
   absl::flat_hash_map<uint32, std::string> id_to_resource_type_map_;
 
-  google::protobuf::RepeatedPtrField<::idpf::PacketModMeter>
-      all_meter_objects_;
+  google::protobuf::RepeatedPtrField<::idpf::PacketModMeter> all_meter_objects_;
   google::protobuf::RepeatedPtrField<::idpf::DirectPacketModMeter>
       direct_meter_objects_;
 };

--- a/stratum/hal/lib/p4/p4_info_manager.h
+++ b/stratum/hal/lib/p4/p4_info_manager.h
@@ -15,6 +15,7 @@
 #include "absl/container/flat_hash_map.h"
 #include "absl/container/flat_hash_set.h"
 #include "google/protobuf/repeated_field.h"
+#include "idpf/p4info.pb.h"
 #include "p4/config/v1/p4info.pb.h"
 #include "stratum/glue/integral_types.h"
 #include "stratum/glue/logging.h"
@@ -104,14 +105,14 @@ class P4InfoManager {
   virtual ::util::StatusOr<const ::p4::config::v1::DirectMeter>
   FindDirectMeterByName(const std::string& meter_name) const;
 
-  virtual ::util::StatusOr<const ::p4::config::v1::PacketModMeter>
+  virtual ::util::StatusOr<const ::idpf::PacketModMeter>
   FindPktModMeterByID(uint32 meter_id) const;
-  virtual ::util::StatusOr<const ::p4::config::v1::PacketModMeter>
+  virtual ::util::StatusOr<const ::idpf::PacketModMeter>
   FindPktModMeterByName(const std::string& meter_name) const;
 
-  virtual ::util::StatusOr<const ::p4::config::v1::DirectPacketModMeter>
+  virtual ::util::StatusOr<const ::idpf::DirectPacketModMeter>
   FindDirectPktModMeterByID(uint32 meter_id) const;
-  virtual ::util::StatusOr<const ::p4::config::v1::DirectPacketModMeter>
+  virtual ::util::StatusOr<const ::idpf::DirectPacketModMeter>
   FindDirectPktModMeterByName(const std::string& meter_name) const;
 
   virtual ::util::StatusOr<const ::p4::config::v1::ValueSet> FindValueSetByID(
@@ -306,8 +307,8 @@ class P4InfoManager {
   P4ResourceMap<::p4::config::v1::DirectCounter> direct_counter_map_;
   P4ResourceMap<::p4::config::v1::Meter> meter_map_;
   P4ResourceMap<::p4::config::v1::DirectMeter> direct_meter_map_;
-  P4ResourceMap<::p4::config::v1::PacketModMeter> pkt_mod_meter_map_;
-  P4ResourceMap<::p4::config::v1::DirectPacketModMeter>
+  P4ResourceMap<::idpf::PacketModMeter> pkt_mod_meter_map_;
+  P4ResourceMap<::idpf::DirectPacketModMeter>
       direct_pkt_mod_meter_map_;
   P4ResourceMap<::p4::config::v1::ValueSet> value_set_map_;
   P4ResourceMap<::p4::config::v1::Register> register_map_;
@@ -320,9 +321,9 @@ class P4InfoManager {
       all_resource_names_;
   absl::flat_hash_map<uint32, std::string> id_to_resource_type_map_;
 
-  google::protobuf::RepeatedPtrField<p4::config::v1::PacketModMeter>
+  google::protobuf::RepeatedPtrField<::idpf::PacketModMeter>
       all_meter_objects_;
-  google::protobuf::RepeatedPtrField<p4::config::v1::DirectPacketModMeter>
+  google::protobuf::RepeatedPtrField<::idpf::DirectPacketModMeter>
       direct_meter_objects_;
 };
 

--- a/stratum/hal/lib/p4/p4_info_manager_mock.h
+++ b/stratum/hal/lib/p4/p4_info_manager_mock.h
@@ -70,20 +70,20 @@ class P4InfoManagerMock : public P4InfoManager {
 
   // FindPktModMeter
   MOCK_CONST_METHOD1(FindPktModMeterByID,
-                     ::util::StatusOr<const ::p4::config::v1::PacketModMeter>(
+                     ::util::StatusOr<const ::idpf::PacketModMeter>(
                          uint32 meter_id));
   MOCK_CONST_METHOD1(FindPktModMeterByName,
-                     ::util::StatusOr<const ::p4::config::v1::PacketModMeter>(
+                     ::util::StatusOr<const ::idpf::PacketModMeter>(
                          const std::string& meter_name));
 
   // FindDirectPktModMeter
   MOCK_CONST_METHOD1(
       FindDirectPktModMeterByID,
-      ::util::StatusOr<const ::p4::config::v1::DirectPacketModMeter>(
+      ::util::StatusOr<const ::idpf::DirectPacketModMeter>(
           uint32 meter_id));
   MOCK_CONST_METHOD1(
       FindDirectPktModMeterByName,
-      ::util::StatusOr<const ::p4::config::v1::DirectPacketModMeter>(
+      ::util::StatusOr<const ::idpf::DirectPacketModMeter>(
           const std::string& meter_name));
 
   // FindValueSet

--- a/stratum/hal/lib/p4/p4_info_manager_mock.h
+++ b/stratum/hal/lib/p4/p4_info_manager_mock.h
@@ -69,9 +69,9 @@ class P4InfoManagerMock : public P4InfoManager {
                          const std::string& meter_name));
 
   // FindPktModMeter
-  MOCK_CONST_METHOD1(FindPktModMeterByID,
-                     ::util::StatusOr<const ::idpf::PacketModMeter>(
-                         uint32 meter_id));
+  MOCK_CONST_METHOD1(
+      FindPktModMeterByID,
+      ::util::StatusOr<const ::idpf::PacketModMeter>(uint32 meter_id));
   MOCK_CONST_METHOD1(FindPktModMeterByName,
                      ::util::StatusOr<const ::idpf::PacketModMeter>(
                          const std::string& meter_name));
@@ -79,12 +79,10 @@ class P4InfoManagerMock : public P4InfoManager {
   // FindDirectPktModMeter
   MOCK_CONST_METHOD1(
       FindDirectPktModMeterByID,
-      ::util::StatusOr<const ::idpf::DirectPacketModMeter>(
-          uint32 meter_id));
-  MOCK_CONST_METHOD1(
-      FindDirectPktModMeterByName,
-      ::util::StatusOr<const ::idpf::DirectPacketModMeter>(
-          const std::string& meter_name));
+      ::util::StatusOr<const ::idpf::DirectPacketModMeter>(uint32 meter_id));
+  MOCK_CONST_METHOD1(FindDirectPktModMeterByName,
+                     ::util::StatusOr<const ::idpf::DirectPacketModMeter>(
+                         const std::string& meter_name));
 
   // FindValueSet
   MOCK_CONST_METHOD1(

--- a/stratum/hal/lib/tdi/BUILD
+++ b/stratum/hal/lib/tdi/BUILD
@@ -307,6 +307,7 @@ stratum_cc_library(
         "//stratum/lib:timer_daemon",
         "//stratum/lib:utils",
         "//stratum/public/proto:error_cc_proto",
+        "@com_github_p4lang_p4runtime//:idpf_p4info_cc_proto",
         "@com_github_p4lang_p4runtime//:p4info_cc_proto",
         "@com_github_p4lang_p4runtime//:p4runtime_cc_grpc",
         "@com_google_absl//absl/container:flat_hash_map",

--- a/stratum/hal/lib/tdi/tdi_table_manager.cc
+++ b/stratum/hal/lib/tdi/tdi_table_manager.cc
@@ -13,6 +13,7 @@
 #include "absl/strings/match.h"
 #include "absl/synchronization/notification.h"
 #include "gflags/gflags.h"
+#include "idpf/p4info.pb.h"
 #include "p4/config/v1/p4info.pb.h"
 #include "stratum/glue/status/status_macros.h"
 #include "stratum/hal/lib/p4/utils.h"
@@ -1032,7 +1033,7 @@ TdiTableManager::ReadDirectMeterEntry(
 }
 
 static ::util::Status GetPktModMeterUnitsInPackets(
-    const ::p4::config::v1::PacketModMeter& meter, bool& result) {
+    const ::idpf::PacketModMeter& meter, bool& result) {
   switch (meter.spec().unit()) {
     case ::p4::config::v1::MeterSpec::BYTES:
       result = false;
@@ -1112,7 +1113,7 @@ static ::util::Status GetPktModMeterUnitsInPackets(
     bool pkt_mod_meter_units_in_packets;
     {
       absl::ReaderMutexLock l(&lock_);
-      p4::config::v1::PacketModMeter meter;
+      ::idpf::PacketModMeter meter;
       ASSIGN_OR_RETURN(
           meter, p4_info_manager_->FindPktModMeterByID(meter_entry.meter_id()));
       RETURN_IF_ERROR(
@@ -1272,7 +1273,7 @@ static ::util::Status SetPktModMeterConfig(
     bool pkt_mod_meter_units_in_packets;
     {
       absl::ReaderMutexLock l(&lock_);
-      p4::config::v1::PacketModMeter meter;
+      ::idpf::PacketModMeter meter;
       ASSIGN_OR_RETURN(
           meter, p4_info_manager_->FindPktModMeterByID(meter_entry.meter_id()));
       RETURN_IF_ERROR(


### PR DESCRIPTION
The IPDK fork of the p4runtime repository includes ES2K-specific changes to `p4runtime.proto` and `p4info.proto`. These extensions support the `PacketModMeter` and `DirectPacketModMeter` externs.

This CL moves the changes from the standard protobuf files to a separate `idpf` package.

Associated PRs: https://github.com/ipdk-io/networking-recipe/pull/428 and https://github.com/ipdk-io/p4runtime-dev/pull/5.