### PR TITLE
Adding the sw_cache to default es2k_skip_p4.conf file

### DIFF
--- a/stratum/hal/bin/tdi/es2k/es2k_skip_p4.conf
+++ b/stratum/hal/bin/tdi/es2k/es2k_skip_p4.conf
@@ -10,6 +10,7 @@
     ],
     "instance": 0,
     "cfgqs-idx": "0-15",
+    "sw_cache": 1,
     "p4_devices": [
     {
         "device-id": 0,


### PR DESCRIPTION
SDE enables the sw_cache by default. 
This PR adds the default value to the conf file so that users are aware that sw_cache is enabled by default.