### PR TITLE
Implement flag to enable sticky TDI sessions

### DIFF
--- a/stratum/hal/lib/tdi/es2k/BUILD
+++ b/stratum/hal/lib/tdi/es2k/BUILD
@@ -2,7 +2,7 @@
 
 # Copyright 2018 Google LLC
 # Copyright 2018-present Open Networking Foundation
-# Copyright 2022-2023 Intel Corporation
+# Copyright 2022-2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
 load(
@@ -52,6 +52,7 @@ stratum_cc_library(
     hdrs = ["es2k_node.h"],
     deps = [
         "//stratum/hal/lib/tdi:tdi_node",
+        "@com_github_gflags_gflags//:gflags",
     ],
 )
 

--- a/stratum/hal/lib/tdi/es2k/es2k_node.cc
+++ b/stratum/hal/lib/tdi/es2k/es2k_node.cc
@@ -1,5 +1,5 @@
 // Copyright 2020-present Open Networking Foundation
-// Copyright 2022-2023 Intel Corporation
+// Copyright 2022-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 #include "stratum/hal/lib/tdi/es2k/es2k_node.h"
@@ -11,6 +11,7 @@
 #include <utility>
 
 #include "absl/memory/memory.h"
+#include "gflags/gflags.h"
 #include "stratum/glue/status/status_macros.h"
 #include "stratum/hal/lib/common/proto_oneof_writer_wrapper.h"
 #include "stratum/hal/lib/common/writer_interface.h"
@@ -21,6 +22,9 @@
 #include "stratum/lib/macros.h"
 #include "stratum/lib/utils.h"
 #include "stratum/public/proto/error.pb.h"
+
+DEFINE_bool(enable_sticky_tdi_session, false,
+            "Use persistent TDI session to write forwarding entries");
 
 namespace stratum {
 namespace hal {
@@ -90,11 +94,18 @@ std::unique_ptr<Es2kNode> Es2kNode::CreateInstance(
     return MAKE_ERROR(ERR_NOT_INITIALIZED) << "Not initialized!";
   }
 
-  if (!_forwarding_session) {
-    ASSIGN_OR_RETURN(auto session, tdi_sde_interface_->CreateSession());
-    _forwarding_session = session;
+  std::shared_ptr<TdiSdeInterface::SessionInterface> session;
+  if (!FLAGS_enable_sticky_tdi_session) {
+    // Use transient TDI session.
+    ASSIGN_OR_RETURN(session, tdi_sde_interface_->CreateSession());
+  } else if (forwarding_session_) {
+    // Use persistent TDI session.
+    session = forwarding_session_;
+  } else {
+    // Create persistent TDI session.
+    ASSIGN_OR_RETURN(session, tdi_sde_interface_->CreateSession());
+    forwarding_session_ = session;
   }
-  auto session = _forwarding_session;
 
   bool success = true;
   RETURN_IF_ERROR(session->BeginBatch());
@@ -151,7 +162,7 @@ std::unique_ptr<Es2kNode> Es2kNode::CreateInstance(
                  << "Unsupported entity type: " << update.ShortDebugString();
         break;
     }
-    success &&= status.ok();
+    success &= status.ok();
     results->push_back(status);
   }
   RETURN_IF_ERROR(session->EndBatch());

--- a/stratum/hal/lib/tdi/es2k/es2k_node.h
+++ b/stratum/hal/lib/tdi/es2k/es2k_node.h
@@ -1,5 +1,5 @@
 // Copyright 2020-present Open Networking Foundation
-// Copyright 2022-2023 Intel Corporation
+// Copyright 2022-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 #ifndef STRATUM_HAL_LIB_TDI_ES2K_ES2K_NODE_H_
@@ -110,8 +110,8 @@ class Es2kNode : public TdiNode {
   TdiPreManager* tdi_pre_manager_;
   TdiCounterManager* tdi_counter_manager_;
 
-  // Persistent session used by WriteForwardingEntries.
-  std::shared_ptr<TdiSdeInterface::SessionInterface> _forwarding_session;
+  // Persistent TDI session used by WriteForwardingEntries.
+  std::shared_ptr<TdiSdeInterface::SessionInterface> forwarding_session_;
 
   // Logical node ID corresponding to the node/ASIC managed by this class
   // instance. Assigned on PushChassisConfig() and might change during the


### PR DESCRIPTION
- Implemented an --enable_sticky_tdi_session flag to enable the use of a persistent TDI session for WriteForwardingEntries requests. It is disabled (false) by default.

This PR is against PR https://github.com/ipdk-io/stratum-dev/pull/227.