### PR TITLE
Overhaul SetPktModMeterConfig()

### DIFF
--- a/stratum/hal/lib/tdi/tdi_table_manager.cc
+++ b/stratum/hal/lib/tdi/tdi_table_manager.cc
@@ -315,8 +315,8 @@ std::unique_ptr<TdiTableManager> TdiTableManager::CreateInstance(
                  << meter.ShortDebugString() << ".";
       }
       TdiPktModMeterConfig config;
-      config.isPktModMeter = meter_units_in_packets;
       SetPktModMeterConfig(config, table_entry);
+      config.isPktModMeter = meter_units_in_packets;
       RETURN_IF_ERROR(table_data->SetPktModMeterConfig(config));
     }
   }


### PR DESCRIPTION
- Modified SetPktModMeterConfig() to return void.

- Revised function to accept discrete meter_config and counter_data parameters. This makes it more readable.

- Added convenience functions that accept a MeterEntry or TableEntry and invoke the primary function.

- Replaced redundant logic in BuildTableData() with a call to SetPktModMeterConfig().