### PR TITLE
Increased logging details to assist in debugging

### DIFF
--- a/stratum/hal/lib/tdi/es2k/es2k_node.cc
+++ b/stratum/hal/lib/tdi/es2k/es2k_node.cc
@@ -152,7 +152,7 @@ std::unique_ptr<Es2kNode> Es2kNode::CreateInstance(
   RETURN_IF_ERROR(session->EndBatch());
 
   if (!success) {
-    return MAKE_ERROR(ERR_AT_LEAST_ONE_OPER_FAILED).without_logging()
+    return MAKE_ERROR(ERR_AT_LEAST_ONE_OPER_FAILED)
            << "One or more write operations failed.";
   }
 
@@ -275,7 +275,7 @@ std::unique_ptr<Es2kNode> Es2kNode::CreateInstance(
   }
   RET_CHECK(writer->Write(resp)) << "Write to stream channel failed.";
   if (!success) {
-    return MAKE_ERROR(ERR_AT_LEAST_ONE_OPER_FAILED).without_logging()
+    return MAKE_ERROR(ERR_AT_LEAST_ONE_OPER_FAILED)
            << "One or more read operations failed.";
   }
   return ::util::OkStatus();

--- a/stratum/hal/lib/tdi/tdi_sde_table_entry.cc
+++ b/stratum/hal/lib/tdi/tdi_sde_table_entry.cc
@@ -67,13 +67,13 @@ using namespace stratum::hal::tdi::helpers;
                                         flags, *real_table_key->table_key_,
                                         *real_table_data->table_data_);
   if (status == TDI_ALREADY_EXISTS) {
-    return MAKE_ERROR(::util::error::Code::ALREADY_EXISTS).without_logging()
+    return MAKE_ERROR(::util::error::Code::ALREADY_EXISTS)
            << "Duplicate table entry with " << dump_args();
   } else if (status == TDI_NO_SPACE) {
-    return MAKE_ERROR(::util::error::Code::RESOURCE_EXHAUSTED).without_logging()
+    return MAKE_ERROR(::util::error::Code::RESOURCE_EXHAUSTED)
            << "Table is already full. No space for " << dump_args();
   } else if (status != TDI_SUCCESS) {
-    return MAKE_ERROR(::util::error::Code::INTERNAL).without_logging()
+    return MAKE_ERROR(::util::error::Code::INTERNAL)
            << "Error adding table entry with " << dump_args();
   }
 
@@ -148,10 +148,10 @@ using namespace stratum::hal::tdi::helpers;
                                         flags, *real_table_key->table_key_);
 
   if (status == TDI_OBJECT_NOT_FOUND) {
-    return MAKE_ERROR(::util::error::Code::NOT_FOUND).without_logging()
+    return MAKE_ERROR(::util::error::Code::NOT_FOUND)
            << "No matching table entry with " << dump_args();
   } else if (status != TDI_SUCCESS) {
-    return MAKE_ERROR(::util::error::Code::INTERNAL).without_logging()
+    return MAKE_ERROR(::util::error::Code::INTERNAL)
            << "Error deleting table entry with " << dump_args();
   }
 
@@ -182,11 +182,11 @@ using namespace stratum::hal::tdi::helpers;
                                         real_table_data->table_data_.get());
 
   if (status == TDI_TABLE_NOT_FOUND || status == TDI_OBJECT_NOT_FOUND) {
-    return MAKE_ERROR(::util::error::Code::NOT_FOUND).without_logging()
+    return MAKE_ERROR(::util::error::Code::NOT_FOUND)
            << "No matching table entry";
   } else if (status != TDI_SUCCESS) {
     TdiStatus ret(status);
-    return MAKE_ERROR(ret.error_code()).without_logging()
+    return MAKE_ERROR(ret.error_code())
            << "Error getting table entry";
   }
 

--- a/stratum/hal/lib/tdi/tdi_table_manager.cc
+++ b/stratum/hal/lib/tdi/tdi_table_manager.cc
@@ -330,15 +330,15 @@ std::unique_ptr<TdiTableManager> TdiTableManager::CreateInstance(
 
     switch (type) {
       case ::p4::v1::Update::INSERT:
-        RETURN_IF_ERROR_WITHOUT_LOGGING(tdi_sde_interface_->InsertTableEntry(
+        RETURN_IF_ERROR(tdi_sde_interface_->InsertTableEntry(
             device_, session, table_id, table_key.get(), table_data.get()));
         break;
       case ::p4::v1::Update::MODIFY:
-        RETURN_IF_ERROR_WITHOUT_LOGGING(tdi_sde_interface_->ModifyTableEntry(
+        RETURN_IF_ERROR(tdi_sde_interface_->ModifyTableEntry(
             device_, session, table_id, table_key.get(), table_data.get()));
         break;
       case ::p4::v1::Update::DELETE:
-        RETURN_IF_ERROR_WITHOUT_LOGGING(tdi_sde_interface_->DeleteTableEntry(
+        RETURN_IF_ERROR(tdi_sde_interface_->DeleteTableEntry(
             device_, session, table_id, table_key.get()));
         break;
       default:
@@ -535,7 +535,7 @@ std::unique_ptr<TdiTableManager> TdiTableManager::CreateInstance(
                    tdi_sde_interface_->CreateTableData(
                        table_id, table_entry.action().action().action_id()));
   RETURN_IF_ERROR(BuildTableKey(table_entry, table_key.get()));
-  RETURN_IF_ERROR_WITHOUT_LOGGING(tdi_sde_interface_->GetTableEntry(
+  RETURN_IF_ERROR(tdi_sde_interface_->GetTableEntry(
       device_, session, table_id, table_key.get(), table_data.get()));
   ASSIGN_OR_RETURN(
       ::p4::v1::TableEntry result,


### PR DESCRIPTION
It is not possible to debug with current level of logging. Increasing the log details to check all errors when we hit the error cases for TDI tables