### PR TITLE
Add missing compile-time dependency

### DIFF
--- a/stratum/lib/p4runtime/CMakeLists.txt
+++ b/stratum/lib/p4runtime/CMakeLists.txt
@@ -22,7 +22,10 @@ target_include_directories(stratum_lib_p4runtime_o PRIVATE
     ${PB_OUT_DIR}
 )
 
-target_link_libraries(stratum_lib_p4runtime_o PRIVATE stratum_proto)
+target_link_libraries(stratum_lib_p4runtime_o PRIVATE
+    p4_role_config_proto
+    stratum_proto
+)
 
 #######################
 # p4runtime_session_o #
@@ -38,4 +41,7 @@ target_include_directories(p4runtime_session_o PUBLIC
     ${PB_OUT_DIR}
 )
 
-target_link_libraries(p4runtime_session_o PUBLIC stratum_proto p4_role_config_proto)
+target_link_libraries(p4runtime_session_o PUBLIC
+    p4_role_config_proto
+    stratum_proto
+)


### PR DESCRIPTION
- Made stratum_lib_p4runtime_o dependent on p4_role_config_proto, to ensure that the protobuf header file has been generated for sdn_controller_manager to #include.