### PR TITLE
Define new cmake object libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,12 +39,14 @@ add_subdirectory(stratum)
 function(add_stratum_object_libs _TGT)
     target_sources(${_TGT} PRIVATE
         $<TARGET_OBJECTS:stratum_glue_o>
+        $<TARGET_OBJECTS:stratum_glue_status_o>
         $<TARGET_OBJECTS:stratum_hal_lib_common_o>
         $<TARGET_OBJECTS:stratum_hal_lib_p4_o>
         $<TARGET_OBJECTS:stratum_hal_lib_phal_o>
         $<TARGET_OBJECTS:stratum_lib_o>
         $<TARGET_OBJECTS:stratum_lib_p4runtime_o>
         $<TARGET_OBJECTS:stratum_lib_security_o>
+        $<TARGET_OBJECTS:stratum_lib_utils_o>
         $<TARGET_OBJECTS:stratum_main_o>
         $<TARGET_OBJECTS:stratum_public_lib_o>
         $<TARGET_OBJECTS:stratum_tdi_common_o>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # CMake build file for stratum project
 #
-# Copyright 2022-2023 Intel Corporation
+# Copyright 2022-2024 Intel Corporation
 # SPDX-License-Identifier: Apache 2.0
 
 cmake_minimum_required(VERSION 3.15)

--- a/stratum/glue/status/CMakeLists.txt
+++ b/stratum/glue/status/CMakeLists.txt
@@ -1,14 +1,14 @@
 # Build file for //stratum/glue/status
 #
-# Copyright 2022-2023 Intel Corporation
+# Copyright 2022-2024 Intel Corporation
 # SPDX-License-Identifier: Apache 2.0
 #
 
-##################
-# stratum_glue_o #
-##################
+#########################
+# stratum_glue_status_o #
+#########################
 
-target_sources(stratum_glue_o PRIVATE
+add_library(stratum_glue_status_o OBJECT
     canonical_errors.cc
     canonical_errors.h
     posix_error_space.cc
@@ -21,9 +21,12 @@ target_sources(stratum_glue_o PRIVATE
     statusor.h
 )
 
-target_include_directories(stratum_glue_o PUBLIC ${DEPEND_INSTALL_DIR}/include)
+target_include_directories(stratum_glue_status_o PUBLIC
+    ${DEPEND_INSTALL_DIR}/include
+    ${STRATUM_INCLUDES}
+)
 
-target_link_libraries(stratum_glue_o PUBLIC
+target_link_libraries(stratum_glue_status_o PUBLIC
     gflags::gflags_shared
     glog::glog
 )

--- a/stratum/hal/lib/tdi/tdi_ipsec_manager.cc
+++ b/stratum/hal/lib/tdi/tdi_ipsec_manager.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2023 Intel Corporation.
+// Copyright 2022-2024 Intel Corporation.
 // SPDX-License-Identifier: Apache-2.0
 
 #include "stratum/hal/lib/tdi/tdi_ipsec_manager.h"

--- a/stratum/hal/lib/tdi/tdi_sde_table_entry.cc
+++ b/stratum/hal/lib/tdi/tdi_sde_table_entry.cc
@@ -1,5 +1,5 @@
 // Copyright 2019-present Barefoot Networks, Inc.
-// Copyright 2022 Intel Corporation
+// Copyright 2022-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 // Target-agnostic SDE wrapper Table Entry methods.

--- a/stratum/hal/lib/yang/CMakeLists.txt
+++ b/stratum/hal/lib/yang/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Build file for //stratum/hal/lib/yang
 #
-# Copyright 2022-2023 Intel Corporation
+# Copyright 2022-2024 Intel Corporation
 # SPDX-License-Identifier: Apache 2.0
 #
 
@@ -39,5 +39,6 @@ target_include_directories(stratum_yang_parse_tree_o PRIVATE
 
 add_dependencies(stratum_yang_parse_tree_o
     gnmi_proto
+    openconfig_proto_o
     stratum_proto
 )

--- a/stratum/lib/CMakeLists.txt
+++ b/stratum/lib/CMakeLists.txt
@@ -13,14 +13,25 @@ add_library(stratum_lib_o OBJECT
     timer_daemon.h
     channel/channel.h
     channel/channel_internal.h
-    macros.h
-    utils.cc
-    utils.h
 )
 
 target_include_directories(stratum_lib_o PRIVATE ${STRATUM_INCLUDES})
 
 add_dependencies(stratum_lib_o stratum_proto gnmi_proto)
+
+#######################
+# stratum_lib_utils_o #
+#######################
+
+add_library(stratum_lib_utils_o OBJECT
+  macros.h
+  utils.cc
+  utils.h
+)
+
+target_include_directories(stratum_lib_utils_o PRIVATE ${STRATUM_INCLUDES})
+
+target_link_libraries(stratum_lib_utils_o PUBLIC stratum_proto)
 
 add_subdirectory(p4runtime)
 add_subdirectory(security)


### PR DESCRIPTION
- Defined stratum_glue_status_o and stratum_lib_utils_o to provide more granular targets for networking-recipe to use.

- Added a dependency on openconfig_proto_o to ensure that openconfig.pb.h has been generated.

This PR supports https://github.com/ipdk-io/networking-recipe/pull/509.