### PR TITLE
Reenable P4InfoManager test cases

### DIFF
--- a/stratum/hal/lib/p4/BUILD
+++ b/stratum/hal/lib/p4/BUILD
@@ -1,5 +1,6 @@
 # Copyright 2018 Google LLC
 # Copyright 2018-present Open Networking Foundation
+# Copyright 2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
 load(
@@ -172,6 +173,7 @@ stratum_cc_test(
     srcs = ["p4_info_manager_test.cc"],
     deps = [
         ":p4_info_manager",
+        ":test_main",
         ":testdata",
         "//stratum/lib:utils",
         "//stratum/public/proto:p4_table_defs_cc_proto",
@@ -179,7 +181,6 @@ stratum_cc_test(
         "@com_github_p4lang_p4runtime//:p4info_cc_proto",
         "@com_google_absl//absl/memory",
         "@com_google_absl//absl/strings",
-        "@com_google_googletest//:gtest_main",
     ],
 )
 
@@ -454,4 +455,15 @@ stratum_cc_library(
     name = "testdata",
     arches = HOST_ARCHES,
     data = glob(["testdata/**"]),
+)
+
+cc_library(
+    name = "test_main",
+    testonly = 1,
+    srcs = ["test_main.cc"],
+    deps = [
+        "//stratum/glue:init_google",
+        "//stratum/glue:logging",
+        "@com_google_googletest//:gtest",
+    ],
 )

--- a/stratum/hal/lib/p4/p4_info_manager_test.cc
+++ b/stratum/hal/lib/p4/p4_info_manager_test.cc
@@ -1,6 +1,6 @@
 // Copyright 2018 Google LLC
 // Copyright 2018-present Open Networking Foundation
-// Copyright 2023 Intel Corporation
+// Copyright 2023-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 // P4InfoManager unit tests.
@@ -19,6 +19,8 @@
 #include "stratum/public/proto/p4_table_defs.pb.h"
 
 DECLARE_bool(skip_p4_min_objects_check);
+
+#define TEST_TOR_P4_INFO 1
 
 namespace stratum {
 namespace hal {
@@ -195,16 +197,17 @@ class P4InfoManagerTest : public testing::Test {
     SetUpNewP4Info();
   }
 
-  // FIXME(boc) disabling test due to missing tor_p4_info.pb.txt
+#ifdef TEST_TOR_P4_INFO
   // Populates p4_test_info_ with all resources from the tor.p4 spec.  This
   // data provides assurance that P4InfoManager can handle real P4 compiler
   // output.
-  //  void SetUpTorP4Info() {
-  //    const std::string kTorP4File =
-  //        "stratum/hal/lib/p4/testdata/tor_p4_info.pb.txt";
-  //    ASSERT_TRUE(ReadProtoFromTextFile(kTorP4File, &p4_test_info_).ok());
-  //    SetUpNewP4Info();
-  //  }
+  void SetUpTorP4Info() {
+    const std::string kTorP4File =
+        "stratum/hal/lib/p4/testdata/tor_p4_info.pb.txt";
+    ASSERT_TRUE(ReadProtoFromTextFile(kTorP4File, &p4_test_info_).ok());
+    SetUpNewP4Info();
+  }
+#endif
 
   ::p4::config::v1::P4Info p4_test_info_;           // Sets up test P4Info.
   std::unique_ptr<P4InfoManager> p4_test_manager_;  // P4InfoManager for tests.
@@ -848,8 +851,7 @@ TEST_F(P4InfoManagerTest, TestDumpNamesToIDs) {
   p4_test_manager_->DumpNamesToIDs();
 }
 
-// FIXME(boc) disabling test due to missing tor_p4_info.pb.txt
-/*
+#ifdef TEST_TOR_P4_INFO
 // Tests ability to handle a "real" P4 spec (tor.p4).
 TEST_F(P4InfoManagerTest, TestTorP4Info) {
   SetUpTorP4Info();
@@ -931,7 +933,7 @@ TEST_F(P4InfoManagerTest, TestDuplicateIDTableAndAction) {
   EXPECT_FALSE(status.error_message().empty());
   EXPECT_THAT(status.error_message(), HasSubstr("not unique"));
 }
- */
+#endif
 
 #if 0
 // TODO(unknown): Rework this test for 2 objects with global IDs.
@@ -972,9 +974,9 @@ TEST_F(P4InfoManagerTest, TestTableMissingActionXref) {
   EXPECT_THAT(status.error_message(), HasSubstr("refers to an invalid"));
 }
 
+#ifdef TEST_TOR_P4_INFO
 // FIXME(boc) disabling test due to missing tor_p4_info.pb.txt
 // Tests GetSwitchStackAnnotations with a pipeline_stage.
-/*
 TEST_F(P4InfoManagerTest, TestPipelineStageAnnotations) {
   SetUpTorP4Info();
   ASSERT_TRUE(p4_test_manager_->InitializeAndVerify().ok());
@@ -983,7 +985,7 @@ TEST_F(P4InfoManagerTest, TestPipelineStageAnnotations) {
   EXPECT_TRUE(status.ok());
   EXPECT_EQ(P4Annotation::VLAN_ACL, status.ValueOrDie().pipeline_stage());
 }
- */
+#endif
 
 // Tests GetSwitchStackAnnotations with multiple annotations.
 TEST_F(P4InfoManagerTest, TestGetAnnotationsMultiple) {

--- a/stratum/hal/lib/p4/test_main.cc
+++ b/stratum/hal/lib/p4/test_main.cc
@@ -1,0 +1,40 @@
+// Copyright 2018 Google LLC
+// Copyright 2018-present Open Networking Foundation
+// Copyright 2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+// This is the main entry for p4 module tests.
+#include <stdlib.h>
+
+#include "gflags/gflags.h"
+#include "gtest/gtest.h"
+#include "stratum/glue/init_google.h"
+#include "stratum/glue/logging.h"
+
+static char kDefaultTmpDir[] = "/tmp/stratum_hal_lib_p4_test.XXXXXX";
+
+DEFINE_string(test_tmpdir, "", "Temp directory to be used for tests.");
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  InitGoogle(argv[0], &argc, &argv, true);
+  ::stratum::InitStratumLogging();
+
+  bool tmpdir_created = false;
+  if (FLAGS_test_tmpdir.empty()) {
+    CHECK(mkdtemp(kDefaultTmpDir));
+    FLAGS_test_tmpdir = kDefaultTmpDir;
+    tmpdir_created = true;
+    LOG(INFO) << "Created FLAGS_test_tmpdir " << FLAGS_test_tmpdir;
+  }
+
+  int result = RUN_ALL_TESTS();
+
+  if (tmpdir_created) {
+    const std::string cleanup("rm -rf " + FLAGS_test_tmpdir);
+    system(cleanup.c_str());
+    LOG(INFO) << "Cleaned up FLAGS_test_tmpdir " << FLAGS_test_tmpdir;
+  }
+
+  return result;
+}


### PR DESCRIPTION
- Reenabled the TorP4Info test cases in p4_info_manager_test.

- Added a local main function to suppress logger initialization warning.