### PR TITLE
Cherry pick from 1.6

### DIFF
--- a/stratum/hal/lib/tdi/es2k/es2k_node.cc
+++ b/stratum/hal/lib/tdi/es2k/es2k_node.cc
@@ -168,7 +168,7 @@ std::unique_ptr<Es2kNode> Es2kNode::CreateInstance(
   RETURN_IF_ERROR(session->EndBatch());
 
   if (!success) {
-    return MAKE_ERROR(ERR_AT_LEAST_ONE_OPER_FAILED)
+    return MAKE_ERROR(ERR_AT_LEAST_ONE_OPER_FAILED).without_logging()
            << "One or more write operations failed.";
   }
 
@@ -291,7 +291,7 @@ std::unique_ptr<Es2kNode> Es2kNode::CreateInstance(
   }
   RET_CHECK(writer->Write(resp)) << "Write to stream channel failed.";
   if (!success) {
-    return MAKE_ERROR(ERR_AT_LEAST_ONE_OPER_FAILED)
+    return MAKE_ERROR(ERR_AT_LEAST_ONE_OPER_FAILED).without_logging()
            << "One or more read operations failed.";
   }
   return ::util::OkStatus();

--- a/stratum/hal/lib/tdi/es2k/es2k_node.cc
+++ b/stratum/hal/lib/tdi/es2k/es2k_node.cc
@@ -168,7 +168,7 @@ std::unique_ptr<Es2kNode> Es2kNode::CreateInstance(
   RETURN_IF_ERROR(session->EndBatch());
 
   if (!success) {
-    return MAKE_ERROR(ERR_AT_LEAST_ONE_OPER_FAILED).without_logging()
+    return MAKE_ERROR(ERR_AT_LEAST_ONE_OPER_FAILED)
            << "One or more write operations failed.";
   }
 
@@ -291,7 +291,7 @@ std::unique_ptr<Es2kNode> Es2kNode::CreateInstance(
   }
   RET_CHECK(writer->Write(resp)) << "Write to stream channel failed.";
   if (!success) {
-    return MAKE_ERROR(ERR_AT_LEAST_ONE_OPER_FAILED).without_logging()
+    return MAKE_ERROR(ERR_AT_LEAST_ONE_OPER_FAILED)
            << "One or more read operations failed.";
   }
   return ::util::OkStatus();

--- a/stratum/hal/lib/tdi/tdi_sde_table_entry.cc
+++ b/stratum/hal/lib/tdi/tdi_sde_table_entry.cc
@@ -67,13 +67,13 @@ using namespace stratum::hal::tdi::helpers;
                                         flags, *real_table_key->table_key_,
                                         *real_table_data->table_data_);
   if (status == TDI_ALREADY_EXISTS) {
-    return MAKE_ERROR(::util::error::Code::ALREADY_EXISTS).without_logging()
+    return MAKE_ERROR(::util::error::Code::ALREADY_EXISTS)
            << "Duplicate table entry with " << dump_args();
   } else if (status == TDI_NO_SPACE) {
-    return MAKE_ERROR(::util::error::Code::RESOURCE_EXHAUSTED).without_logging()
+    return MAKE_ERROR(::util::error::Code::RESOURCE_EXHAUSTED)
            << "Table is already full. No space for " << dump_args();
   } else if (status != TDI_SUCCESS) {
-    return MAKE_ERROR(::util::error::Code::INTERNAL).without_logging()
+    return MAKE_ERROR(::util::error::Code::INTERNAL)
            << "Error adding table entry with " << dump_args();
   }
 
@@ -148,10 +148,10 @@ using namespace stratum::hal::tdi::helpers;
                                         flags, *real_table_key->table_key_);
 
   if (status == TDI_OBJECT_NOT_FOUND) {
-    return MAKE_ERROR(::util::error::Code::NOT_FOUND).without_logging()
+    return MAKE_ERROR(::util::error::Code::NOT_FOUND)
            << "No matching table entry with " << dump_args();
   } else if (status != TDI_SUCCESS) {
-    return MAKE_ERROR(::util::error::Code::INTERNAL).without_logging()
+    return MAKE_ERROR(::util::error::Code::INTERNAL)
            << "Error deleting table entry with " << dump_args();
   }
 
@@ -182,11 +182,11 @@ using namespace stratum::hal::tdi::helpers;
                                         real_table_data->table_data_.get());
 
   if (status == TDI_TABLE_NOT_FOUND || status == TDI_OBJECT_NOT_FOUND) {
-    return MAKE_ERROR(::util::error::Code::NOT_FOUND).without_logging()
+    return MAKE_ERROR(::util::error::Code::NOT_FOUND)
            << "No matching table entry";
   } else if (status != TDI_SUCCESS) {
     TdiStatus ret(status);
-    return MAKE_ERROR(ret.error_code()).without_logging()
+    return MAKE_ERROR(ret.error_code())
            << "Error getting table entry";
   }
 

