### PR TITLE
Fix bug in Es2kSwitch::RegisterEventNotifyWriter

### DIFF
--- a/stratum/hal/lib/tdi/es2k/es2k_switch_test.cc
+++ b/stratum/hal/lib/tdi/es2k/es2k_switch_test.cc
@@ -1,6 +1,6 @@
 // Copyright 2018 Google LLC
 // Copyright 2018-present Open Networking Foundation
-// Copyright 2022-2023 Intel Corporation
+// Copyright 2022-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 // adapted from ipdk_switch_test, which was
@@ -149,19 +149,16 @@ TEST_F(Es2kSwitchTest, ShutdownFailsWhenSomeManagerShutdownFails) {
   EXPECT_THAT(switch_->Shutdown(), DerivedFromStatus(DefaultError()));
 }
 
-#if 0
 // Chassis config pushed successfully.
 // PushForwardingPipelineConfig() should propagate the config.
-TEST_F(Es2kSwitchTest, PushForwardingPipelineConfigSucceeds) {
+TEST_F(Es2kSwitchTest, DISABLED_PushForwardingPipelineConfigSucceeds) {
   PushChassisConfigSuccessfully();
 
   ::p4::v1::ForwardingPipelineConfig config;
-  EXPECT_CALL(*node_mock_,
-              PushForwardingPipelineConfig(EqualsProto(config)))
+  EXPECT_CALL(*node_mock_, PushForwardingPipelineConfig(EqualsProto(config)))
       .WillOnce(Return(::util::OkStatus()));
   EXPECT_OK(switch_->PushForwardingPipelineConfig(kNodeId, config));
 }
-#endif
 
 // When Es2kSwitchTest fails to push a forwarding config during
 // PushForwardingPipelineConfig(), it should fail immediately.
@@ -196,6 +193,7 @@ TEST_F(Es2kSwitchTest, RegisterEventNotifyWriterTest) {
 
   // Successful Es2kChassisManager registration.
   EXPECT_OK(switch_->RegisterEventNotifyWriter(writer));
+
   // Failed Es2kChassisManager registration.
   EXPECT_THAT(switch_->RegisterEventNotifyWriter(writer),
               DerivedFromStatus(DefaultError()));


### PR DESCRIPTION
- Es2kSwitchTest::RegisterEventNotifyWriterTest failed with the following error:

  stratum/hal/lib/tdi/es2k/es2k_switch_test.cc:198: Failure
  Value of: switch_->RegisterEventNotifyWriter(writer)
  Expected: derived from status StratumErrorSpace::ERR_UNKNOWN: Test error message
    Actual: StratumErrorSpace::ERR_INTERNAL:  Cannot register gNMI event writers (of type util::Status)

  It turns out that the IPsec modifications to the Es2kSwitch RegisterNotifyWriter() method changed both the status code and the message returned if an error occurred. This change in error semantics caused the unit test to fail.

  Revised Es2kSwitch::RegisterEvenNotifyWriter to forward the error status returned by ChassisManager and IpsecManager, restoring the original semantics and fixing the unit test.

- Disabled Es2kSwitchTest::PushForwardingPipelineConfigSucceeds instead of conditionalizing it out.

This CL is based on PR https://github.com/ipdk-io/stratum-dev/pull/218. It will be rebased on `split-arch` once #218 is merged.