### PR TITLE
Implement tdi_port_manager.cc

### DIFF
--- a/stratum/hal/lib/tdi/BUILD
+++ b/stratum/hal/lib/tdi/BUILD
@@ -2,7 +2,7 @@
 
 # Copyright 2018 Google LLC
 # Copyright 2018-present Open Networking Foundation
-# Copyright 2022-2023 Intel Corporation
+# Copyright 2022-2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
 load("@rules_proto//proto:defs.bzl", "proto_library")
@@ -273,6 +273,7 @@ stratum_cc_library(
 
 stratum_cc_library(
     name = "tdi_port_manager",
+    srcs = ["tdi_port_manager.cc"],
     hdrs = ["tdi_port_manager.h"],
     deps = [
         "//stratum/glue/status",

--- a/stratum/hal/lib/tdi/CMakeLists.txt
+++ b/stratum/hal/lib/tdi/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Build file for //stratum/hal/lib/tdi
 #
-# Copyright 2022-2023 Intel Corporation
+# Copyright 2022-2024 Intel Corporation
 # SPDX-License-Identifier: Apache 2.0
 #
 
@@ -24,6 +24,7 @@ add_library(stratum_tdi_common_o OBJECT
     tdi_packetio_manager.h
     tdi_pipeline_utils.cc
     tdi_pipeline_utils.h
+    tdi_port_manager.cc
     tdi_port_manager.h
     tdi_pre_manager.cc
     tdi_pre_manager.h

--- a/stratum/hal/lib/tdi/dpdk/dpdk_port_manager.cc
+++ b/stratum/hal/lib/tdi/dpdk/dpdk_port_manager.cc
@@ -1,5 +1,5 @@
 // Copyright 2019-present Barefoot Networks, Inc.
-// Copyright 2022-2023 Intel Corporation
+// Copyright 2022-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 // DPDK-specific port manager methods.
@@ -35,13 +35,7 @@ namespace stratum {
 namespace hal {
 namespace tdi {
 
-constexpr absl::Duration DpdkPortManager::kWriteTimeout;
-constexpr int32 DpdkPortManager::kBfDefaultMtu;
-
 DpdkPortManager* DpdkPortManager::singleton_ = nullptr;
-ABSL_CONST_INIT absl::Mutex DpdkPortManager::init_lock_(absl::kConstInit);
-
-DpdkPortManager::DpdkPortManager() : port_status_event_writer_(nullptr) {}
 
 DpdkPortManager* DpdkPortManager::CreateSingleton() {
   absl::WriterMutexLock l(&init_lock_);
@@ -83,19 +77,6 @@ DpdkPortManager* DpdkPortManager::GetSingleton() {
   counters->set_out_errors(stats[TX_ERRORS]);
   counters->set_in_fcs_errors(0);
 
-  return ::util::OkStatus();
-}
-
-::util::Status DpdkPortManager::RegisterPortStatusEventWriter(
-    std::unique_ptr<ChannelWriter<PortStatusEvent>> writer) {
-  absl::WriterMutexLock l(&port_status_event_writer_lock_);
-  port_status_event_writer_ = std::move(writer);
-  return ::util::OkStatus();
-}
-
-::util::Status DpdkPortManager::UnregisterPortStatusEventWriter() {
-  absl::WriterMutexLock l(&port_status_event_writer_lock_);
-  port_status_event_writer_ = nullptr;
   return ::util::OkStatus();
 }
 

--- a/stratum/hal/lib/tdi/dpdk/dpdk_port_manager.h
+++ b/stratum/hal/lib/tdi/dpdk/dpdk_port_manager.h
@@ -1,5 +1,5 @@
 // Copyright 2020-present Open Networking Foundation
-// Copyright 2022-2023 Intel Corporation
+// Copyright 2022-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 #ifndef STRATUM_HAL_LIB_TDI_DPDK_PORT_MANAGER_H_
@@ -55,16 +55,10 @@ class DpdkPortManager : public TdiPortManager {
     QemuHotplugMode qemu_hotplug_mode;
   };
 
-  DpdkPortManager();
+  DpdkPortManager() {}
+  virtual ~DpdkPortManager() {}
 
   // ---------- Common public methods ----------
-
-  ::util::Status RegisterPortStatusEventWriter(
-      std::unique_ptr<ChannelWriter<PortStatusEvent>> writer)
-      LOCKS_EXCLUDED(port_status_event_writer_lock_);
-
-  ::util::Status UnregisterPortStatusEventWriter()
-      LOCKS_EXCLUDED(port_status_event_writer_lock_);
 
   ::util::Status GetPortInfo(int device, int port,
                              TargetDatapathId* target_dp_id);
@@ -122,28 +116,8 @@ class DpdkPortManager : public TdiPortManager {
       LOCKS_EXCLUDED(port_status_event_writer_lock_);
 
  protected:
-  // RW mutex lock for protecting the singleton instance initialization and
-  // reading it back from other threads. Unlike other singleton classes, we
-  // use RW lock as we need the pointer to class to be returned.
-  static absl::Mutex init_lock_;
-
   // The singleton instance.
   static DpdkPortManager* singleton_ GUARDED_BY(init_lock_);
-
- private:
-  // Timeout for Write() operations on port status events.
-  static constexpr absl::Duration kWriteTimeout = absl::InfiniteDuration();
-
-  // Default MTU for ports.
-  static constexpr int32 kBfDefaultMtu = 10 * 1024;  // 10K
-
-  // RM Mutex to protect the port status writer.
-  mutable absl::Mutex port_status_event_writer_lock_;
-
-  // Writer to forward the port status change message to. It is registered
-  // by chassis manager to receive SDE port status change events.
-  std::unique_ptr<ChannelWriter<PortStatusEvent>> port_status_event_writer_
-      GUARDED_BY(port_status_event_writer_lock_);
 };
 
 }  // namespace tdi

--- a/stratum/hal/lib/tdi/dpdk/dpdk_port_manager_dummy.cc
+++ b/stratum/hal/lib/tdi/dpdk/dpdk_port_manager_dummy.cc
@@ -16,13 +16,7 @@ namespace stratum {
 namespace hal {
 namespace tdi {
 
-constexpr absl::Duration DpdkPortManager::kWriteTimeout;
-constexpr int32 DpdkPortManager::kBfDefaultMtu;
-
 DpdkPortManager* DpdkPortManager::singleton_ = nullptr;
-ABSL_CONST_INIT absl::Mutex DpdkPortManager::init_lock_(absl::kConstInit);
-
-DpdkPortManager::DpdkPortManager() : port_status_event_writer_(nullptr) {}
 
 DpdkPortManager* DpdkPortManager::CreateSingleton() {
   absl::WriterMutexLock l(&init_lock_);
@@ -59,19 +53,6 @@ DpdkPortManager* DpdkPortManager::GetSingleton() {
   counters->set_in_errors(89);
   counters->set_out_errors(144);
   counters->set_in_fcs_errors(233);
-  return ::util::OkStatus();
-}
-
-::util::Status DpdkPortManager::RegisterPortStatusEventWriter(
-    std::unique_ptr<ChannelWriter<PortStatusEvent>> writer) {
-  absl::WriterMutexLock l(&port_status_event_writer_lock_);
-  port_status_event_writer_ = std::move(writer);
-  return ::util::OkStatus();
-}
-
-::util::Status DpdkPortManager::UnregisterPortStatusEventWriter() {
-  absl::WriterMutexLock l(&port_status_event_writer_lock_);
-  port_status_event_writer_ = nullptr;
   return ::util::OkStatus();
 }
 

--- a/stratum/hal/lib/tdi/es2k/es2k_port_manager.cc
+++ b/stratum/hal/lib/tdi/es2k/es2k_port_manager.cc
@@ -206,21 +206,6 @@ bool Es2kPortManager::IsValidPort(int device, int port) { return IPU_SUCCESS; }
   return static_cast<uint32>(dev_port);
 }
 
-::util::StatusOr<int> Es2kPortManager::GetPcieCpuPort(int device) {
-  int port = 0;
-  return port;
-}
-
-::util::Status Es2kPortManager::SetTmCpuPort(int device, int port) {
-  return ::util::OkStatus();
-}
-
-::util::Status Es2kPortManager::SetDeflectOnDropDestination(int device,
-                                                            int port,
-                                                            int queue) {
-  return ::util::OkStatus();
-}
-
 }  // namespace tdi
 }  // namespace hal
 }  // namespace stratum

--- a/stratum/hal/lib/tdi/es2k/es2k_port_manager.cc
+++ b/stratum/hal/lib/tdi/es2k/es2k_port_manager.cc
@@ -1,5 +1,5 @@
 // Copyright 2019-present Barefoot Networks, Inc.
-// Copyright 2022-2023 Intel Corporation
+// Copyright 2022-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 // ES2K-specific port methods.
@@ -38,13 +38,7 @@ namespace stratum {
 namespace hal {
 namespace tdi {
 
-constexpr absl::Duration Es2kPortManager::kWriteTimeout;
-constexpr int32 Es2kPortManager::kBfDefaultMtu;
-
 Es2kPortManager* Es2kPortManager::singleton_ = nullptr;
-ABSL_CONST_INIT absl::Mutex Es2kPortManager::init_lock_(absl::kConstInit);
-
-Es2kPortManager::Es2kPortManager() : port_status_event_writer_(nullptr) {}
 
 namespace {
 
@@ -120,19 +114,6 @@ Es2kPortManager* Es2kPortManager::GetSingleton() {
     }
     return port_status_event_writer_->Write(event, kWriteTimeout);
   }
-}
-
-::util::Status Es2kPortManager::RegisterPortStatusEventWriter(
-    std::unique_ptr<ChannelWriter<PortStatusEvent>> writer) {
-  absl::WriterMutexLock l(&port_status_event_writer_lock_);
-  port_status_event_writer_ = std::move(writer);
-  return ::util::OkStatus();
-}
-
-::util::Status Es2kPortManager::UnregisterPortStatusEventWriter() {
-  absl::WriterMutexLock l(&port_status_event_writer_lock_);
-  port_status_event_writer_ = nullptr;
-  return ::util::OkStatus();
 }
 
 ::util::Status Es2kPortManager::GetPortInfo(int device, int port,

--- a/stratum/hal/lib/tdi/es2k/es2k_port_manager.h
+++ b/stratum/hal/lib/tdi/es2k/es2k_port_manager.h
@@ -51,10 +51,6 @@ class Es2kPortManager : public TdiPortManager {
   virtual ::util::Status SetPortMtu(int device, int port, int32 mtu);
   virtual ::util::Status SetPortLoopbackMode(int uint, int port,
                                              LoopbackState loopback_mode);
-  virtual ::util::StatusOr<int> GetPcieCpuPort(int device);
-  virtual ::util::Status SetTmCpuPort(int device, int port);
-  virtual ::util::Status SetDeflectOnDropDestination(int device, int port,
-                                                     int queue);
 
   // Creates the singleton instance. Expected to be called once to initialize
   // the instance.

--- a/stratum/hal/lib/tdi/es2k/es2k_port_manager.h
+++ b/stratum/hal/lib/tdi/es2k/es2k_port_manager.h
@@ -1,5 +1,5 @@
 // Copyright 2020-present Open Networking Foundation
-// Copyright 2022 Intel Corporation
+// Copyright 2022-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 #ifndef STRATUM_HAL_LIB_TDI_ES2K_PORT_MANAGER_H_
@@ -23,15 +23,10 @@ namespace tdi {
 
 class Es2kPortManager : public TdiPortManager {
  public:
-  Es2kPortManager();
+  Es2kPortManager() {}
+  virtual ~Es2kPortManager() {}
 
   // ---------- Common public methods ----------
-
-  ::util::Status RegisterPortStatusEventWriter(
-      std::unique_ptr<ChannelWriter<PortStatusEvent>> writer)
-      LOCKS_EXCLUDED(port_status_event_writer_lock_);
-  ::util::Status UnregisterPortStatusEventWriter()
-      LOCKS_EXCLUDED(port_status_event_writer_lock_);
 
   ::util::Status GetPortInfo(int device, int port,
                              TargetDatapathId* target_dp_id);
@@ -79,28 +74,8 @@ class Es2kPortManager : public TdiPortManager {
       LOCKS_EXCLUDED(port_status_event_writer_lock_);
 
  protected:
-  // RW mutex lock for protecting the singleton instance initialization and
-  // reading it back from other threads. Unlike other singleton classes, we
-  // use RW lock as we need the pointer to class to be returned.
-  static absl::Mutex init_lock_;
-
   // The singleton instance.
   static Es2kPortManager* singleton_ GUARDED_BY(init_lock_);
-
- private:
-  // Timeout for Write() operations on port status events.
-  static constexpr absl::Duration kWriteTimeout = absl::InfiniteDuration();
-
-  // Default MTU for ports on ES2K.
-  static constexpr int32 kBfDefaultMtu = 10 * 1024;  // 10K
-
-  // RM Mutex to protect the port status writer.
-  mutable absl::Mutex port_status_event_writer_lock_;
-
-  // Writer to forward the port status change message to. It is registered
-  // by chassis manager to receive port status change events.
-  std::unique_ptr<ChannelWriter<PortStatusEvent>> port_status_event_writer_
-      GUARDED_BY(port_status_event_writer_lock_);
 };
 
 }  // namespace tdi

--- a/stratum/hal/lib/tdi/es2k/es2k_port_manager_dummy.cc
+++ b/stratum/hal/lib/tdi/es2k/es2k_port_manager_dummy.cc
@@ -20,13 +20,7 @@ namespace stratum {
 namespace hal {
 namespace tdi {
 
-constexpr absl::Duration Es2kPortManager::kWriteTimeout;
-constexpr int32 Es2kPortManager::kBfDefaultMtu;
-
 Es2kPortManager* Es2kPortManager::singleton_ = nullptr;
-ABSL_CONST_INIT absl::Mutex Es2kPortManager::init_lock_(absl::kConstInit);
-
-Es2kPortManager::Es2kPortManager() : port_status_event_writer_(nullptr) {}
 
 Es2kPortManager* Es2kPortManager::CreateSingleton() {
   absl::WriterMutexLock l(&init_lock_);
@@ -53,19 +47,6 @@ Es2kPortManager* Es2kPortManager::GetSingleton() {
 
 ::util::Status Es2kPortManager::OnPortStatusEvent(int device, int port, bool up,
                                                   absl::Time timestamp) {
-  return ::util::OkStatus();
-}
-
-::util::Status Es2kPortManager::RegisterPortStatusEventWriter(
-    std::unique_ptr<ChannelWriter<PortStatusEvent>> writer) {
-  absl::WriterMutexLock l(&port_status_event_writer_lock_);
-  port_status_event_writer_ = std::move(writer);
-  return ::util::OkStatus();
-}
-
-::util::Status Es2kPortManager::UnregisterPortStatusEventWriter() {
-  absl::WriterMutexLock l(&port_status_event_writer_lock_);
-  port_status_event_writer_ = nullptr;
   return ::util::OkStatus();
 }
 

--- a/stratum/hal/lib/tdi/es2k/es2k_port_manager_dummy.cc
+++ b/stratum/hal/lib/tdi/es2k/es2k_port_manager_dummy.cc
@@ -1,5 +1,5 @@
 // Copyright 2019-present Barefoot Networks, Inc.
-// Copyright 2022-2023 Intel Corporation
+// Copyright 2022-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 // Dummy implementation of ES2K Port Manager.
@@ -101,20 +101,6 @@ bool Es2kPortManager::IsValidPort(int device, int port) { return true; }
 ::util::StatusOr<uint32> Es2kPortManager::GetPortIdFromPortKey(
     int device, const PortKey& port_key) {
   return 43;
-}
-
-::util::StatusOr<int> Es2kPortManager::GetPcieCpuPort(int device) {
-  return 1776;
-}
-
-::util::Status Es2kPortManager::SetTmCpuPort(int device, int port) {
-  return ::util::OkStatus();
-}
-
-::util::Status Es2kPortManager::SetDeflectOnDropDestination(int device,
-                                                            int port,
-                                                            int queue) {
-  return ::util::OkStatus();
 }
 
 }  // namespace tdi

--- a/stratum/hal/lib/tdi/es2k/es2k_port_manager_mock.h
+++ b/stratum/hal/lib/tdi/es2k/es2k_port_manager_mock.h
@@ -1,5 +1,5 @@
 // Copyright 2020-present Open Networking Foundation
-// Copyright 2022-2023 Intel Corporation
+// Copyright 2022-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 #ifndef STRATUM_HAL_LIB_TDI_ES2K_PORT_MANAGER_MOCK_H_
@@ -62,13 +62,6 @@ class Es2kPortManagerMock : public Es2kPortManager {
 
   MOCK_METHOD(::util::Status, SetPortLoopbackMode,
               (int uint, int port, LoopbackState loopback_mode), (override));
-
-  MOCK_METHOD(::util::StatusOr<int>, GetPcieCpuPort, (int device), (override));
-
-  MOCK_METHOD(::util::Status, SetTmCpuPort, (int device, int port), (override));
-
-  MOCK_METHOD(::util::Status, SetDeflectOnDropDestination,
-              (int device, int port, int queue), (override));
 };
 
 }  // namespace tdi

--- a/stratum/hal/lib/tdi/tdi_port_manager.cc
+++ b/stratum/hal/lib/tdi/tdi_port_manager.cc
@@ -4,8 +4,8 @@
 
 #include "stratum/hal/lib/tdi/tdi_port_manager.h"
 
-#include "absl/time/time.h"
 #include "absl/synchronization/mutex.h"
+#include "absl/time/time.h"
 #include "stratum/glue/integral_types.h"
 #include "stratum/lib/channel/channel.h"
 

--- a/stratum/hal/lib/tdi/tdi_port_manager.cc
+++ b/stratum/hal/lib/tdi/tdi_port_manager.cc
@@ -1,0 +1,38 @@
+// Copyright 2020-present Open Networking Foundation
+// Copyright 2022-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#include "stratum/hal/lib/tdi/tdi_port_manager.h"
+
+#include "absl/time/time.h"
+#include "absl/synchronization/mutex.h"
+#include "stratum/glue/integral_types.h"
+#include "stratum/lib/channel/channel.h"
+
+namespace stratum {
+namespace hal {
+namespace tdi {
+
+constexpr absl::Duration TdiPortManager::kWriteTimeout;
+constexpr int32 TdiPortManager::kBfDefaultMtu;
+
+ABSL_CONST_INIT absl::Mutex TdiPortManager::init_lock_(absl::kConstInit);
+
+TdiPortManager::TdiPortManager() : port_status_event_writer_(nullptr) {}
+
+::util::Status TdiPortManager::RegisterPortStatusEventWriter(
+    std::unique_ptr<ChannelWriter<PortStatusEvent>> writer) {
+  absl::WriterMutexLock l(&port_status_event_writer_lock_);
+  port_status_event_writer_ = std::move(writer);
+  return ::util::OkStatus();
+}
+
+::util::Status TdiPortManager::UnregisterPortStatusEventWriter() {
+  absl::WriterMutexLock l(&port_status_event_writer_lock_);
+  port_status_event_writer_ = nullptr;
+  return ::util::OkStatus();
+}
+
+}  // namespace tdi
+}  // namespace hal
+}  // namespace stratum

--- a/stratum/hal/lib/tdi/tdi_port_manager.cc
+++ b/stratum/hal/lib/tdi/tdi_port_manager.cc
@@ -14,7 +14,6 @@ namespace hal {
 namespace tdi {
 
 constexpr absl::Duration TdiPortManager::kWriteTimeout;
-constexpr int32 TdiPortManager::kBfDefaultMtu;
 
 ABSL_CONST_INIT absl::Mutex TdiPortManager::init_lock_(absl::kConstInit);
 

--- a/stratum/hal/lib/tdi/tdi_port_manager.h
+++ b/stratum/hal/lib/tdi/tdi_port_manager.h
@@ -81,9 +81,6 @@ class TdiPortManager {
   // Timeout for Write() operations on port status events.
   static constexpr absl::Duration kWriteTimeout = absl::InfiniteDuration();
 
-  // Default MTU for ports on ES2K.
-  static constexpr int32 kBfDefaultMtu = 10 * 1024;  // 10K
-
   // RW Mutex to protect the port status writer.
   mutable absl::Mutex port_status_event_writer_lock_;
 

--- a/stratum/hal/lib/tdi/tofino/BUILD
+++ b/stratum/hal/lib/tdi/tofino/BUILD
@@ -2,7 +2,7 @@
 
 # Copyright 2018 Google LLC
 # Copyright 2018-present Open Networking Foundation
-# Copyright 2022-2023 Intel Corporation
+# Copyright 2022-2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
 load(
@@ -73,6 +73,7 @@ stratum_cc_library(
     testonly = 1,
     hdrs = ["tofino_port_manager_mock.h"],
     deps = [
+        ":tofino_port_manager",
         ":tofino_port_manager_dummy",
         "@com_google_googletest//:gtest",
     ],

--- a/stratum/hal/lib/tdi/tofino/tofino_port_manager.cc
+++ b/stratum/hal/lib/tdi/tofino/tofino_port_manager.cc
@@ -1,5 +1,5 @@
 // Copyright 2019-present Barefoot Networks, Inc.
-// Copyright 2022-2023 Intel Corporation
+// Copyright 2022-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 // Tofino-specific SDE port methods.
@@ -41,13 +41,7 @@ namespace stratum {
 namespace hal {
 namespace tdi {
 
-constexpr absl::Duration TofinoPortManager::kWriteTimeout;
-constexpr int32 TofinoPortManager::kBfDefaultMtu;
-
 TofinoPortManager* TofinoPortManager::singleton_ = nullptr;
-ABSL_CONST_INIT absl::Mutex TofinoPortManager::init_lock_(absl::kConstInit);
-
-TofinoPortManager::TofinoPortManager() : port_status_event_writer_(nullptr) {}
 
 namespace {
 
@@ -215,12 +209,6 @@ TofinoPortManager* TofinoPortManager::GetSingleton() {
   port_status_event_writer_ = std::move(writer);
   RETURN_IF_TDI_ERROR(
       bf_pal_port_status_notif_reg(sde_port_status_callback, nullptr));
-  return ::util::OkStatus();
-}
-
-::util::Status TofinoPortManager::UnregisterPortStatusEventWriter() {
-  absl::WriterMutexLock l(&port_status_event_writer_lock_);
-  port_status_event_writer_ = nullptr;
   return ::util::OkStatus();
 }
 

--- a/stratum/hal/lib/tdi/tofino/tofino_port_manager.cc
+++ b/stratum/hal/lib/tdi/tofino/tofino_port_manager.cc
@@ -42,6 +42,7 @@ namespace hal {
 namespace tdi {
 
 TofinoPortManager* TofinoPortManager::singleton_ = nullptr;
+constexpr int32 TofinoPortManager::kBfDefaultMtu;
 
 namespace {
 

--- a/stratum/hal/lib/tdi/tofino/tofino_port_manager.h
+++ b/stratum/hal/lib/tdi/tofino/tofino_port_manager.h
@@ -1,5 +1,5 @@
 // Copyright 2020-present Open Networking Foundation
-// Copyright 2022-2023 Intel Corporation
+// Copyright 2022-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 #ifndef STRATUM_HAL_LIB_TDI_TOFINO_TOFINO_PORT_MANAGER_H_
@@ -20,14 +20,12 @@ namespace tdi {
 
 class TofinoPortManager : public TdiPortManager {
  public:
-  TofinoPortManager();
+  TofinoPortManager() {}
   virtual ~TofinoPortManager() {}
 
   // TdiPortManager public methods
   ::util::Status RegisterPortStatusEventWriter(
-      std::unique_ptr<ChannelWriter<PortStatusEvent>> writer)
-      LOCKS_EXCLUDED(port_status_event_writer_lock_);
-  ::util::Status UnregisterPortStatusEventWriter()
+      std::unique_ptr<ChannelWriter<PortStatusEvent>> writer) override
       LOCKS_EXCLUDED(port_status_event_writer_lock_);
   ::util::Status GetPortInfo(int device, int port,
                              TargetDatapathId* target_dp_id);
@@ -77,28 +75,8 @@ class TofinoPortManager : public TdiPortManager {
       LOCKS_EXCLUDED(port_status_event_writer_lock_);
 
  protected:
-  // RW mutex lock for protecting the singleton instance initialization and
-  // reading it back from other threads. Unlike other singleton classes, we
-  // use RW lock as we need the pointer to class to be returned.
-  static absl::Mutex init_lock_;
-
   // The singleton instance.
   static TofinoPortManager* singleton_ GUARDED_BY(init_lock_);
-
- private:
-  // Timeout for Write() operations on port status events.
-  static constexpr absl::Duration kWriteTimeout = absl::InfiniteDuration();
-
-  // Default MTU for ports on Tofino.
-  static constexpr int32 kBfDefaultMtu = 10 * 1024;  // 10K
-
-  // RM Mutex to protect the port status writer.
-  mutable absl::Mutex port_status_event_writer_lock_;
-
-  // Writer to forward the port status change message to. It is registered
-  // by chassis manager to receive SDE port status change events.
-  std::unique_ptr<ChannelWriter<PortStatusEvent>> port_status_event_writer_
-      GUARDED_BY(port_status_event_writer_lock_);
 };
 
 }  // namespace tdi

--- a/stratum/hal/lib/tdi/tofino/tofino_port_manager.h
+++ b/stratum/hal/lib/tdi/tofino/tofino_port_manager.h
@@ -75,11 +75,12 @@ class TofinoPortManager : public TdiPortManager {
       LOCKS_EXCLUDED(port_status_event_writer_lock_);
 
  protected:
-  // Default MTU for Tofino ports.
-  static constexpr int32 kBfDefaultMtu = 10 * 1024;  // 10K
-
   // The singleton instance.
   static TofinoPortManager* singleton_ GUARDED_BY(init_lock_);
+
+ private:
+  // Default MTU for Tofino ports.
+  static constexpr int32 kBfDefaultMtu = 10 * 1024;  // 10K
 };
 
 }  // namespace tdi

--- a/stratum/hal/lib/tdi/tofino/tofino_port_manager.h
+++ b/stratum/hal/lib/tdi/tofino/tofino_port_manager.h
@@ -75,6 +75,9 @@ class TofinoPortManager : public TdiPortManager {
       LOCKS_EXCLUDED(port_status_event_writer_lock_);
 
  protected:
+  // Default MTU for Tofino ports.
+  static constexpr int32 kBfDefaultMtu = 10 * 1024;  // 10K
+
   // The singleton instance.
   static TofinoPortManager* singleton_ GUARDED_BY(init_lock_);
 };

--- a/stratum/hal/lib/tdi/tofino/tofino_port_manager_dummy.cc
+++ b/stratum/hal/lib/tdi/tofino/tofino_port_manager_dummy.cc
@@ -20,13 +20,7 @@ namespace stratum {
 namespace hal {
 namespace tdi {
 
-constexpr absl::Duration TofinoPortManager::kWriteTimeout;
-constexpr int32 TofinoPortManager::kBfDefaultMtu;
-
 TofinoPortManager* TofinoPortManager::singleton_ = nullptr;
-ABSL_CONST_INIT absl::Mutex TofinoPortManager::init_lock_(absl::kConstInit);
-
-TofinoPortManager::TofinoPortManager() : port_status_event_writer_(nullptr) {}
 
 TofinoPortManager* TofinoPortManager::CreateSingleton() {
   absl::WriterMutexLock l(&init_lock_);
@@ -69,19 +63,6 @@ TofinoPortManager* TofinoPortManager::GetSingleton() {
 ::util::Status TofinoPortManager::OnPortStatusEvent(int device, int port,
                                                     bool up,
                                                     absl::Time timestamp) {
-  return ::util::OkStatus();
-}
-
-::util::Status TofinoPortManager::RegisterPortStatusEventWriter(
-    std::unique_ptr<ChannelWriter<PortStatusEvent>> writer) {
-  absl::WriterMutexLock l(&port_status_event_writer_lock_);
-  port_status_event_writer_ = std::move(writer);
-  return ::util::OkStatus();
-}
-
-::util::Status TofinoPortManager::UnregisterPortStatusEventWriter() {
-  absl::WriterMutexLock l(&port_status_event_writer_lock_);
-  port_status_event_writer_ = nullptr;
   return ::util::OkStatus();
 }
 


### PR DESCRIPTION
- Converted TdiPortManager from an abstract class to a base class.
- Moved common definitions from subclasses to the base class.
- Eliminated vestigial Es2kPortManager methods.