--- a/stratum/hal/lib/tdi/tdi_sde_table_entry.cc
+++ b/stratum/hal/lib/tdi/tdi_sde_table_entry.cc
@@ -186,8 +186,7 @@ using namespace stratum::hal::tdi::helpers;
            << "No matching table entry";
   } else if (status != TDI_SUCCESS) {
     TdiStatus ret(status);
-    return MAKE_ERROR(ret.error_code())
-           << "Error getting table entry";
+    return MAKE_ERROR(ret.error_code()) << "Error getting table entry";
   }
 
   return ::util::OkStatus();

--- a/stratum/hal/lib/tdi/tdi_table_manager.cc
+++ b/stratum/hal/lib/tdi/tdi_table_manager.cc
@@ -330,15 +330,15 @@ std::unique_ptr<TdiTableManager> TdiTableManager::CreateInstance(
 
     switch (type) {
       case ::p4::v1::Update::INSERT:
-        RETURN_IF_ERROR(tdi_sde_interface_->InsertTableEntry(
+        RETURN_IF_ERROR_WITHOUT_LOGGING(tdi_sde_interface_->InsertTableEntry(
             device_, session, table_id, table_key.get(), table_data.get()));
         break;
       case ::p4::v1::Update::MODIFY:
-        RETURN_IF_ERROR(tdi_sde_interface_->ModifyTableEntry(
+        RETURN_IF_ERROR_WITHOUT_LOGGING(tdi_sde_interface_->ModifyTableEntry(
             device_, session, table_id, table_key.get(), table_data.get()));
         break;
       case ::p4::v1::Update::DELETE:
-        RETURN_IF_ERROR(tdi_sde_interface_->DeleteTableEntry(
+        RETURN_IF_ERROR_WITHOUT_LOGGING(tdi_sde_interface_->DeleteTableEntry(
             device_, session, table_id, table_key.get()));
         break;
       default:

--- a/stratum/hal/lib/tdi/tdi_table_manager.cc
+++ b/stratum/hal/lib/tdi/tdi_table_manager.cc
@@ -330,15 +330,15 @@ std::unique_ptr<TdiTableManager> TdiTableManager::CreateInstance(
 
     switch (type) {
       case ::p4::v1::Update::INSERT:
-        RETURN_IF_ERROR_WITHOUT_LOGGING(tdi_sde_interface_->InsertTableEntry(
+        RETURN_IF_ERROR(tdi_sde_interface_->InsertTableEntry(
             device_, session, table_id, table_key.get(), table_data.get()));
         break;
       case ::p4::v1::Update::MODIFY:
-        RETURN_IF_ERROR_WITHOUT_LOGGING(tdi_sde_interface_->ModifyTableEntry(
+        RETURN_IF_ERROR(tdi_sde_interface_->ModifyTableEntry(
             device_, session, table_id, table_key.get(), table_data.get()));
         break;
       case ::p4::v1::Update::DELETE:
-        RETURN_IF_ERROR_WITHOUT_LOGGING(tdi_sde_interface_->DeleteTableEntry(
+        RETURN_IF_ERROR(tdi_sde_interface_->DeleteTableEntry(
             device_, session, table_id, table_key.get()));
         break;
       default:
@@ -535,7 +535,7 @@ std::unique_ptr<TdiTableManager> TdiTableManager::CreateInstance(
                    tdi_sde_interface_->CreateTableData(
                        table_id, table_entry.action().action().action_id()));
   RETURN_IF_ERROR(BuildTableKey(table_entry, table_key.get()));
-  RETURN_IF_ERROR_WITHOUT_LOGGING(tdi_sde_interface_->GetTableEntry(
+  RETURN_IF_ERROR(tdi_sde_interface_->GetTableEntry(
       device_, session, table_id, table_key.get(), table_data.get()));
   ASSIGN_OR_RETURN(
       ::p4::v1::TableEntry result,


### PR DESCRIPTION
This PR cherry-picks #230 and #233 from mev-ts-1.6 branch to split-arch branch

Some of the previous log level noise reduction is being undone here. Since we started reducing them, error conditions are too generic now saying "one or more read/write operations failed" with nothing else to give us any info on what the problem could be (was it duplicate entry, was it table_not_found, was it some other internal error -- its hard to tell what type of error). Leaving some of the error logs in now to give user a bit more detailed information.