### PR TITLE
Rename libgrpc_proto to libgoogle_rpc_proto

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,7 +113,7 @@ function(add_stratum_proto_libs _TGT)
         openconfig_proto
         stratum_proto
         gnmi_proto
-        rpc_proto
+        google_rpc_proto
         p4runtime_proto
     )
 endfunction()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,7 +113,7 @@ function(add_stratum_proto_libs _TGT)
         openconfig_proto
         stratum_proto
         gnmi_proto
-        grpc_proto
+        rpc_proto
         p4runtime_proto
     )
 endfunction()

--- a/stratum/tools/gnmi/CMakeLists.txt
+++ b/stratum/tools/gnmi/CMakeLists.txt
@@ -21,7 +21,7 @@ target_link_libraries(gnmi_cli PUBLIC
     gRPC::re2
     protobuf::libprotobuf
     pthread
-    rpc_proto
+    google_rpc_proto
 )
 
 if(HAVE_POSIX_AIO)

--- a/stratum/tools/gnmi/CMakeLists.txt
+++ b/stratum/tools/gnmi/CMakeLists.txt
@@ -15,13 +15,13 @@ set_install_rpath(gnmi_cli ${EXEC_ELEMENT} ${DEP_ELEMENT})
 target_link_libraries(gnmi_cli PUBLIC
     stratum_static
     gnmi_proto
-    grpc_proto
     gflags::gflags_shared
     gRPC::grpc
     gRPC::grpc++
     gRPC::re2
     protobuf::libprotobuf
     pthread
+    rpc_proto
 )
 
 if(HAVE_POSIX_AIO)


### PR DESCRIPTION
- This library is built from files in `googleapis/google/rpc`.
  Rename it to make it clear it's not part of gRPC.

Corequisite: https://github.com/ipdk-io/networking-recipe/pull/574.