### PR TITLE
Disable failing test cases in tdi_table_manager_test

### DIFF
--- a/stratum/hal/lib/tdi/BUILD
+++ b/stratum/hal/lib/tdi/BUILD
@@ -320,7 +320,7 @@ stratum_cc_library(
 stratum_cc_test(
     name = "tdi_table_manager_test",
     srcs = ["tdi_table_manager_test.cc"],
-    tags = ["broken"],
+#   tags = ["broken"],  # disabled 3 test cases
     deps = [
         ":tdi_sde_mock",
         ":tdi_table_manager",

--- a/stratum/hal/lib/tdi/tdi_table_manager_test.cc
+++ b/stratum/hal/lib/tdi/tdi_table_manager_test.cc
@@ -173,8 +173,9 @@ TEST_F(TdiTableManagerTest, WriteDirectCounterEntryTest) {
           ::util::StatusOr<std::unique_ptr<TdiSdeInterface::TableKeyInterface>>(
               std::move(table_key_mock)))));
   EXPECT_CALL(*tdi_sde_wrapper_mock_, CreateTableData(kTdiRtTableId, _))
-      .WillOnce(Return(ByMove(
-          ::util::StatusOr<std::unique_ptr<TdiSdeInterface::TableDataInterface>>(
+      .WillOnce(
+          Return(ByMove(::util::StatusOr<
+                        std::unique_ptr<TdiSdeInterface::TableDataInterface>>(
               std::move(table_data_mock)))));
 
   const std::string kDirectCounterEntryText = R"pb(
@@ -261,6 +262,7 @@ TEST_F(TdiTableManagerTest, WriteDirectMeterEntryTest) {
       session_mock, ::p4::v1::Update::MODIFY, entry));
 }
 
+// clang-format off
 //[ RUN      ] TdiTableManagerTest.WriteIndirectMeterEntryTest
 //E20241008 22:01:52.255509    12 p4_info_manager.cc:297] StratumErrorSpace::ERR_INVALID_P4_INFO: P4Info ID UNSPECIFIED/0x2b67 (0x2b67) is not found
 //E20241008 22:01:52.255726    12 tdi_table_manager.cc:1257] Return Error: p4_info_manager_->FindResourceTypeByID(meter_id) at stratum/hal/lib/tdi/tdi_table_manager.cc:1257
@@ -273,6 +275,7 @@ TEST_F(TdiTableManagerTest, WriteDirectMeterEntryTest) {
 //         Expected: to be called once
 //           Actual: never called - unsatisfied and active
 //[  FAILED  ] TdiTableManagerTest.WriteIndirectMeterEntryTest (1 ms)
+// clang-format on
 TEST_F(TdiTableManagerTest, DISABLED_WriteIndirectMeterEntryTest) {
   ASSERT_OK(PushTestConfig());
   constexpr int kP4MeterId = 55555;
@@ -333,6 +336,7 @@ TEST_F(TdiTableManagerTest, RejectMeterEntryModifyWithoutMeterId) {
   EXPECT_THAT(ret.error_message(), HasSubstr("Missing meter id"));
 }
 
+// clang-format off
 //[ RUN      ] TdiTableManagerTest.RejectMeterEntryInsertDelete
 //E20241008 22:00:27.954881    12 tdi_table_manager.cc:1246] StratumErrorSpace::ERR_INVALID_PARAM: RET_CHECK failure (stratum/hal/lib/tdi/tdi_table_manager.cc:1246) 'type == ::p4::v1::Update::MODIFY || type == ::p4::v1::Update::DELETE' is false. Update type of RegisterEntry meter_id: 55555 index { index: 12345 } config { cir: 1 cburst: 100 pir: 2 pburst: 200 } must be MODIFY or DELETE.
 //E20241008 22:00:27.954906    12 tdi_table_manager.cc:1254] Return Error: tdi_sde_interface_->GetTdiRtId(meter_entry.meter_id()) at stratum/hal/lib/tdi/tdi_table_manager.cc:1254
@@ -343,6 +347,7 @@ TEST_F(TdiTableManagerTest, RejectMeterEntryModifyWithoutMeterId) {
 //  ret.error_code()
 //    Which is: 2
 //[  FAILED  ] TdiTableManagerTest.RejectMeterEntryInsertDelete (0 ms)
+// clang-format on
 TEST_F(TdiTableManagerTest, DISABLED_RejectMeterEntryInsertDelete) {
   ASSERT_OK(PushTestConfig());
   auto session_mock = std::make_shared<SessionMock>();
@@ -375,6 +380,7 @@ TEST_F(TdiTableManagerTest, DISABLED_RejectMeterEntryInsertDelete) {
   EXPECT_EQ(ERR_INVALID_PARAM, ret.error_code());
 }
 
+// clang-format off
 //[ RUN      ] TdiTableManagerTest.ReadSingleIndirectMeterEntryTest
 //E20241008 21:45:59.952771    12 p4_info_manager.cc:297] StratumErrorSpace::ERR_INVALID_P4_INFO: P4Info ID UNSPECIFIED/0x2b67 (0x2b67) is not found
 //E20241008 21:45:59.952782    12 tdi_table_manager.cc:1081] Return Error: p4_info_manager_->FindResourceTypeByID(table_id) at stratum/hal/lib/tdi/tdi_table_manager.cc:1081
@@ -391,6 +397,7 @@ TEST_F(TdiTableManagerTest, DISABLED_RejectMeterEntryInsertDelete) {
 //         Expected: to be called once
 //           Actual: never called - unsatisfied and active
 //[  FAILED  ] TdiTableManagerTest.ReadSingleIndirectMeterEntryTest (0 ms)
+// clang-format on
 TEST_F(TdiTableManagerTest, DISABLED_ReadSingleIndirectMeterEntryTest) {
   ASSERT_OK(PushTestConfig());
   auto session_mock = std::make_shared<SessionMock>();

--- a/stratum/hal/lib/tdi/tdi_table_manager_test.cc
+++ b/stratum/hal/lib/tdi/tdi_table_manager_test.cc
@@ -1,5 +1,5 @@
 // Copyright 2020-present Open Networking Foundation
-// Copyright 2022-2004 Intel Corporation
+// Copyright 2022-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 // adapted from bfrt_table_manager_test.cc


### PR DESCRIPTION
Disabled the following test cases:
- WriteIndirectMeterEntryTest
- RejectMeterEntryInsertDelete
- ReadSingleIndirectMeterEntryTest

Commented out the "broken" tag in the Bazel BUILD file.