### PR TITLE
Modify tdi_bf_status.h to be target-neutral

### DIFF
--- a/stratum/hal/lib/tdi/dpdk/BUILD
+++ b/stratum/hal/lib/tdi/dpdk/BUILD
@@ -294,6 +294,17 @@ stratum_cc_test(
 )
 
 stratum_cc_test(
+    name = "dpdk_tdi_status_test",
+    srcs = ["dpdk_tdi_status_test.cc"],
+    deps = [
+        ":test_main",
+        "//stratum/hal/lib/tdi:tdi_bf_status",
+        "@com_google_googletest//:gtest",
+        "@local_dpdk_bin//:dpdk_hdrs",
+    ],
+)
+
+stratum_cc_test(
     name = "dpdk_switch_test",
     srcs = [
         "dpdk_switch_test.cc",

--- a/stratum/hal/lib/tdi/dpdk/dpdk_tdi_status_test.cc
+++ b/stratum/hal/lib/tdi/dpdk/dpdk_tdi_status_test.cc
@@ -1,0 +1,70 @@
+// Copyright 2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#include "bf_types/bf_types.h"
+#include "gtest/gtest.h"
+#include "stratum/hal/lib/tdi/tdi_bf_status.h"
+
+namespace stratum {
+namespace hal {
+namespace tdi {
+
+class DpdkTdiStatusTest : public ::testing::Test {};
+
+// Verify that BF status codes map directly to TDI status codes.
+TEST_F(DpdkTdiStatusTest, status_codes_match) {
+  ASSERT_EQ(TDI_SUCCESS, BF_SUCCESS);
+  ASSERT_EQ(TDI_NO_SYS_RESOURCES, BF_NO_SYS_RESOURCES);
+  ASSERT_EQ(TDI_INVALID_ARG, BF_INVALID_ARG);
+  ASSERT_EQ(TDI_ALREADY_EXISTS, BF_ALREADY_EXISTS);
+  ASSERT_EQ(TDI_HW_COMM_FAIL, BF_HW_COMM_FAIL);
+  ASSERT_EQ(TDI_OBJECT_NOT_FOUND, BF_OBJECT_NOT_FOUND);
+  ASSERT_EQ(TDI_MAX_SESSIONS_EXCEEDED, BF_MAX_SESSIONS_EXCEEDED);
+  ASSERT_EQ(TDI_SESSION_NOT_FOUND, BF_SESSION_NOT_FOUND);
+  ASSERT_EQ(TDI_NO_SPACE, BF_NO_SPACE);
+  ASSERT_EQ(TDI_EAGAIN, BF_EAGAIN);
+  ASSERT_EQ(TDI_INIT_ERROR, BF_INIT_ERROR);
+  ASSERT_EQ(TDI_TXN_NOT_SUPPORTED, BF_TXN_NOT_SUPPORTED);
+  ASSERT_EQ(TDI_TABLE_LOCKED, BF_TABLE_LOCKED);
+  ASSERT_EQ(TDI_IO, BF_IO);
+  ASSERT_EQ(TDI_UNEXPECTED, BF_UNEXPECTED);
+  ASSERT_EQ(TDI_ENTRY_REFERENCES_EXIST, BF_ENTRY_REFERENCES_EXIST);
+  ASSERT_EQ(TDI_NOT_SUPPORTED, BF_NOT_SUPPORTED);
+  ASSERT_EQ(TDI_HW_UPDATE_FAILED, BF_HW_UPDATE_FAILED);
+  ASSERT_EQ(TDI_NO_LEARN_CLIENTS, BF_NO_LEARN_CLIENTS);
+  ASSERT_EQ(TDI_IDLE_UPDATE_IN_PROGRESS, BF_IDLE_UPDATE_IN_PROGRESS);
+  ASSERT_EQ(TDI_DEVICE_LOCKED, BF_DEVICE_LOCKED);
+  ASSERT_EQ(TDI_INTERNAL_ERROR, BF_INTERNAL_ERROR);
+  ASSERT_EQ(TDI_TABLE_NOT_FOUND, BF_TABLE_NOT_FOUND);
+  ASSERT_EQ(TDI_IN_USE, BF_IN_USE);
+  ASSERT_EQ(TDI_NOT_IMPLEMENTED, BF_NOT_IMPLEMENTED);
+  ASSERT_EQ(TDI_STS_MAX, BF_STS_MAX);
+}
+
+// Verify that status() returns the original TDI status code.
+TEST_F(DpdkTdiStatusTest, status_method_returns_tdi_status) {
+  TdiStatus ret(TDI_NOT_IMPLEMENTED);
+  ASSERT_EQ(ret.status(), TDI_NOT_IMPLEMENTED);
+}
+
+// Verify that error_code() returns the corresponding Stratum ErrorCode.
+TEST_F(DpdkTdiStatusTest, error_code_method_returns_errorcode) {
+  TdiStatus ret(TDI_NO_SPACE);
+  ASSERT_EQ(ret.error_code(), ERR_NO_RESOURCE);
+}
+
+// Verify that success status evaluates to Boolean True.
+TEST_F(DpdkTdiStatusTest, successful_status_is_boolean_true) {
+  TdiStatus okay(TDI_SUCCESS);
+  ASSERT_TRUE(okay);
+}
+
+// Verify that failure status evaluates to Boolean False.
+TEST_F(DpdkTdiStatusTest, failure_status_is_boolean_false) {
+  TdiStatus not_okay(TDI_INTERNAL_ERROR);
+  ASSERT_FALSE(not_okay);
+}
+
+}  // namespace tdi
+}  // namespace hal
+}  // namespace stratum

--- a/stratum/hal/lib/tdi/es2k/BUILD
+++ b/stratum/hal/lib/tdi/es2k/BUILD
@@ -319,6 +319,17 @@ stratum_cc_test(
     ],
 )
 
+stratum_cc_test(
+    name = "es2k_tdi_status_test",
+    srcs = ["es2k_tdi_status_test.cc"],
+    deps = [
+        ":test_main",
+        "//stratum/hal/lib/tdi:tdi_bf_status",
+        "@com_google_googletest//:gtest",
+        "@local_es2k_bin//:es2k_hdrs",
+    ],
+)
+
 stratum_cc_library(
     name = "test_main",
     testonly = 1,

--- a/stratum/hal/lib/tdi/es2k/es2k_tdi_status_test.cc
+++ b/stratum/hal/lib/tdi/es2k/es2k_tdi_status_test.cc
@@ -1,0 +1,70 @@
+// Copyright 2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#include "gtest/gtest.h"
+#include "ipu_types/ipu_types.h"
+#include "stratum/hal/lib/tdi/tdi_bf_status.h"
+
+namespace stratum {
+namespace hal {
+namespace tdi {
+
+class Es2kTdiStatusTest : public ::testing::Test {};
+
+// Verify that IPU status codes map directly to TDI status codes.
+TEST_F(Es2kTdiStatusTest, status_codes_match) {
+  ASSERT_EQ(TDI_SUCCESS, IPU_SUCCESS);
+  ASSERT_EQ(TDI_NO_SYS_RESOURCES, IPU_NO_SYS_RESOURCES);
+  ASSERT_EQ(TDI_INVALID_ARG, IPU_INVALID_ARG);
+  ASSERT_EQ(TDI_ALREADY_EXISTS, IPU_ALREADY_EXISTS);
+  ASSERT_EQ(TDI_HW_COMM_FAIL, IPU_HW_COMM_FAIL);
+  ASSERT_EQ(TDI_OBJECT_NOT_FOUND, IPU_OBJECT_NOT_FOUND);
+  ASSERT_EQ(TDI_MAX_SESSIONS_EXCEEDED, IPU_MAX_SESSIONS_EXCEEDED);
+  ASSERT_EQ(TDI_SESSION_NOT_FOUND, IPU_SESSION_NOT_FOUND);
+  ASSERT_EQ(TDI_NO_SPACE, IPU_NO_SPACE);
+  ASSERT_EQ(TDI_EAGAIN, IPU_EAGAIN);
+  ASSERT_EQ(TDI_INIT_ERROR, IPU_INIT_ERROR);
+  ASSERT_EQ(TDI_TXN_NOT_SUPPORTED, IPU_TXN_NOT_SUPPORTED);
+  ASSERT_EQ(TDI_TABLE_LOCKED, IPU_TABLE_LOCKED);
+  ASSERT_EQ(TDI_IO, IPU_IO);
+  ASSERT_EQ(TDI_UNEXPECTED, IPU_UNEXPECTED);
+  ASSERT_EQ(TDI_ENTRY_REFERENCES_EXIST, IPU_ENTRY_REFERENCES_EXIST);
+  ASSERT_EQ(TDI_NOT_SUPPORTED, IPU_NOT_SUPPORTED);
+  ASSERT_EQ(TDI_HW_UPDATE_FAILED, IPU_HW_UPDATE_FAILED);
+  ASSERT_EQ(TDI_NO_LEARN_CLIENTS, IPU_NO_LEARN_CLIENTS);
+  ASSERT_EQ(TDI_IDLE_UPDATE_IN_PROGRESS, IPU_IDLE_UPDATE_IN_PROGRESS);
+  ASSERT_EQ(TDI_DEVICE_LOCKED, IPU_DEVICE_LOCKED);
+  ASSERT_EQ(TDI_INTERNAL_ERROR, IPU_INTERNAL_ERROR);
+  ASSERT_EQ(TDI_TABLE_NOT_FOUND, IPU_TABLE_NOT_FOUND);
+  ASSERT_EQ(TDI_IN_USE, IPU_IN_USE);
+  ASSERT_EQ(TDI_NOT_IMPLEMENTED, IPU_NOT_IMPLEMENTED);
+  ASSERT_EQ(TDI_STS_MAX, IPU_STS_MAX);
+}
+
+// Verify that status() returns the original TDI status code.
+TEST_F(Es2kTdiStatusTest, status_method_returns_tdi_status) {
+  TdiStatus ret(TDI_NOT_IMPLEMENTED);
+  ASSERT_EQ(ret.status(), TDI_NOT_IMPLEMENTED);
+}
+
+// Verify that error_code() returns the corresponding Stratum ErrorCode.
+TEST_F(Es2kTdiStatusTest, error_code_method_returns_errorcode) {
+  TdiStatus ret(TDI_NO_SPACE);
+  ASSERT_EQ(ret.error_code(), ERR_NO_RESOURCE);
+}
+
+// Verify that success status evaluates to Boolean True.
+TEST_F(Es2kTdiStatusTest, successful_status_is_boolean_true) {
+  TdiStatus okay(TDI_SUCCESS);
+  ASSERT_TRUE(okay);
+}
+
+// Verify that failure status evaluates to Boolean False.
+TEST_F(Es2kTdiStatusTest, failure_status_is_boolean_false) {
+  TdiStatus not_okay(TDI_INTERNAL_ERROR);
+  ASSERT_FALSE(not_okay);
+}
+
+}  // namespace tdi
+}  // namespace hal
+}  // namespace stratum

--- a/stratum/hal/lib/tdi/tdi_bf_status.h
+++ b/stratum/hal/lib/tdi/tdi_bf_status.h
@@ -1,16 +1,12 @@
 // Copyright 2020-present Open Networking Foundation
-// Copyright 2022-2023 Intel Corporation
+// Copyright 2022-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 #ifndef STRATUM_HAL_LIB_TDI_TDI_BF_STATUS_H_
 #define STRATUM_HAL_LIB_TDI_TDI_BF_STATUS_H_
 
 extern "C" {
-#ifdef ES2K_TARGET
-#include "ipu_types/ipu_types.h"
-#else
-#include "bf_types/bf_types.h"
-#endif
+#include "tdi/common/tdi_defs.h"
 }
 
 #include "stratum/glue/status/status.h"
@@ -21,139 +17,76 @@ namespace stratum {
 namespace hal {
 namespace tdi {
 
-// Wrapper object for a ipu_status code from the SDE.
-class TdiBfStatus {
+// Wrapper object for a tdi_status code from the SDE.
+class TdiStatus {
  public:
-#ifdef ES2K_TARGET
-  explicit TdiBfStatus(ipu_status_t status) : status_(status) {}
-  operator bool() const { return status_ == IPU_SUCCESS; }
-  inline ipu_status_t status() const { return status_; }
+  explicit TdiStatus(tdi_status_t status) : status_(status) {}
+  operator bool() const { return status_ == TDI_SUCCESS; }
+  inline tdi_status_t status() const { return status_; }
   inline ErrorCode error_code() const {
     switch (status_) {
-      case IPU_SUCCESS:
+      case TDI_SUCCESS:
         return ERR_SUCCESS;
-      case IPU_NOT_READY:
+      case TDI_NOT_READY:
         return ERR_NOT_INITIALIZED;
-      case IPU_INVALID_ARG:
+      case TDI_INVALID_ARG:
         return ERR_INVALID_PARAM;
-      case IPU_ALREADY_EXISTS:
+      case TDI_ALREADY_EXISTS:
         return ERR_ENTRY_EXISTS;
-      case IPU_NO_SYS_RESOURCES:
-      case IPU_MAX_SESSIONS_EXCEEDED:
-      case IPU_NO_SPACE:
-      case IPU_EAGAIN:
+      case TDI_NO_SYS_RESOURCES:
+      case TDI_MAX_SESSIONS_EXCEEDED:
+      case TDI_NO_SPACE:
+      case TDI_EAGAIN:
         return ERR_NO_RESOURCE;
-      case IPU_ENTRY_REFERENCES_EXIST:
+      case TDI_ENTRY_REFERENCES_EXIST:
         return ERR_FAILED_PRECONDITION;
-      case IPU_TXN_NOT_SUPPORTED:
-      case IPU_NOT_SUPPORTED:
+      case TDI_TXN_NOT_SUPPORTED:
+      case TDI_NOT_SUPPORTED:
         return ERR_OPER_NOT_SUPPORTED;
-      case IPU_HW_COMM_FAIL:
-      case IPU_HW_UPDATE_FAILED:
+      case TDI_HW_COMM_FAIL:
+      case TDI_HW_UPDATE_FAILED:
         return ERR_HARDWARE_ERROR;
-      case IPU_NO_LEARN_CLIENTS:
+      case TDI_NO_LEARN_CLIENTS:
         return ERR_FEATURE_UNAVAILABLE;
-      case IPU_IDLE_UPDATE_IN_PROGRESS:
+      case TDI_IDLE_UPDATE_IN_PROGRESS:
         return ERR_OPER_STILL_RUNNING;
-      case IPU_OBJECT_NOT_FOUND:
-      case IPU_TABLE_NOT_FOUND:
+      case TDI_OBJECT_NOT_FOUND:
+      case TDI_TABLE_NOT_FOUND:
         return ERR_ENTRY_NOT_FOUND;
-      case IPU_NOT_IMPLEMENTED:
+      case TDI_NOT_IMPLEMENTED:
         return ERR_UNIMPLEMENTED;
-      case IPU_SESSION_NOT_FOUND:
-      case IPU_INIT_ERROR:
-      case IPU_TABLE_LOCKED:
-      case IPU_IO:
-      case IPU_UNEXPECTED:
-      case IPU_DEVICE_LOCKED:
-      case IPU_INTERNAL_ERROR:
-      case IPU_IN_USE:
+      case TDI_SESSION_NOT_FOUND:
+      case TDI_INIT_ERROR:
+      case TDI_TABLE_LOCKED:
+      case TDI_IO:
+      case TDI_UNEXPECTED:
+      case TDI_DEVICE_LOCKED:
+      case TDI_INTERNAL_ERROR:
+      case TDI_IN_USE:
       default:
         return ERR_INTERNAL;
     }
   }
-#else
-  explicit TdiBfStatus(bf_status_t status) : status_(status) {}
-  operator bool() const { return status_ == BF_SUCCESS; }
-  inline bf_status_t status() const { return status_; }
-  inline ErrorCode error_code() const {
-    switch (status_) {
-      case BF_SUCCESS:
-        return ERR_SUCCESS;
-      case BF_NOT_READY:
-        return ERR_NOT_INITIALIZED;
-      case BF_INVALID_ARG:
-        return ERR_INVALID_PARAM;
-      case BF_ALREADY_EXISTS:
-        return ERR_ENTRY_EXISTS;
-      case BF_NO_SYS_RESOURCES:
-      case BF_MAX_SESSIONS_EXCEEDED:
-      case BF_NO_SPACE:
-      case BF_EAGAIN:
-        return ERR_NO_RESOURCE;
-      case BF_ENTRY_REFERENCES_EXIST:
-        return ERR_FAILED_PRECONDITION;
-      case BF_TXN_NOT_SUPPORTED:
-      case BF_NOT_SUPPORTED:
-        return ERR_OPER_NOT_SUPPORTED;
-      case BF_HW_COMM_FAIL:
-      case BF_HW_UPDATE_FAILED:
-        return ERR_HARDWARE_ERROR;
-      case BF_NO_LEARN_CLIENTS:
-        return ERR_FEATURE_UNAVAILABLE;
-      case BF_IDLE_UPDATE_IN_PROGRESS:
-        return ERR_OPER_STILL_RUNNING;
-      case BF_OBJECT_NOT_FOUND:
-      case BF_TABLE_NOT_FOUND:
-        return ERR_ENTRY_NOT_FOUND;
-      case BF_NOT_IMPLEMENTED:
-        return ERR_UNIMPLEMENTED;
-      case BF_SESSION_NOT_FOUND:
-      case BF_INIT_ERROR:
-      case BF_TABLE_LOCKED:
-      case BF_IO:
-      case BF_UNEXPECTED:
-      case BF_DEVICE_LOCKED:
-      case BF_INTERNAL_ERROR:
-      case BF_IN_USE:
-      default:
-        return ERR_INTERNAL;
-    }
-  }
-#endif
 
  private:
-#ifdef ES2K_TARGET
-  ipu_status_t status_;
-#else
-  bf_status_t status_;
-#endif
+  tdi_status_t status_;
 };
 
-// A macro to simplify checking and logging the return value of a SDE function
-// call.
-#ifdef ES2K_TARGET
+// A macro to simplify checking and logging the return value of an SDE
+// function call.
 #define RETURN_IF_TDI_ERROR(expr)                             \
-  if (const TdiBfStatus __ret = TdiBfStatus(expr)) {          \
+  if (const TdiStatus __ret = TdiStatus(expr)) {              \
   } else /* NOLINT */                                         \
     return MAKE_ERROR(__ret.error_code())                     \
            << "'" << #expr << "' failed with error message: " \
-           << FixMessage(ipu_err_str(__ret.status()))
-#else
-#define RETURN_IF_TDI_ERROR(expr)                             \
-  if (const TdiBfStatus __ret = TdiBfStatus(expr)) {          \
-  } else /* NOLINT */                                         \
-    return MAKE_ERROR(__ret.error_code())                     \
-           << "'" << #expr << "' failed with error message: " \
-           << FixMessage(bf_err_str(__ret.status()))
-#endif
+           << FixMessage(tdi_err_str(__ret.status()))
+
 // A macro to simplify creating a new error or appending new info to an
-// error based on the return value of a SDE function call. The caller function
-// will not return. The variable given as "status" must be an object of type
-// ::util::Status.
-#ifdef ES2K_TARGET
-#define APPEND_STATUS_IF_BFRT_ERROR(status, expr)                           \
-  if (const TdiBfStatus __ret = TdiBfStatus(expr)) {                        \
+// error based on the return value of an SDE function call. The function that
+// invokes the macro does not return to the calling function. The "status"
+// parameter must be an object of type ::util::Status.
+#define APPEND_STATUS_IF_TDI_ERROR(status, expr)                            \
+  if (const TdiStatus __ret = TdiStatus(expr)) {                            \
   } else /* NOLINT */                                                       \
     status =                                                                \
         APPEND_ERROR(!status.ok() ? status                                  \
@@ -165,23 +98,8 @@ class TdiBfStatus {
                 ? ""                                                        \
                 : " ")                                                      \
         << "'" << #expr << "' failed with error message: "                  \
-        << FixMessage(ipu_err_str(__ret.status()))
-#else
-#define APPEND_STATUS_IF_BFRT_ERROR(status, expr)                           \
-  if (const TdiBfStatus __ret = TdiBfStatus(expr)) {                        \
-  } else /* NOLINT */                                                       \
-    status =                                                                \
-        APPEND_ERROR(!status.ok() ? status                                  \
-                                  : ::util::Status(StratumErrorSpace(),     \
-                                                   __ret.error_code(), "")) \
-            .without_logging()                                              \
-        << (status.error_message().empty() ||                               \
-                    status.error_message().back() == ' '                    \
-                ? ""                                                        \
-                : " ")                                                      \
-        << "'" << #expr << "' failed with error message: "                  \
-        << FixMessage(bf_err_str(__ret.status()))
-#endif
+        << FixMessage(tdi_err_str(__ret.status()))
+
 }  // namespace tdi
 }  // namespace hal
 }  // namespace stratum


### PR DESCRIPTION
- Revised `tdi_bf_status.h` to represent a TDI status code, rather than a legacy BF status code or an ES2K IPU status code. This is how the class should have been implemented in the first place, since it is intended to operate on status codes returned by TDI.

- Renamed class from `TdiBfStatus` to `TdiStatus`.

- Created dpdk- and es2k-specific unit tests for the `TdiStatus` class.

The implementation relies on the 1:1:1 correspondence between the BF, TDI, and IPU status codes. This is not as outrageous as it may seem: the Stratum TDI code uses `RETURN_IF_TDI_ERROR()` indiscriminately for both TDI methods and bf_pal function calls.

Should the correspondence ever change, the target-specific unit tests will let us know, and we can deal with the issue then.

I plan to rename `tdi_bf_status.h` to `tdi_status.h` in a subsequent commit (#218).

NOTE: when reviewing this PR, look first at `tdi_bf_status.h` to see what's being changed. Everything else is for support.