### PR TITLE
Implement -optimize_full_table_reads flag

### DIFF
--- a/stratum/hal/lib/tdi/tdi_sde_helpers.cc
+++ b/stratum/hal/lib/tdi/tdi_sde_helpers.cc
@@ -12,12 +12,17 @@
 #include <utility>
 
 #include "absl/strings/str_cat.h"
+#include "gflags/gflags.h"
 #include "stratum/glue/gtl/stl_util.h"
 #include "stratum/hal/lib/tdi/tdi_sde_common.h"
 #include "stratum/hal/lib/tdi/tdi_sde_utils.h"
 #include "stratum/hal/lib/tdi/utils.h"
 #include "stratum/lib/macros.h"
 #include "stratum/lib/utils.h"
+
+DEFINE_bool(optimize_full_table_reads, true,
+            "Whether to skip full-table reads if the reported table size "
+            "is zero.");
 
 namespace stratum {
 namespace hal {
@@ -430,7 +435,10 @@ namespace helpers {
 
   table_keys->resize(0);
   table_values->resize(0);
-  if (entries == 0) return ::util::OkStatus();
+
+  if (FLAGS_optimize_full_table_reads && entries == 0) {
+    return ::util::OkStatus();
+  }
 
   // Get first entry.
   {


### PR DESCRIPTION
- Implemented an `-optimize_full_table_reads` command-line flag. Disabling this flag at startup time causes `GetAllEntries()` to read the underlying table even if the reported size (number of entries) is zero. This may be necessary in cases where the table consists entirely of entries learned by the hardware.

  The flag may be disabled by specifying `-nooptimize_full_table_reads` or `-optimize_full_table_reads=false` on the `infrap4d` command line.

  The default value is `true`, maintaining backward compatibility with previous versions of the software.