### PR TITLE
Reduce log noise for common operations

### DIFF
--- a/stratum/glue/status/status_macros.h
+++ b/stratum/glue/status/status_macros.h
@@ -404,6 +404,19 @@ class UtilStatusConvertibleToBool {
     }                                                                        \
   } while (0)
 
+// Same functionality as RETURN_IF_ERROR, but without logging any messages
+//
+// Example:
+//   RETURN_IF_ERROR_WITHOUT_LOGGING(DoThings(4));
+#define RETURN_IF_ERROR_WITHOUT_LOGGING(expr)                                                \
+  do {                                                                       \
+    /* Using _status below to avoid capture problems if expr is "status". */ \
+    const ::util::Status _status = (expr);                                   \
+    if (ABSL_PREDICT_FALSE(!_status.ok())) {                                 \
+      return _status;                                                        \
+    }                                                                        \
+  } while (0)
+
 // This is like RETURN_IF_ERROR, but instead of propagating the existing error
 // Status, it constructs a new Status and can append additional messages.
 //

--- a/stratum/glue/status/status_macros.h
+++ b/stratum/glue/status/status_macros.h
@@ -408,7 +408,7 @@ class UtilStatusConvertibleToBool {
 //
 // Example:
 //   RETURN_IF_ERROR_WITHOUT_LOGGING(DoThings(4));
-#define RETURN_IF_ERROR_WITHOUT_LOGGING(expr)                                                \
+#define RETURN_IF_ERROR_WITHOUT_LOGGING(expr)                                \
   do {                                                                       \
     /* Using _status below to avoid capture problems if expr is "status". */ \
     const ::util::Status _status = (expr);                                   \

--- a/stratum/hal/lib/tdi/es2k/es2k_node.cc
+++ b/stratum/hal/lib/tdi/es2k/es2k_node.cc
@@ -152,7 +152,7 @@ std::unique_ptr<Es2kNode> Es2kNode::CreateInstance(
   RETURN_IF_ERROR(session->EndBatch());
 
   if (!success) {
-    return MAKE_ERROR(ERR_AT_LEAST_ONE_OPER_FAILED)
+    return MAKE_ERROR(ERR_AT_LEAST_ONE_OPER_FAILED).without_logging()
            << "One or more write operations failed.";
   }
 
@@ -275,7 +275,7 @@ std::unique_ptr<Es2kNode> Es2kNode::CreateInstance(
   }
   RET_CHECK(writer->Write(resp)) << "Write to stream channel failed.";
   if (!success) {
-    return MAKE_ERROR(ERR_AT_LEAST_ONE_OPER_FAILED)
+    return MAKE_ERROR(ERR_AT_LEAST_ONE_OPER_FAILED).without_logging()
            << "One or more read operations failed.";
   }
   return ::util::OkStatus();

--- a/stratum/hal/lib/tdi/tdi_sde_table_entry.cc
+++ b/stratum/hal/lib/tdi/tdi_sde_table_entry.cc
@@ -67,13 +67,13 @@ using namespace stratum::hal::tdi::helpers;
                                         flags, *real_table_key->table_key_,
                                         *real_table_data->table_data_);
   if (status == TDI_ALREADY_EXISTS) {
-    return MAKE_ERROR(::util::error::Code::ALREADY_EXISTS)
+    return MAKE_ERROR(::util::error::Code::ALREADY_EXISTS).without_logging()
            << "Duplicate table entry with " << dump_args();
   } else if (status == TDI_NO_SPACE) {
-    return MAKE_ERROR(::util::error::Code::RESOURCE_EXHAUSTED)
+    return MAKE_ERROR(::util::error::Code::RESOURCE_EXHAUSTED).without_logging()
            << "Table is already full. No space for " << dump_args();
   } else if (status != TDI_SUCCESS) {
-    return MAKE_ERROR(::util::error::Code::INTERNAL)
+    return MAKE_ERROR(::util::error::Code::INTERNAL).without_logging()
            << "Error adding table entry with " << dump_args();
   }
 

--- a/stratum/hal/lib/tdi/tdi_table_manager.cc
+++ b/stratum/hal/lib/tdi/tdi_table_manager.cc
@@ -330,15 +330,15 @@ std::unique_ptr<TdiTableManager> TdiTableManager::CreateInstance(
 
     switch (type) {
       case ::p4::v1::Update::INSERT:
-        RETURN_IF_ERROR(tdi_sde_interface_->InsertTableEntry(
+        RETURN_IF_ERROR_WITHOUT_LOGGING(tdi_sde_interface_->InsertTableEntry(
             device_, session, table_id, table_key.get(), table_data.get()));
         break;
       case ::p4::v1::Update::MODIFY:
-        RETURN_IF_ERROR(tdi_sde_interface_->ModifyTableEntry(
+        RETURN_IF_ERROR_WITHOUT_LOGGING(tdi_sde_interface_->ModifyTableEntry(
             device_, session, table_id, table_key.get(), table_data.get()));
         break;
       case ::p4::v1::Update::DELETE:
-        RETURN_IF_ERROR(tdi_sde_interface_->DeleteTableEntry(
+        RETURN_IF_ERROR_WITHOUT_LOGGING(tdi_sde_interface_->DeleteTableEntry(
             device_, session, table_id, table_key.get()));
         break;
       default:


### PR DESCRIPTION
Feedback received from other teams that logs are too noisy (and sometimes confusing) for common operations. This PR reduces the amount of logs. A log already exists from SDE layer when failures are encountered. This PR removes the logs from lower layers while keeping the higher layer log in p4_service.cc (in addition, user also gets feedback on the client side with details when it is a user-generated event).

Example:
A command adding a duplicate entry from `p4rt-ctl` results in 4 lines of log from various layers of Stratum: p4_service.cc, es2k_node.cc, tdi_table_manager.cc, and tdi_sde_table_entry.cc (in addition to the log from SDE layer, as seen in the first line below).

```
2024-03-29 08:20:37.301832 BF_PIPE ERROR - duplicate entry found in table = ipsec_tx_spd_table
E20240329 08:20:37.301975 297618 tdi_sde_table_entry.cc:70] generic::already_exists: Duplicate table entry with table_name: main.crypto_tunnel_control.ipsec_tx_spd_table, table_id: 44556728, table_type: 2048, tdi_table_key { hdrs.ipv4[meta.common.depth].dst_ip { field_id: 1 key_type: 1 field_size: 32 value: 0xC0000002 & 0xFFFFFFFF } $MATCH_PRIORITY { field_id: 2 key_type: 0 field_size: 32 value: 0x00FFFFFE } }, tdi_table_data { action_id: 21435079 }
E20240329 08:20:37.302067 297618 tdi_table_manager.cc:333] Return Error: tdi_sde_interface_->InsertTableEntry( device_, session, table_id, table_key.get(), table_data.get()) failed with generic::already_exists: Duplicate table entry with table_name: main.crypto_tunnel_control.ipsec_tx_spd_table, table_id: 44556728, table_type: 2048, tdi_table_key { hdrs.ipv4[meta.common.depth].dst_ip { field_id: 1 key_type: 1 field_size: 32 value: 0xC0000002 & 0xFFFFFFFF } $MATCH_PRIORITY { field_id: 2 key_type: 0 field_size: 32 value: 0x00FFFFFE } }, tdi_table_data { action_id: 21435079 }
E20240329 08:20:37.302172 297618 es2k_node.cc:155] StratumErrorSpace::ERR_AT_LEAST_ONE_OPER_FAILED: One or more write operations failed.
E20240329 08:20:37.302783 297618 p4_service.cc:353] Failed to write forwarding entries to node 1: One or more write operations failed.
```

After the log suppression applied in this PR:
```
2024-03-29 09:43:09.451739 BF_PIPE ERROR - duplicate entry found in table = ipsec_tx_spd_table
E20240329 09:43:09.452292 302989 p4_service.cc:353] Failed to write forwarding entries to node 1: One or more write operations failed.
```