### PR TITLE
Extract P4ResourceMap class from P4InfoManager

### DIFF
--- a/stratum/hal/lib/p4/BUILD
+++ b/stratum/hal/lib/p4/BUILD
@@ -1,5 +1,6 @@
 # Copyright 2018 Google LLC
 # Copyright 2018-present Open Networking Foundation
+# Copyright 2023-2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
 load(
@@ -188,12 +189,13 @@ stratum_cc_library(
     name = "p4_resource_map",
     hdrs = ["p4_resource_map.h"],
     deps = [
+        "//stratum/glue:integral_types",
         "//stratum/glue:logging",
         "//stratum/glue/status",
         "//stratum/glue/status:status_macros",
         "//stratum/glue/status:statusor",
+        "//stratum/hal/lib/p4:utils",
         "//stratum/lib:macros",
-        "//stratum/lib:utils",
         "@com_github_p4lang_p4runtime//:p4info_cc_proto",
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_protobuf//:protobuf",

--- a/stratum/hal/lib/p4/BUILD
+++ b/stratum/hal/lib/p4/BUILD
@@ -137,6 +137,7 @@ stratum_cc_library(
     srcs = ["p4_info_manager.cc"],
     hdrs = ["p4_info_manager.h"],
     deps = [
+        ":p4_resource_map",
         ":utils",
         "//stratum/glue:logging",
         "//stratum/glue/gtl:map_util",
@@ -180,6 +181,22 @@ stratum_cc_test(
         "@com_google_absl//absl/memory",
         "@com_google_absl//absl/strings",
         "@com_google_googletest//:gtest_main",
+    ],
+)
+
+stratum_cc_library(
+    name = "p4_resource_map",
+    hdrs = ["p4_resource_map.h"],
+    deps = [
+        "//stratum/glue:logging",
+        "//stratum/glue/status",
+        "//stratum/glue/status:status_macros",
+        "//stratum/glue/status:statusor",
+        "//stratum/lib:macros",
+        "//stratum/lib:utils",
+        "@com_github_p4lang_p4runtime//:p4info_cc_proto",
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_protobuf//:protobuf",
     ],
 )
 

--- a/stratum/hal/lib/p4/CMakeLists.txt
+++ b/stratum/hal/lib/p4/CMakeLists.txt
@@ -7,6 +7,7 @@
 add_library(stratum_hal_lib_p4_o OBJECT
     p4_info_manager.cc
     p4_info_manager.h
+    p4_resource_map.h
     utils.cc
     utils.h
 )

--- a/stratum/hal/lib/p4/p4_info_manager.h
+++ b/stratum/hal/lib/p4/p4_info_manager.h
@@ -22,6 +22,7 @@
 #include "stratum/glue/status/status.h"
 #include "stratum/glue/status/status_macros.h"
 #include "stratum/glue/status/statusor.h"
+#include "stratum/hal/lib/p4/p4_resource_map.h"
 #include "stratum/hal/lib/p4/utils.h"
 #include "stratum/lib/macros.h"
 #include "stratum/public/proto/p4_annotation.pb.h"
@@ -183,101 +184,6 @@ class P4InfoManager {
   virtual ::util::Status VerifyRequiredObjects();
 
  private:
-  // This type defines a callback that verifies the Preamble content.
-  typedef std::function<::util::Status(
-      const ::p4::config::v1::Preamble& preamble,
-      const std::string& resource_type)>
-      PreambleCallback;
-
-  // This class provides a common implementation for mapping P4 IDs and names
-  // to a specific P4 resource of type T, i.e. name/ID to Table, name/ID to
-  // Action, etc.
-  template <class T>
-  class P4ResourceMap {
-   public:
-    // The resource_type is a descriptive string for logging and error messages.
-    explicit P4ResourceMap(const std::string& resource_type)
-        : resource_type_(resource_type) {}
-    virtual ~P4ResourceMap() {}
-
-    // Iterates over all the P4 resources of type T and builds the internal
-    // maps for ID and name lookup.
-    ::util::Status BuildMaps(
-        const ::google::protobuf::RepeatedPtrField<T>& p4_resources,
-        PreambleCallback preamble_cb) {
-      ::util::Status status = ::util::OkStatus();
-      for (const auto& resource : p4_resources) {
-        auto preamble_status = preamble_cb(resource.preamble(), resource_type_);
-        if (preamble_status.ok()) {
-          AddIdMapEntry(resource);
-          AddNameMapEntry(resource);
-        } else {
-          APPEND_STATUS_IF_ERROR(status, preamble_status);
-        }
-      }
-      return status;
-    }
-
-    // Attempts to find the P4 resource matching the input ID.
-    ::util::StatusOr<const T> FindByID(uint32 id) const {
-      auto iter = id_to_resource_map_.find(id);
-      if (iter == id_to_resource_map_.end()) {
-        return MAKE_ERROR(ERR_INVALID_P4_INFO)
-               << "P4Info " << resource_type_ << " ID " << PrintP4ObjectID(id)
-               << " is not found";
-      }
-      return *iter->second;
-    }
-
-    // Attempts to find the P4 resource matching the input name.
-    ::util::StatusOr<const T> FindByName(const std::string& name) const {
-      auto iter = name_to_resource_map_.find(name);
-      if (iter == name_to_resource_map_.end()) {
-        return MAKE_ERROR(ERR_INVALID_P4_INFO)
-               << "P4Info " << resource_type_ << " name " << name
-               << " is not found";
-      }
-      return *iter->second;
-    }
-
-    // Outputs LOG messages with name to ID translations for all members of
-    // this P4ResourceMap.
-    void DumpNamesToIDs() const {
-      for (auto iter : name_to_resource_map_) {
-        LOG(INFO) << resource_type_ << " name " << iter.first << " has ID "
-                  << PrintP4ObjectID(iter.second->preamble().id());
-      }
-    }
-
-    // Accessor.
-    const std::string& resource_type() const { return resource_type_; }
-
-   private:
-    // The next two methods create lookup map entries for the input resource.
-    // They expect that the preamble ID and name have been validated before
-    // they are called.
-    void AddIdMapEntry(const T& p4_resource) {
-      uint32 id_key = p4_resource.preamble().id();
-      auto id_result = id_to_resource_map_.emplace(id_key, &p4_resource);
-      DCHECK(id_result.second)
-          << "P4Info unexpected duplicate " << resource_type_ << " ID "
-          << PrintP4ObjectID(id_key);
-    }
-
-    void AddNameMapEntry(const T& p4_resource) {
-      const std::string& name_key = p4_resource.preamble().name();
-      auto name_result = name_to_resource_map_.emplace(name_key, &p4_resource);
-      DCHECK(name_result.second) << "P4Info unexpected duplicate "
-                                 << resource_type_ << " name " << name_key;
-    }
-
-    const std::string resource_type_;  // String used in errors and logs.
-
-    // These maps facilitate lookups from P4 name/ID to resource type T.
-    absl::flat_hash_map<uint32, const T*> id_to_resource_map_;
-    absl::flat_hash_map<std::string, const T*> name_to_resource_map_;
-  };
-
   // Does common processing of Preamble fields embedded in any resource,
   // returning an error status if the name or ID is invalid or non-unique.
   ::util::Status ProcessPreamble(const ::p4::config::v1::Preamble& preamble,

--- a/stratum/hal/lib/p4/p4_resource_map.h
+++ b/stratum/hal/lib/p4/p4_resource_map.h
@@ -1,0 +1,124 @@
+// Copyright 2018 Google LLC
+// Copyright 2018-present Open Networking Foundation
+// Copyright 2023-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+// Extracted from the P4InfoManager class.
+
+#ifndef STRATUM_HAL_LIB_P4_P4_RESOURCE_MAP
+#define STRATUM_HAL_LIB_P4_P4_RESOURCE_MAP
+
+#include <functional>
+#include <string>
+
+#include "absl/container/flat_hash_map.h"
+#include "google/protobuf/repeated_field.h"
+#include "idpf/p4info.pb.h"
+#include "stratum/glue/integral_types.h"
+#include "stratum/glue/logging.h"
+#include "stratum/glue/status/status.h"
+#include "stratum/glue/status/status_macros.h"
+#include "stratum/glue/status/statusor.h"
+#include "stratum/hal/lib/p4/utils.h"
+#include "stratum/lib/macros.h"
+
+namespace stratum {
+namespace hal {
+
+// This type defines a callback that verifies the Preamble content.
+typedef std::function<::util::Status(const ::p4::config::v1::Preamble& preamble,
+                                     const std::string& resource_type)>
+    PreambleCallback;
+
+// This class provides a common implementation for mapping P4 IDs and names
+// to a specific P4 resource of type T, i.e. name/ID to Table, name/ID to
+// Action, etc.
+template <class T>
+class P4ResourceMap {
+ public:
+  // The resource_type is a descriptive string for logging and error messages.
+  explicit P4ResourceMap(const std::string& resource_type)
+      : resource_type_(resource_type) {}
+  virtual ~P4ResourceMap() {}
+
+  // Iterates over all the P4 resources of type T and builds the internal
+  // maps for ID and name lookup.
+  ::util::Status BuildMaps(
+      const ::google::protobuf::RepeatedPtrField<T>& p4_resources,
+      PreambleCallback preamble_cb) {
+    ::util::Status status = ::util::OkStatus();
+    for (const auto& resource : p4_resources) {
+      auto preamble_status = preamble_cb(resource.preamble(), resource_type_);
+      if (preamble_status.ok()) {
+        AddIdMapEntry(resource);
+        AddNameMapEntry(resource);
+      } else {
+        APPEND_STATUS_IF_ERROR(status, preamble_status);
+      }
+    }
+    return status;
+  }
+
+  // Attempts to find the P4 resource matching the input ID.
+  ::util::StatusOr<const T> FindByID(uint32 id) const {
+    auto iter = id_to_resource_map_.find(id);
+    if (iter == id_to_resource_map_.end()) {
+      return MAKE_ERROR(ERR_INVALID_P4_INFO)
+             << "P4Info " << resource_type_ << " ID " << PrintP4ObjectID(id)
+             << " is not found";
+    }
+    return *iter->second;
+  }
+
+  // Attempts to find the P4 resource matching the input name.
+  ::util::StatusOr<const T> FindByName(const std::string& name) const {
+    auto iter = name_to_resource_map_.find(name);
+    if (iter == name_to_resource_map_.end()) {
+      return MAKE_ERROR(ERR_INVALID_P4_INFO)
+             << "P4Info " << resource_type_ << " name " << name
+             << " is not found";
+    }
+    return *iter->second;
+  }
+
+  // Outputs LOG messages with name to ID translations for all members of
+  // this P4ResourceMap.
+  void DumpNamesToIDs() const {
+    for (auto iter : name_to_resource_map_) {
+      LOG(INFO) << resource_type_ << " name " << iter.first << " has ID "
+                << PrintP4ObjectID(iter.second->preamble().id());
+    }
+  }
+
+  // Accessor.
+  const std::string& resource_type() const { return resource_type_; }
+
+ private:
+  // The next two methods create lookup map entries for the input resource.
+  // They expect that the preamble ID and name have been validated before
+  // they are called.
+  void AddIdMapEntry(const T& p4_resource) {
+    uint32 id_key = p4_resource.preamble().id();
+    auto id_result = id_to_resource_map_.emplace(id_key, &p4_resource);
+    DCHECK(id_result.second) << "P4Info unexpected duplicate " << resource_type_
+                             << " ID " << PrintP4ObjectID(id_key);
+  }
+
+  void AddNameMapEntry(const T& p4_resource) {
+    const std::string& name_key = p4_resource.preamble().name();
+    auto name_result = name_to_resource_map_.emplace(name_key, &p4_resource);
+    DCHECK(name_result.second) << "P4Info unexpected duplicate "
+                               << resource_type_ << " name " << name_key;
+  }
+
+  const std::string resource_type_;  // String used in errors and logs.
+
+  // These maps facilitate lookups from P4 name/ID to resource type T.
+  absl::flat_hash_map<uint32, const T*> id_to_resource_map_;
+  absl::flat_hash_map<std::string, const T*> name_to_resource_map_;
+};
+
+}  // namespace hal
+}  // namespace stratum
+
+#endif  // STRATUM_HAL_LIB_P4_P4_RESOURCE_MAP

--- a/stratum/hal/lib/p4/p4_resource_map.h
+++ b/stratum/hal/lib/p4/p4_resource_map.h
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Extracted from the P4InfoManager class.
+// Note that is module is covered by P4InfoManagerTest.
 
 #ifndef STRATUM_HAL_LIB_P4_P4_RESOURCE_MAP
 #define STRATUM_HAL_LIB_P4_P4_RESOURCE_MAP
@@ -13,7 +14,7 @@
 
 #include "absl/container/flat_hash_map.h"
 #include "google/protobuf/repeated_field.h"
-#include "idpf/p4info.pb.h"
+#include "p4/config/v1/p4info.pb.h"
 #include "stratum/glue/integral_types.h"
 #include "stratum/glue/logging.h"
 #include "stratum/glue/status/status.h"


### PR DESCRIPTION
This refactoring is part of an effort to move the ES2K-specific code in `P4InfoManager` (a common file) to a separate class.

Tested by running the p4 module unit tests (`//stratum/hal/lib/p4:all`).

`p4_info_manager_test` covers 97.6% of the lines and 79.6% of the functions in `p4_resource_map.h`. The sole omission is:

![image](https://github.com/user-attachments/assets/a2b1d453-1d8d-470b-901f-6ff947ddbc41)

Interesting that this line constitutes 20.4% of the functions...😕