### PR TITLE
Fix for Packet based counters for Direct Meters

### DIFF
--- a/stratum/hal/lib/tdi/tdi_table_manager.cc
+++ b/stratum/hal/lib/tdi/tdi_table_manager.cc
@@ -934,15 +934,15 @@ TdiTableManager::ReadDirectMeterEntry(
           ->set_policer_spec_ebs(static_cast<int64>(cfg.pburst));
       result.mutable_counter_data()->mutable_green()->set_byte_count(
           static_cast<int64>(cfg.greenBytes));
-      result.mutable_counter_data()->mutable_green()->set_byte_count(
+      result.mutable_counter_data()->mutable_green()->set_packet_count(
           static_cast<int64>(cfg.greenPackets));
       result.mutable_counter_data()->mutable_yellow()->set_byte_count(
           static_cast<int64>(cfg.yellowBytes));
-      result.mutable_counter_data()->mutable_yellow()->set_byte_count(
+      result.mutable_counter_data()->mutable_yellow()->set_packet_count(
           static_cast<int64>(cfg.yellowPackets));
       result.mutable_counter_data()->mutable_red()->set_byte_count(
           static_cast<int64>(cfg.redBytes));
-      result.mutable_counter_data()->mutable_red()->set_byte_count(
+      result.mutable_counter_data()->mutable_red()->set_packet_count(
           static_cast<int64>(cfg.redPackets));
     }
   }


### PR DESCRIPTION
Issue:
This fixes the issue where packet counters for direct meters show incorrect value (always 0).

Resolution:
ReadDirectMeterEntry() is responsible for get-direct-packet-mod-meter operation. Here I found out, that for both types of supported counter modes i.e PACKETS and BYTES, we are always setting up the byte_count. We have fetched both counters from the TDI, we are just not populating the response correctly. For byte counters, we need to use set_byte_count() and for packet counters, we need to use set_packet_count().
