### PR TITLE
Fix compiler warnings in bits_test

### DIFF
--- a/stratum/glue/net_util/bits_test.cc
+++ b/stratum/glue/net_util/bits_test.cc
@@ -226,9 +226,9 @@ TEST_F(BitsTest, BitCountingRandom) {
     float p = RandomFloat();
     int nbits = 0;
     uint32 n = 0;
-    for (int i = 0; i < 32; i++) {
+    for (int j = 0; j < 32; j++) {
       if (RandomFloat() < p) {
-        n |= (1U << i);
+        n |= (1U << j);
         nbits++;
       }
     }
@@ -242,9 +242,9 @@ TEST_F(BitsTest, BitCountingRandom64) {
     float p = RandomFloat();
     int nbits = 0;
     uint64 n = 0;
-    for (int i = 0; i < 64; i++) {
+    for (int j = 0; j < 64; j++) {
       if (RandomFloat() < p) {
-        n |= (1LL << i);
+        n |= (1LL << j);
         nbits++;
       }
     }
@@ -258,9 +258,9 @@ TEST_F(BitsTest, BitCountingRandom128) {
     float p = RandomFloat();
     int nbits = 0;
     absl::uint128 n = 0;
-    for (int i = 0; i < 128; i++) {
+    for (int j = 0; j < 128; j++) {
       if (RandomFloat() < p) {
-        n |= (absl::uint128(1) << i);
+        n |= (absl::uint128(1) << j);
         nbits++;
       }
     }


### PR DESCRIPTION
The CircleCI pipeline issued several "declaration shadows a local variable" warnings when compiling bits_test.cc. This CL fixes those warnings.