### PR TITLE
Replace static variables with instance variable

### DIFF
--- a/stratum/hal/lib/tdi/es2k/es2k_node.h
+++ b/stratum/hal/lib/tdi/es2k/es2k_node.h
@@ -110,6 +110,9 @@ class Es2kNode : public TdiNode {
   TdiPreManager* tdi_pre_manager_;
   TdiCounterManager* tdi_counter_manager_;
 
+  // Persistent session used by WriteForwardingEntries.
+  std::shared_ptr<TdiSdeInterface::SessionInterface> _forwarding_session;
+
   // Logical node ID corresponding to the node/ASIC managed by this class
   // instance. Assigned on PushChassisConfig() and might change during the
   // lifetime of the class.


### PR DESCRIPTION
This PR addresses one of the issues raised during the review of PR https://github.com/ipdk-io/stratum-dev/pull/228.

Note that it uses the Boolean property of the `shared_ptr`, rather than a discrete Boolean variable, to determine whether the pointer has been initialized.