### PR TITLE
Implement GetMeterUnitsInPackets()

### DIFF
--- a/stratum/hal/lib/tdi/tdi_table_manager.cc
+++ b/stratum/hal/lib/tdi/tdi_table_manager.cc
@@ -47,6 +47,26 @@ namespace stratum {
 namespace hal {
 namespace tdi {
 
+namespace {
+
+template <typename T>
+::util::Status GetMeterUnitsInPackets(const T& meter, bool& units_in_packets) {
+  switch (meter.spec().unit()) {
+    case ::p4::config::v1::MeterSpec::BYTES:
+      units_in_packets = false;
+      break;
+    case ::p4::config::v1::MeterSpec::PACKETS:
+      units_in_packets = true;
+      break;
+    default:
+      return MAKE_ERROR(ERR_INVALID_PARAM) << "Unsupported meter spec on meter "
+                                           << meter.ShortDebugString() << ".";
+  }
+  return ::util::OkStatus();
+}
+
+}  // namespace
+
 TdiTableManager::TdiTableManager(OperationMode mode,
                                  TdiSdeInterface* tdi_sde_interface, int device)
     : mode_(mode),
@@ -197,23 +217,6 @@ std::unique_ptr<TdiTableManager> TdiTableManager::CreateInstance(
   RETURN_IF_ERROR(table_data->Reset(action.action_id()));
   for (const auto& param : action.params()) {
     RETURN_IF_ERROR(table_data->SetParam(param.param_id(), param.value()));
-  }
-  return ::util::OkStatus();
-}
-
-template <typename T>
-static ::util::Status GetMeterUnitsInPackets(const T& meter,
-                                             bool& units_in_packets) {
-  switch (meter.spec().unit()) {
-    case ::p4::config::v1::MeterSpec::BYTES:
-      units_in_packets = false;
-      break;
-    case ::p4::config::v1::MeterSpec::PACKETS:
-      units_in_packets = true;
-      break;
-    default:
-      return MAKE_ERROR(ERR_INVALID_PARAM) << "Unsupported meter spec on meter "
-                                           << meter.ShortDebugString() << ".";
   }
   return ::util::OkStatus();
 }

--- a/stratum/hal/lib/tdi/tdi_table_manager.cc
+++ b/stratum/hal/lib/tdi/tdi_table_manager.cc
@@ -504,14 +504,9 @@ static ::util::Status GetMeterUnitsInPackets(const T& meter,
     if (resource_type == "Direct-Meter" && request.has_meter_config()) {
       ASSIGN_OR_RETURN(auto meter,
                        p4_info_manager_->FindDirectMeterByID(resource_id));
-      switch (meter.spec().unit()) {
-        case ::p4::config::v1::MeterSpec::BYTES:
-        case ::p4::config::v1::MeterSpec::PACKETS:
-          break;
-        default:
-          return MAKE_ERROR(ERR_INVALID_PARAM)
-                 << "Unsupported meter spec on meter "
-                 << meter.ShortDebugString() << ".";
+      {
+        bool units_in_packets;
+        RETURN_IF_ERROR(GetMeterUnitsInPackets(meter, units_in_packets));
       }
       uint64 cir = 0;
       uint64 cburst = 0;
@@ -1057,14 +1052,9 @@ TdiTableManager::ReadDirectMeterEntry(
       absl::ReaderMutexLock l(&lock_);
       ASSIGN_OR_RETURN(auto meter,
                        p4_info_manager_->FindMeterByID(meter_entry.meter_id()));
-      switch (meter.spec().unit()) {
-        case ::p4::config::v1::MeterSpec::BYTES:
-        case ::p4::config::v1::MeterSpec::PACKETS:
-          break;
-        default:
-          return MAKE_ERROR(ERR_INVALID_PARAM)
-                 << "Unsupported meter spec on meter "
-                 << meter.ShortDebugString() << ".";
+      {
+        bool units_in_packets;
+        RETURN_IF_ERROR(GetMeterUnitsInPackets(meter, units_in_packets));
       }
     }
     // Index 0 is a valid value and not a wildcard.


### PR DESCRIPTION
- Defined a GetMeterUnitsInPackets() template function to replace
  both ad hoc logic and GetPktModMeterUnitsInPackets().

- Renamed meter_units_in_packets variables to units_in_packets.