### PR TITLE
Revise stratum_utils library

### DIFF
--- a/stratum/glue/CMakeLists.txt
+++ b/stratum/glue/CMakeLists.txt
@@ -29,15 +29,14 @@ add_subdirectory(status)
 # stratum_utils #
 #################
 
-add_library(stratum_utils SHARED
-    $<TARGET_OBJECTS:stratum_glue_o>
+add_library(stratum_utils STATIC
+    $<TARGET_OBJECTS:error_proto_o>
+    $<TARGET_OBJECTS:stratum_glue_status_o>
+    $<TARGET_OBJECTS:stratum_lib_utils_o>
     $<TARGET_OBJECTS:stratum_public_lib_o>
 )
 
 target_link_libraries(stratum_utils PUBLIC
-    absl::strings
-    absl::synchronization
-    gflags::gflags_shared
     glog::glog
 )
 


### PR DESCRIPTION
- Converted `stratum_utils` library from SHARED to STATIC.

- Updated contents.

stratum_utils provides a small subset of the stratum support functions. It is intended for use by ovsp4rt and krnlmon.