### PR TITLE
Limit logger output on ALREADY_EXISTS error

### DIFF
--- a/stratum/glue/status/status_macros.cc
+++ b/stratum/glue/status/status_macros.cc
@@ -151,9 +151,8 @@ MakeErrorStream::Impl::~Impl() {
                      true /* should_log */, ERROR /* log_severity */,
                      should_log_stack_trace_);
   } else {
-    const LogSeverity actual_severity = ERROR;
     return MakeError(file_, line_, error_space_, code_, str, should_log_,
-                     actual_severity, should_log_stack_trace_);
+                     log_severity_, should_log_stack_trace_);
   }
 }
 

--- a/stratum/hal/lib/tdi/es2k/es2k_node.cc
+++ b/stratum/hal/lib/tdi/es2k/es2k_node.cc
@@ -168,7 +168,7 @@ std::unique_ptr<Es2kNode> Es2kNode::CreateInstance(
   RETURN_IF_ERROR(session->EndBatch());
 
   if (!success) {
-    // Tally up the ALREADY_EXISTS errors.
+    // Tally up the number of ALREADY_EXISTS errors.
     int already_exists_errors = 0;
     for (const ::util::Status& status : *results) {
       if (status.error_code() == ::util::error::Code::ALREADY_EXISTS) {
@@ -182,7 +182,7 @@ std::unique_ptr<Es2kNode> Es2kNode::CreateInstance(
       // If all the errors are ALREADY_EXISTS, downgrade severity to INFO
       // and set the description to something less likely to alarm the
       // customer.
-      const char* entries = (already_exists_errors) ? "entry" : "entries";
+      const char* entries = (already_exists_errors == 1) ? "entry" : "entries";
       return MAKE_ERROR(ERR_AT_LEAST_ONE_OPER_FAILED)
                  .severity(INFO)
                  .without_logging()

--- a/stratum/hal/lib/tdi/es2k/es2k_node.cc
+++ b/stratum/hal/lib/tdi/es2k/es2k_node.cc
@@ -168,8 +168,30 @@ std::unique_ptr<Es2kNode> Es2kNode::CreateInstance(
   RETURN_IF_ERROR(session->EndBatch());
 
   if (!success) {
-    return MAKE_ERROR(ERR_AT_LEAST_ONE_OPER_FAILED).without_logging()
-           << "One or more write operations failed.";
+    // Tally up the ALREADY_EXISTS errors.
+    int already_exists_errors = 0;
+    for (const ::util::Status& status : *results) {
+      if (status.error_code() == ::util::error::Code::ALREADY_EXISTS) {
+        ++already_exists_errors;
+      } else if (!status.ok()) {
+        already_exists_errors = 0;
+        break;
+      }
+    }
+    if (already_exists_errors) {
+      // If all the errors are ALREADY_EXISTS, downgrade severity to INFO
+      // and set the description to something less likely to alarm the
+      // customer.
+      const char* entries = (already_exists_errors) ? "entry" : "entries";
+      return MAKE_ERROR(ERR_AT_LEAST_ONE_OPER_FAILED)
+                 .severity(INFO)
+                 .without_logging()
+             << "Duplicate table " << entries << " (may not be an error)";
+
+    } else {
+      return MAKE_ERROR(ERR_AT_LEAST_ONE_OPER_FAILED).without_logging()
+             << "One or more write operations failed.";
+    }
   }
 
   LOG(INFO) << "P4-based forwarding entities written successfully to node with "

--- a/stratum/hal/lib/tdi/tdi_sde_table_entry.cc
+++ b/stratum/hal/lib/tdi/tdi_sde_table_entry.cc
@@ -70,7 +70,7 @@ using namespace stratum::hal::tdi::helpers;
     // This is a common condition and not necessarily serious.
     // Log without detail and propagate the status.
     return MAKE_ERROR(::util::error::Code::ALREADY_EXISTS).severity(INFO)
-           << "Duplicate table entry";
+           << "Duplicate table entry (may not be an error)";
   } else if (status == TDI_NO_SPACE) {
     return MAKE_ERROR(::util::error::Code::RESOURCE_EXHAUSTED)
            << "Table is already full. No space for " << dump_args();

--- a/stratum/hal/lib/tdi/tdi_sde_table_entry.cc
+++ b/stratum/hal/lib/tdi/tdi_sde_table_entry.cc
@@ -67,8 +67,10 @@ using namespace stratum::hal::tdi::helpers;
                                         flags, *real_table_key->table_key_,
                                         *real_table_data->table_data_);
   if (status == TDI_ALREADY_EXISTS) {
-    return MAKE_ERROR(::util::error::Code::ALREADY_EXISTS)
-           << "Duplicate table entry with " << dump_args();
+    // This is a common condition and not necessarily serious.
+    // Log without detail and propagate the status.
+    return MAKE_ERROR(::util::error::Code::ALREADY_EXISTS).severity(INFO)
+           << "Duplicate table entry";
   } else if (status == TDI_NO_SPACE) {
     return MAKE_ERROR(::util::error::Code::RESOURCE_EXHAUSTED)
            << "Table is already full. No space for " << dump_args();


### PR DESCRIPTION
Limited logger output when TdiSdeWrapper::InsertTableEntry returns a TDI_ALREADY_EXISTS error.

- Downgraded severity to INFO and omitted dump_args() when logging the condition in TdiSdeWrapper.

- Downgraded severity to INFO and suppressed error details when logging the condition in TdiTableManager.

The SDE will log BF_PIPE_ERROR when the error is detected. This message is outside the scope of infrap4d.

Es2kNode::WriteForwardingEntries returns a consolidated error code (ERR_AT_LEAST_ONE_OPER_FAILED) if any of the write requests fail.

The net effect of this PR should be to reduce the logger output to:

1. BF_PIPE_ERROR - duplicate entry found in table...
2. generic::already_exists: Duplicate table entry (may not be an error)
3. Duplicate table entry (may not be an error)
4. StratumErrorSpace::ERR_AT_LEAST_ONE_OPER_FAILED...
5. Failed to write forwarding entries...

The second and third lines will be suppressed if the logging level is WARNING or above.

----

We _could_ propagate the error status without logging for lines 2 and 3, but that would be at the cost of reduced context when an error is returned. I think downgrading the severity to INFO and setting the logger severity filter to WARNING is the better choice.