### PR TITLE
Fix for getting direct/indirect meter entry

### DIFF
--- a/stratum/hal/lib/p4/p4_info_manager.cc
+++ b/stratum/hal/lib/p4/p4_info_manager.cc
@@ -102,10 +102,10 @@ P4InfoManager::~P4InfoManager() {}
     for (const auto& p4extern : p4_info_.externs()) {
       switch (p4extern.extern_type_id()) {
         case ::p4::config::v1::P4Ids_Prefix_PACKET_MOD_METER:
-          InitDirectPacketModMeters(p4extern);
+          InitPacketModMeters(p4extern);
           break;
         case ::p4::config::v1::P4Ids_Prefix_DIRECT_PACKET_MOD_METER:
-          InitPacketModMeters(p4extern);
+          InitDirectPacketModMeters(p4extern);
           break;
         default:
           LOG(INFO) << "Unrecognized p4_info extern type: "

--- a/stratum/hal/lib/tdi/tdi_table_manager.cc
+++ b/stratum/hal/lib/tdi/tdi_table_manager.cc
@@ -900,8 +900,7 @@ TdiTableManager::ReadDirectMeterEntry(
       result.mutable_config()->set_pir(static_cast<int64>(pir));
       result.mutable_config()->set_pburst(static_cast<int64>(pburst));
     }
-    if (resource_type == "DirectPacketModMeter" &&
-        table_entry.has_meter_config()) {
+    if (resource_type == "DirectPacketModMeter") {
       // build response entry from returned data
       TdiPktModMeterConfig cfg;
       RETURN_IF_ERROR(table_data->GetPktModMeterConfig(cfg));


### PR DESCRIPTION
Issue:
get-pkt-mod-meter and get-direct-pkt-mod-meter commands from p4rt-ctl isn't showing any output, all the counters output are 0 even after sending the traffic.

RCA:
Wrong initialization done for PacketModMeters and DirectPacketModMeter.
ReadMeterEntry and ReadDirectMeterEntry is responsible for fetching the values based on resource_type. For direct meter, resource_type is "DirectPacketModMeter" and for indirect meters, resource_type is "PacketModMeter". However, because of wrong initialization, the expected and actual values of resource_type are different, hence the API returns without fetching any values.

Also, has_meter_config() check while doing a get operation isn't required, since we are not providing the meter config data while building the key in get-direct-packet-mod-meter operation.
