### PR TITLE
Eliminate comparisons to ::util::OkStatus()

### DIFF
--- a/stratum/hal/lib/common/config_monitoring_service.cc
+++ b/stratum/hal/lib/common/config_monitoring_service.cc
@@ -1,6 +1,6 @@
 // Copyright 2018 Google LLC
 // Copyright 2018-present Open Networking Foundation
-// Copyright 2021-2023 Intel Corporation.
+// Copyright 2021-2024 Intel Corporation.
 // SPDX-License-Identifier: Apache-2.0
 
 #include "stratum/hal/lib/common/config_monitoring_service.h"
@@ -485,7 +485,7 @@ constexpr int kThousandMilliseconds = 1000 /* milliseconds */;
               PeriodicWithHeartbeat(sample_interval, heartbeat_interval),
               subscription.path(), stream, &h);
         }
-        if (status == ::util::OkStatus()) {
+        if (status.ok()) {
           // A handle has to be saved, so later we know what to unsubscribe.
           (*subscriptions)[subscription.path()] = h;
         } else {

--- a/stratum/hal/lib/common/gnmi_publisher.cc
+++ b/stratum/hal/lib/common/gnmi_publisher.cc
@@ -1,6 +1,6 @@
 // Copyright 2018 Google LLC
 // Copyright 2018-present Open Networking Foundation
-// Copyright 2023 Intel Corporation
+// Copyright 2023-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 #include "stratum/hal/lib/common/gnmi_publisher.h"
@@ -144,7 +144,7 @@ GnmiPublisher::~GnmiPublisher() {}
                                                 SubscriptionHandle* h) {
   auto status = Subscribe(&TreeNode::AllSubtreeLeavesSupportOnTimer,
                           &TreeNode::GetOnTimerHandler, path, stream, h);
-  if (status != ::util::OkStatus()) {
+  if (!status.ok()) {
     return status;
   }
   EventHandlerRecordPtr weak(*h);
@@ -171,7 +171,7 @@ GnmiPublisher::~GnmiPublisher() {}
                                                 SubscriptionHandle* h) {
   auto status = Subscribe(&TreeNode::AllSubtreeLeavesSupportOnChange,
                           &TreeNode::GetOnChangeHandler, path, stream, h);
-  if (status != ::util::OkStatus()) {
+  if (!status.ok()) {
     return status;
   }
   // A handler has been successfully found and now it has to be registered in
@@ -274,7 +274,7 @@ void GnmiPublisher::ReadGnmiEvents(
     }
     // Handle received message.
     ::util::Status status = HandleChange(*event_ptr);
-    if (status != ::util::OkStatus()) LOG(ERROR) << status;
+    if (!status.ok()) LOG(ERROR) << status;
   } while (true);
 }
 

--- a/stratum/hal/lib/common/p4_service.cc
+++ b/stratum/hal/lib/common/p4_service.cc
@@ -1,6 +1,6 @@
 // Copyright 2018 Google LLC
 // Copyright 2018-present Open Networking Foundation
-// Copyright 2021-2023 Intel Corporation.
+// Copyright 2021-2024 Intel Corporation.
 // SPDX-License-Identifier: Apache-2.0
 
 #include "stratum/hal/lib/common/p4_service.h"
@@ -366,6 +366,7 @@ void LogReadRequest(uint64 node_id, const ::p4::v1::ReadRequest& req,
   RETURN_IF_NOT_AUTHORIZED(auth_policy_checker_, P4Service, Read, context);
 
   if (!req->entities_size()) return ::grpc::Status::OK;
+
   // device_id is nothing but the node_id specified in the config for the node.
   uint64 node_id = req->device_id();
   if (node_id == 0) {

--- a/stratum/hal/lib/tdi/dpdk/dpdk_parse_tree_interface.cc
+++ b/stratum/hal/lib/tdi/dpdk/dpdk_parse_tree_interface.cc
@@ -171,7 +171,7 @@ void SetUpInterfacesInterfaceConfigPortType(uint64 type, uint64 node_id,
     auto status = SetValue(node_id, port_id, tree,
                            &SetRequest::Request::Port::mutable_port_type,
                            &DpdkPortTypeValue::set_type, port_type);
-    if (status != ::util::OkStatus()) {
+    if (!status.ok()) {
       return status;
     }
 
@@ -252,7 +252,7 @@ void SetUpInterfacesInterfaceConfigDeviceType(uint64 type, uint64 node_id,
     auto status = SetValue(node_id, port_id, tree,
                            &SetRequest::Request::Port::mutable_device_type,
                            &DpdkDeviceTypeValue::set_device_type, device_type);
-    if (status != ::util::OkStatus()) {
+    if (!status.ok()) {
       return status;
     }
 
@@ -473,7 +473,7 @@ void SetUpInterfacesInterfaceConfigPacketDir(uint64 packet_dir, uint64 node_id,
     auto status = SetValue(node_id, port_id, tree,
                            &SetRequest::Request::Port::mutable_packet_dir,
                            &PacketDirValue::set_packet_dir, direction);
-    if (status != ::util::OkStatus()) {
+    if (!status.ok()) {
       return status;
     }
 
@@ -681,7 +681,7 @@ void SetUpInterfacesInterfaceConfigMtuValue(uint64 mtu, uint64 node_id,
     auto status = SetValue(node_id, port_id, tree,
                            &SetRequest::Request::Port::mutable_mtu_value,
                            &MtuValue::set_mtu_value, mtu_val);
-    if (status != ::util::OkStatus()) {
+    if (!status.ok()) {
       return status;
     }
 
@@ -751,7 +751,7 @@ void SetUpInterfacesInterfaceConfigQueues(uint64 queues_count, uint64 node_id,
     auto status = SetValue(
         node_id, port_id, tree, &SetRequest::Request::Port::mutable_queue_count,
         &QueuesConfigured::set_queue_count, queues_configured);
-    if (status != ::util::OkStatus()) {
+    if (!status.ok()) {
       return status;
     }
 

--- a/stratum/hal/lib/tdi/tdi_ipsec_manager.cc
+++ b/stratum/hal/lib/tdi/tdi_ipsec_manager.cc
@@ -42,11 +42,6 @@ static void ipsec_notification_callback(uint32_t dev_id, uint32_t ipsec_sa_spi,
                                         uint8_t ipsec_sa_protocol,
                                         char* ipsec_sa_dest_address, bool ipv4,
                                         void* cookie) {
-  // printf("IPsec callback: dev_id=%d, ipsec_sa_spi=%d, soft_lifetime=%d, "
-  //       "ipsec_sa_protocol=%d, "
-  //       "ipsec_sa_dest_address=%s, ipv4=%d, cookie=%p\n",
-  //       dev_id, ipsec_sa_spi, soft_lifetime_expire, ipsec_sa_protocol,
-  //       ipsec_sa_dest_address, ipv4, cookie);
   auto ipsec_mgr_hdl = reinterpret_cast<TdiIpsecManager*>(cookie);
   ipsec_mgr_hdl->SendSADExpireNotificationEvent(
       dev_id, ipsec_sa_spi, soft_lifetime_expire, ipsec_sa_protocol,
@@ -73,7 +68,7 @@ TdiIpsecManager::~TdiIpsecManager() = default;
   auto status = tdi_fixed_function_manager_->InitNotificationTableWithCallback(
       IPSEC_NOTIFICATION_TABLE_NAME, &ipsec_notification_callback, this);
 
-  if (status != ::util::OkStatus()) {
+  if (!status.ok()) {
     LOG(ERROR) << "Failed to register IPsec notification callback";
   }
   return ::util::OkStatus();
@@ -84,7 +79,7 @@ TdiIpsecManager::~TdiIpsecManager() = default;
   // TDI layer is not initialized until 'set-pipe' is completed by user via P4RT
   if (!notif_initialized_) {
     auto status = InitializeNotificationCallback();
-    if (status == ::util::OkStatus()) {
+    if (status.ok()) {
       notif_initialized_ = true;
     }
   }
@@ -92,7 +87,7 @@ TdiIpsecManager::~TdiIpsecManager() = default;
   ASSIGN_OR_RETURN(auto session, tdi_sde_interface_->CreateSession());
   auto status = tdi_fixed_function_manager_->FetchSpi(
       session, IPSEC_FETCH_SPI_TABLE_NAME, &fetched_spi);
-  if (status != ::util::OkStatus()) {
+  if (!status.ok()) {
     return MAKE_ERROR(ERR_AT_LEAST_ONE_OPER_FAILED)
            << "One or more read operations failed.";
   }
@@ -105,7 +100,7 @@ TdiIpsecManager::~TdiIpsecManager() = default;
   // TDI layer is not initialized until 'set-pipe' is completed by user via P4RT
   if (!notif_initialized_) {
     auto status = InitializeNotificationCallback();
-    if (status == ::util::OkStatus()) {
+    if (status.ok()) {
       notif_initialized_ = true;
     }
   }
@@ -122,7 +117,7 @@ TdiIpsecManager::~TdiIpsecManager() = default;
   ASSIGN_OR_RETURN(auto session, tdi_sde_interface_->CreateSession());
   auto status = tdi_fixed_function_manager_->WriteSadbEntry(
       session, IPSEC_CONFIG_SADB_TABLE_NAME, op_type, msg);
-  if (status != ::util::OkStatus()) {
+  if (!status.ok()) {
     return MAKE_ERROR(ERR_AT_LEAST_ONE_OPER_FAILED)
            << "One or more write operations failed. "
            << "offload-id=" << msg.offload_id()

--- a/stratum/hal/lib/yang/yang_parse_tree_interface.cc
+++ b/stratum/hal/lib/yang/yang_parse_tree_interface.cc
@@ -1,6 +1,6 @@
 // Copyright 2018 Google LLC
 // Copyright 2018-present Open Networking Foundation
-// Copyright 2022-2023 Intel Corporation
+// Copyright 2022-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 // Interface setup functions for YangParseTreePaths. Used by the
@@ -626,7 +626,7 @@ void SetUpInterfacesInterfaceConfigHealthIndicator(const std::string& state,
     auto status = SetValue(node_id, port_id, tree,
                            &SetRequest::Request::Port::mutable_health_indicator,
                            &HealthIndicator::set_state, typed_state);
-    if (status != ::util::OkStatus()) {
+    if (!status.ok()) {
       return status;
     }
 
@@ -709,7 +709,7 @@ void SetUpInterfacesInterfaceEthernetConfigForwardingViability(
                  &SetRequest::Request::Port::mutable_forwarding_viability,
                  &ForwardingViability::set_state, new_forwarding_viability);
 
-    if (status != ::util::OkStatus()) {
+    if (!status.ok()) {
       return status;
     }
 

--- a/stratum/hal/lib/yang/yang_parse_tree_singleton.cc
+++ b/stratum/hal/lib/yang/yang_parse_tree_singleton.cc
@@ -102,7 +102,7 @@ void SetUpInterfacesInterfaceEthernetConfigPortSpeed(uint64 node_id,
     auto status = SetValue(node_id, port_id, tree,
                            &SetRequest::Request::Port::mutable_port_speed,
                            &PortSpeed::set_speed_bps, speed_bps);
-    if (status != ::util::OkStatus()) {
+    if (!status.ok()) {
       return status;
     }
 
@@ -170,7 +170,7 @@ void SetUpInterfacesInterfaceEthernetConfigAutoNegotiate(uint64 node_id,
     auto status = SetValue(node_id, port_id, tree,
                            &SetRequest::Request::Port::mutable_autoneg_status,
                            &AutonegotiationStatus::set_state, autoneg_status);
-    if (status != ::util::OkStatus()) {
+    if (!status.ok()) {
       return status;
     }
 
@@ -235,7 +235,7 @@ void SetUpInterfacesInterfaceConfigEnabled(const bool state, uint64 node_id,
     auto status = SetValue(node_id, port_id, tree,
                            &SetRequest::Request::Port::mutable_admin_status,
                            &AdminStatus::set_state, typed_state);
-    if (status != ::util::OkStatus()) {
+    if (!status.ok()) {
       return status;
     }
 
@@ -304,7 +304,7 @@ void SetUpInterfacesInterfaceConfigLoopbackMode(const bool loopback,
     auto status = SetValue(node_id, port_id, tree,
                            &SetRequest::Request::Port::mutable_loopback_status,
                            &LoopbackStatus::set_state, typed_state);
-    if (status != ::util::OkStatus()) {
+    if (!status.ok()) {
       return status;
     }
 
@@ -374,7 +374,7 @@ void SetUpInterfacesInterfaceEthernetConfigMacAddress(uint64 node_id,
     auto status = SetValue(node_id, port_id, tree,
                            &SetRequest::Request::Port::mutable_mac_address,
                            &MacAddress::set_mac_address, mac_address);
-    if (status != ::util::OkStatus()) {
+    if (!status.ok()) {
       return status;
     }
 


### PR DESCRIPTION
- Converted `status == ::util::OkStatus()` to `status.ok()` and `status != ::util::OkStatus()` to `!status.ok()`.