### PR TITLE
Minor revisions to ValidateYangHexString

### DIFF
--- a/stratum/hal/lib/tdi/tdi_ipsec_manager.cc
+++ b/stratum/hal/lib/tdi/tdi_ipsec_manager.cc
@@ -113,7 +113,7 @@ TdiIpsecManager::~TdiIpsecManager() = default;
   if (op_type == IPSEC_SADB_CONFIG_OP_ADD_ENTRY) {
     // Convert encryption key from hex to ASCII
     std::string hex_encoded = msg.esp_payload().encryption().key();
-    RETURN_IF_ERROR(ValidateIETFYangHexString(hex_encoded));
+    RETURN_IF_ERROR(ValidateYangHexString(hex_encoded));
 
     std::string ascii_encoded = ConvertEncryptionKeyEncoding(hex_encoded);
     msg.mutable_esp_payload()->mutable_encryption()->set_key(ascii_encoded);

--- a/stratum/lib/utils.cc
+++ b/stratum/lib/utils.cc
@@ -272,7 +272,7 @@ std::string Demangle(const char* mangled) {
   return ::util::OkStatus();
 }
 
-::util::Status ValidateIETFYangHexString(std::string input) {
+::util::Status ValidateYangHexString(const std::string& input) {
   const std::regex pattern("^([0-9a-fA-F]{2}(:[0-9a-fA-F]{2})*)$");
   if (regex_match(input, pattern)) {
     return ::util::OkStatus();

--- a/stratum/lib/utils.h
+++ b/stratum/lib/utils.h
@@ -270,7 +270,7 @@ std::string Demangle(const char* mangled);
 // From YANG definition: A hexadecimal string with octets represented as
 // hex digits separated by colons. The canonical representation uses lowercase
 // characters.   pattern '([0-9a-fA-F]{2}(:[0-9a-fA-F]{2})*)?';
-::util::Status ValidateIETFYangHexString(std::string input);
+::util::Status ValidateYangHexString(const std::string& input);
 
 }  // namespace stratum
 


### PR DESCRIPTION
- Renamed ValidateIETFYangHexString to ValidateYangHexString.

- Changed input parameter type to `const std::string&`.