### PR TITLE
Make tdi_pipeline_builder adapt dynamically to json change

### DIFF
--- a/stratum/hal/bin/tdi/tdi_pipeline_builder.cc
+++ b/stratum/hal/bin/tdi/tdi_pipeline_builder.cc
@@ -129,11 +129,11 @@ p4_device_config field of the P4Runtime SetForwardingPipelineConfig message.
     bf_config.set_p4_name(program["program-name"].get<std::string>());
     LOG(INFO) << "Found P4 program: " << bf_config.p4_name();
     std::string tdi_content;
-#ifdef ES2K_TARGET
-    RETURN_IF_ERROR(ReadFileToString(program["tdi-config"], &tdi_content));
-#else
-    RETURN_IF_ERROR(ReadFileToString(program["bfrt-config"], &tdi_content));
-#endif
+    if (program.contains("tdi-config")) {
+      RETURN_IF_ERROR(ReadFileToString(program["tdi-config"], &tdi_content));
+    } else {
+      RETURN_IF_ERROR(ReadFileToString(program["bfrt-config"], &tdi_content));
+    }
     bf_config.set_bfruntime_info(tdi_content);
     for (const auto& pipeline : program["p4_pipelines"]) {
       auto profile = bf_config.add_profiles();


### PR DESCRIPTION
The "bfrt-config" element in the json configuration file was recently renamed to "tdi-config" for the ES2K target. The change was implemented in `tdi_pipeline_builder` by using `#ifdef ES2K_TARGET` to select the element name.

This CL replaces the compile-time logic with run-time logic that checks first for a "tdi-config" element, and then falls back to "bfrt-config".

NOTE: This is an experimental change. It still needs to be tested.