### PR TITLE
Update version of googletest used in Bazel build

### DIFF
--- a/bazel/deps.bzl
+++ b/bazel/deps.bzl
@@ -197,9 +197,9 @@ def stratum_deps():
     if "com_google_googletest" not in native.existing_rules():
         http_archive(
             name = "com_google_googletest",
-            sha256 = "d3d307a240e129bb57da8aae64f3b0099bf1b8efff7249df993b619b8641ec77",
-            strip_prefix = "googletest-a3460d1aeeaa43fdf137a6adefef10ba0b59fe4b",
-            urls = ["https://github.com/google/googletest/archive/a3460d1aeeaa43fdf137a6adefef10ba0b59fe4b.zip"],
+            sha256 = "8daa1a71395892f7c1ec5f7cb5b099a02e606be720d62f1a6a98f8f8898ec826",
+            strip_prefix = "googletest-e2239ee6043f73722e7aa812a459f54a28552929",
+            urls = ["https://github.com/google/googletest/archive/e2239ee6043f73722e7aa812a459f54a28552929.zip"],
         )
 
     if "com_googlesource_code_re2" not in native.existing_rules():


### PR DESCRIPTION
- Aligned the version of googletest used by the Bazel build with the one used by stratum-deps. (e2239ee60 11-Jun-2021)

This is a Bazel-only change. It does for googletest what PR https://github.com/ipdk-io/stratum-dev/pull/241 did for googleapis.