### PR TITLE
Fix ES2K Bazel build

### DIFF
--- a/bazel/external/es2k.BUILD
+++ b/bazel/external/es2k.BUILD
@@ -1,6 +1,6 @@
 # bazel/external/es2k.BUILD
 
-# Copyright 2023 Intel Corporation
+# Copyright 2023-2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
 load("@rules_cc//cc:defs.bzl", "cc_library")
@@ -13,25 +13,24 @@ cc_library(
     name = "es2k_libs",
     srcs = glob([
         # "es2k-bin/lib/libacccp.so",
-        "es2k-bin/lib/libbf_switchd_lib.so*",
         "es2k-bin/lib/libclish.so",
         "es2k-bin/lib/libcpf.so",
         "es2k-bin/lib/libcpf_pmd_infra.so",
         "es2k-bin/lib/libdriver.so*",
+        "es2k-bin/lib/libipu_p4d_lib.so*",
         "es2k-bin/lib/libpython3.10.so*",
         "es2k-bin/lib/libtarget_sys.so",
         "es2k-bin/lib/libtarget_utils.so",
         "es2k-bin/lib/libtdi.so",
         "es2k-bin/lib/libtdi_json_parser.so",
         "es2k-bin/lib/libtdi_pna.so",
-        # "es2k-bin/lib/libtdi_psa.so",
-        # "es2k-bin/lib/libtdi_tna.so",
         "es2k-bin/lib/libvfio.so",
         "es2k-bin/lib/libxeoncp.so",
         "es2k-bin/lib/x86_64-linux-gnu/*.so*",
     ]),
     linkopts = [
         "-L/usr/lib/x86_64-linux-gnu",
+        "-lbsd",  # strlcpy
         "-lglib-2.0",
         "-lpthread",
         "-lm",
@@ -42,18 +41,21 @@ cc_library(
 cc_library(
     name = "es2k_hdrs",
     hdrs = glob([
-        "es2k-bin/include/bf_pal/*.h",
-        "es2k-bin/include/bf_switchd/**/*.h",
-        "es2k-bin/include/bf_types/*.h",
         "es2k-bin/include/cjson/*.h",
         "es2k-bin/include/dvm/*.h",
+        "es2k-bin/include/ipu_pal/*.h",
+        "es2k-bin/include/ipu_p4d/**/*.h",
+        "es2k-bin/include/ipu_types/*.h",
+        "es2k-bin/include/lld/*.h",
         "es2k-bin/include/osdep/*.h",
+        "es2k-bin/include/pkt_mgr/**/*.h",
         "es2k-bin/include/port_mgr/**/*.h",
         "es2k-bin/include/target-sys/**/*.h",
         "es2k-bin/include/target-utils/**/*.h",
         "es2k-bin/include/tdi/**/*.h",
         "es2k-bin/include/tdi/**/*.hpp",
         "es2k-bin/include/tdi_rt/*.h",
+        "es2k-bin/include/tdi_rt/*.hpp",
     ]),
     strip_include_prefix = "es2k-bin/include",
 )

--- a/stratum/hal/lib/tdi/es2k/BUILD
+++ b/stratum/hal/lib/tdi/es2k/BUILD
@@ -104,24 +104,12 @@ stratum_cc_library(
 
 stratum_cc_library(
     name = "es2k_sde_meter",
-    srcs = [
-        "es2k_sde_meter.cc",
-        "es2k_sde_wrapper.cc",
-    ],
-    hdrs = ["es2k_sde_wrapper.h"],
+    srcs = ["es2k_sde_meter.cc"],
     deps = [
-        ":es2k_port_manager",
+        ":es2k_sde_wrapper",
         "//stratum/glue:integral_types",
-        "//stratum/glue:logging",
-        "//stratum/glue/gtl:map_util",
         "//stratum/glue/status",
-        "//stratum/glue/status:statusor",
-        "//stratum/hal/lib/tdi:tdi_constants",
         "//stratum/hal/lib/tdi:tdi_sde_headers",
-        "//stratum/lib:constants",
-        "//stratum/lib:utils",
-        "@com_google_absl//absl/base:core_headers",
-        "@com_google_absl//absl/cleanup",
         "@local_es2k_bin//:es2k_sde",
     ],
 )

--- a/stratum/hal/lib/tdi/es2k/es2k_sde_meter.cc
+++ b/stratum/hal/lib/tdi/es2k/es2k_sde_meter.cc
@@ -3,28 +3,17 @@
 
 // ES2K-specific PktModMeter methods.
 
-#include <stddef.h>
 #include <stdint.h>
 
-#include <algorithm>
-#include <memory>
 #include <string>
 #include <vector>
 
-#include "absl/synchronization/mutex.h"
-#include "absl/types/optional.h"
-#include "stratum/glue/integral_types.h"
 #include "stratum/glue/status/status.h"
 #include "stratum/glue/status/status_macros.h"
 #include "stratum/hal/lib/tdi/es2k/es2k_sde_wrapper.h"
-#include "stratum/hal/lib/tdi/tdi_bf_status.h"
 #include "stratum/hal/lib/tdi/tdi_constants.h"
-#include "stratum/hal/lib/tdi/tdi_pkt_mod_meter_config.h"
-#include "stratum/hal/lib/tdi/tdi_sde_common.h"
 #include "stratum/hal/lib/tdi/tdi_sde_helpers.h"
 #include "stratum/hal/lib/tdi/tdi_sde_wrapper.h"
-#include "stratum/lib/macros.h"
-#include "stratum/public/proto/error.pb.h"
 
 namespace stratum {
 namespace hal {

--- a/stratum/hal/lib/tdi/es2k/es2k_sde_packetio.cc
+++ b/stratum/hal/lib/tdi/es2k/es2k_sde_packetio.cc
@@ -178,7 +178,7 @@ void Es2kSdeWrapper::PktIoTxCallback(
   pkts_info.pkt_len[0] = buffer.size();
   pkts_info.pkt_data[0] = pkt_buf;
 
-  ops->setValue(static_cast<const tdi_operations_field_type_e>(
+  ops->setValue(static_cast<tdi_operations_field_type_e>(
                     TDI_RT_OPERATIONS_TX_PKT_FIELD_TYPE_PKTS_INFO),
                 reinterpret_cast<uint64_t>(&pkts_info));
 

--- a/stratum/hal/lib/tdi/es2k/es2k_sde_wrapper.h
+++ b/stratum/hal/lib/tdi/es2k/es2k_sde_wrapper.h
@@ -1,5 +1,5 @@
 // Copyright 2019-present Barefoot Networks, Inc.
-// Copyright 2022-2023 Intel Corporation
+// Copyright 2022-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 #ifndef STRATUM_HAL_LIB_TDI_ES2K_SDE_WRAPPER_H_
@@ -8,6 +8,7 @@
 #include <string>
 
 #include "absl/synchronization/mutex.h"
+#include "ipu_types/ipu_types.h"
 #include "stratum/hal/lib/tdi/tdi.pb.h"
 #include "stratum/hal/lib/tdi/tdi_sde_wrapper.h"
 


### PR DESCRIPTION
- Updated es2k.BUILD to reflect wrenching changes in the ES2K SDE's public interface.

- Cleaned up target definition and #includes for es2k_sde_meter, which contained a significant number of copy-paste errors.

- Supplied a missing #include in es2k_sde_wrapper.h.

- Fixed a compile error in es2k_sde_packetio.cc.

This CL is based on PR #215. It will be rebased on `split-arch` once #215 has been merged.