### PR TITLE
Rename libp4_role_config to libp4_role_config_proto

### DIFF
--- a/stratum/lib/p4runtime/CMakeLists.txt
+++ b/stratum/lib/p4runtime/CMakeLists.txt
@@ -38,4 +38,4 @@ target_include_directories(p4runtime_session_o PUBLIC
     ${PB_OUT_DIR}
 )
 
-target_link_libraries(p4runtime_session_o PUBLIC stratum_proto p4_role_config)
+target_link_libraries(p4runtime_session_o PUBLIC stratum_proto p4_role_config_proto)

--- a/stratum/public/proto/CMakeLists.txt
+++ b/stratum/public/proto/CMakeLists.txt
@@ -4,23 +4,23 @@
 # SPDX-License-Identifier: Apache 2.0
 #
 
-########################
-# Build p4_role_config #
-########################
+##############################
+# Build p4_role_config_proto #
+##############################
 
 generate_proto_files(
   "stratum/public/proto/p4_role_config.proto"
   "${STRATUM_SOURCE_DIR}"
 )
 
-add_library(p4_role_config SHARED
+add_library(p4_role_config_proto SHARED
   ${PB_OUT_DIR}/stratum/public/proto/p4_role_config.pb.cc
   ${PB_OUT_DIR}/stratum/public/proto/p4_role_config.pb.h
 )
 
-target_include_directories(p4_role_config PUBLIC ${PB_OUT_DIR})
+target_include_directories(p4_role_config_proto PUBLIC ${PB_OUT_DIR})
 
-install(TARGETS p4_role_config LIBRARY)
+install(TARGETS p4_role_config_proto LIBRARY)
 
 #######################
 # Build error_proto_o #

--- a/stratum/tools/p4_pipeline_pusher/CMakeLists.txt
+++ b/stratum/tools/p4_pipeline_pusher/CMakeLists.txt
@@ -19,6 +19,6 @@ target_link_libraries(p4_pipeline_pusher PUBLIC
     $<TARGET_OBJECTS:p4runtime_session_o>
 )
 
-target_link_libraries(p4_pipeline_pusher PUBLIC p4_role_config)
+target_link_libraries(p4_pipeline_pusher PUBLIC p4_role_config_proto)
 
 install(TARGETS p4_pipeline_pusher RUNTIME)


### PR DESCRIPTION
- Renamed library for consistency with other protobuf libraries.

This PR is paired with https://github.com/ipdk-io/networking-recipe/pull/449.