### PR TITLE
Introduce ExternManager class architecture

### DIFF
--- a/stratum/hal/lib/p4/BUILD
+++ b/stratum/hal/lib/p4/BUILD
@@ -134,6 +134,15 @@ stratum_cc_test(
 )
 
 stratum_cc_library(
+    name = "p4_extern_manager",
+    hdrs = ["p4_extern_manager.h"],
+    deps = [
+        ":p4_resource_map",
+        "@com_github_p4lang_p4runtime//:p4info_cc_proto",
+    ],
+)
+
+stratum_cc_library(
     name = "p4_info_manager",
     srcs = ["p4_info_manager.cc"],
     hdrs = ["p4_info_manager.h"],

--- a/stratum/hal/lib/p4/CMakeLists.txt
+++ b/stratum/hal/lib/p4/CMakeLists.txt
@@ -5,6 +5,7 @@
 #
 
 add_library(stratum_hal_lib_p4_o OBJECT
+    p4_extern_manager.h
     p4_info_manager.cc
     p4_info_manager.h
     p4_resource_map.h

--- a/stratum/hal/lib/p4/p4_extern_manager.h
+++ b/stratum/hal/lib/p4/p4_extern_manager.h
@@ -1,0 +1,29 @@
+// Copyright 2023-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef STRATUM_HAL_LIB_P4_P4_EXTERN_MANAGER_H_
+#define STRATUM_HAL_LIB_P4_P4_EXTERN_MANAGER_H_
+
+#include "p4/config/v1/p4info.pb.h"
+#include "stratum/hal/lib/p4/p4_resource_map.h"
+
+namespace stratum {
+namespace hal {
+
+class P4ExternManager {
+ public:
+  virtual ~P4ExternManager() = default;
+
+  // Called by P4InfoManager to register P4Extern resources.
+  virtual void RegisterExterns(const ::p4::config::v1::P4Info& p4info,
+                               const PreambleCallback& preamble_pb) = 0;
+
+ protected:
+  // Default constructor.
+  P4ExternManager() {}
+};
+
+}  // namespace hal
+}  // namespace stratum
+
+#endif  // STRATUM_HAL_LIB_P4_P4_EXTERN_MANAGER_H_

--- a/stratum/hal/lib/p4/p4_resource_map.h
+++ b/stratum/hal/lib/p4/p4_resource_map.h
@@ -91,8 +91,9 @@ class P4ResourceMap {
     }
   }
 
-  // Accessor.
+  // Accessors.
   const std::string& resource_type() const { return resource_type_; }
+  uint32 size() const { return id_to_resource_map_.size(); }
 
  private:
   // The next two methods create lookup map entries for the input resource.

--- a/stratum/hal/lib/tdi/BUILD
+++ b/stratum/hal/lib/tdi/BUILD
@@ -683,3 +683,59 @@ stratum_cc_test(
         "@com_google_googletest//:gtest_main",
     ],
 )
+
+stratum_cc_library(
+    name = "tdi_extern_manager",
+    hdrs = ["tdi_extern_manager.h"],
+    deps = [
+        ":tdi_resource_handler",
+        "//stratum/hal/lib/p4:p4_extern_manager",
+        "//stratum/hal/lib/p4:p4_resource_map",
+        "@com_github_p4lang_p4runtime//:p4info_cc_proto",
+        "@com_google_absl//absl/memory",
+    ],
+)
+
+stratum_cc_library(
+    name = "tdi_pkt_mod_meter_config",
+    hdrs = ["tdi_pkt_mod_meter_config.h"],
+    deps = [
+        "//stratum/glue:integral_types",
+    ],
+)
+
+stratum_cc_library(
+    name = "tdi_table_helpers",
+    srcs = ["tdi_table_helpers.cc"],
+    hdrs = ["tdi_table_helpers.h"],
+    deps = [
+        ":tdi_pkt_mod_meter_config",
+        "//stratum/glue/status:status_macros",
+        "//stratum/public/proto:error_cc_proto",
+        "@com_github_p4lang_p4runtime//:p4info_cc_proto",
+        "@com_github_p4lang_p4runtime//:p4runtime_cc_proto",
+    ],
+)
+
+stratum_cc_library(
+    name = "tdi_target_factory",
+    hdrs = ["tdi_target_factory.h"],
+    deps = [
+        ":tdi_extern_manager",
+        "@com_google_absl//absl/memory",
+    ],
+)
+
+stratum_cc_library(
+    name = "tdi_resource_handler",
+    hdrs = ["tdi_resource_handler.h"],
+    deps = [
+        ":tdi_sde_interface",
+        "//stratum/glue:integral_types",
+        "//stratum/glue/status",
+        "//stratum/glue/status:statusor",
+        "//stratum/hal/lib/common:writer_interface",
+        "@com_github_p4lang_p4runtime//:p4runtime_cc_proto",
+        "@com_google_absl//absl/memory",
+    ],
+)

--- a/stratum/hal/lib/tdi/es2k/BUILD
+++ b/stratum/hal/lib/tdi/es2k/BUILD
@@ -330,3 +330,93 @@ stratum_cc_library(
         "@com_google_googletest//:gtest",
     ],
 )
+
+stratum_cc_library(
+    name = "es2k_extern_manager",
+    srcs = ["es2k_extern_manager.cc"],
+    deps = [
+        ":es2k_direct_pkt_mod_meter_handler",
+        ":es2k_extern_manager_hdrs",
+        ":es2k_pkt_mod_meter_handler",
+        "//stratum/glue/status:status_macros",
+        "//stratum/hal/lib/p4:utils",
+    ],
+)
+
+stratum_cc_library(
+    name = "es2k_extern_manager_hdrs",
+    hdrs = ["es2k_extern_manager.h"],
+    deps = [
+        "//stratum/glue:integral_types",
+        "//stratum/glue/status:statusor",
+        "//stratum/hal/lib/p4:p4_info_manager",
+        "//stratum/hal/lib/p4:p4_resource_map",
+        "//stratum/hal/lib/tdi:tdi_extern_manager",
+        "//stratum/hal/lib/tdi:tdi_resource_handler",
+        "@com_github_p4lang_p4runtime//:idpf_p4info_cc_proto",
+        "@com_github_p4lang_p4runtime//:p4info_cc_proto",
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_protobuf//:protobuf",
+    ],
+)
+
+stratum_cc_test(
+    name = "es2k_extern_manager_test",
+    srcs = ["es2k_extern_manager_test.cc"],
+    deps = [
+        ":es2k_extern_manager",
+        ":es2k_target_factory",
+        ":test_main",
+        "//stratum/hal/lib/p4:p4_info_manager_mock",
+        "//stratum/hal/lib/tdi:tdi_sde_mock",
+        "@com_github_p4lang_p4runtime//:p4info_cc_proto",
+        "@com_google_absl//absl/memory",
+        "@com_google_absl//absl/synchronization",
+        "@com_google_googletest//:gtest",
+    ],
+)
+
+stratum_cc_library(
+    name = "es2k_target_factory",
+    hdrs = ["es2k_target_factory.h"],
+    deps = [
+        ":es2k_extern_manager",
+        "//stratum/hal/lib/tdi:tdi_target_factory",
+    ],
+)
+
+stratum_cc_library(
+    name = "es2k_direct_pkt_mod_meter_handler",
+    srcs = ["es2k_direct_pkt_mod_meter_handler.cc"],
+    hdrs = ["es2k_direct_pkt_mod_meter_handler.h"],
+    deps = [
+        ":es2k_extern_manager_hdrs",
+        "//stratum/glue:integral_types",
+        "//stratum/glue/status",
+        "//stratum/glue/status:status_macros",
+        "//stratum/glue/status:statusor",
+        "//stratum/hal/lib/tdi:tdi_resource_handler",
+        "//stratum/hal/lib/tdi:tdi_sde_interface",
+        "//stratum/hal/lib/tdi:tdi_table_helpers",
+        "@com_github_p4lang_p4runtime//:idpf_p4info_cc_proto",
+        "@com_github_p4lang_p4runtime//:p4runtime_cc_proto",
+    ],
+)
+
+stratum_cc_library(
+    name = "es2k_pkt_mod_meter_handler",
+    srcs = ["es2k_pkt_mod_meter_handler.cc"],
+    hdrs = ["es2k_pkt_mod_meter_handler.h"],
+    deps = [
+        ":es2k_extern_manager_hdrs",
+        "//stratum/glue:integral_types",
+        "//stratum/glue/status",
+        "//stratum/glue/status:status_macros",
+        "//stratum/hal/lib/p4:p4_info_manager",
+        "//stratum/hal/lib/tdi:tdi_resource_handler",
+        "//stratum/hal/lib/tdi:tdi_sde_interface",
+        "//stratum/hal/lib/tdi:tdi_table_helpers",
+        "@com_github_p4lang_p4runtime//:idpf_p4info_cc_proto",
+        "@com_github_p4lang_p4runtime//:p4runtime_cc_proto",
+    ],
+)

--- a/stratum/hal/lib/tdi/es2k/es2k_direct_pkt_mod_meter_handler.cc
+++ b/stratum/hal/lib/tdi/es2k/es2k_direct_pkt_mod_meter_handler.cc
@@ -1,0 +1,59 @@
+// Copyright 2020-present Open Networking Foundation
+// Copyright 2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+// ES2K DirectPktModMeter resource handler (implementation).
+
+#include "stratum/hal/lib/tdi/es2k/es2k_direct_pkt_mod_meter_handler.h"
+
+#include "idpf/p4info.pb.h"
+#include "p4/config/v1/p4info.pb.h"
+#include "stratum/glue/status/status_macros.h"
+#include "stratum/hal/lib/tdi/tdi_pkt_mod_meter_config.h"
+#include "stratum/hal/lib/tdi/tdi_table_helpers.h"
+
+namespace stratum {
+namespace hal {
+namespace tdi {
+
+using namespace stratum::hal::tdi::helpers;
+
+Es2kDirectPktModMeterHandler::Es2kDirectPktModMeterHandler(
+    Es2kExternManager* extern_manager)
+    : TdiResourceHandler("DirectPacketModMeter",
+                         ::p4::config::v1::P4Ids::DIRECT_PACKET_MOD_METER),
+      extern_manager_(extern_manager) {}
+
+Es2kDirectPktModMeterHandler::~Es2kDirectPktModMeterHandler() {}
+
+::util::Status Es2kDirectPktModMeterHandler::DoBuildTableData(
+    const ::p4::v1::TableEntry& table_entry,
+    TdiSdeInterface::TableDataInterface* table_data, uint32 resource_id) {
+  if (table_entry.has_meter_config()) {
+    bool units_in_packets;  // or bytes
+    ASSIGN_OR_RETURN(auto meter,
+                     extern_manager_->FindDirectPktModMeterByID(resource_id));
+    RETURN_IF_ERROR(GetMeterUnitsInPackets(meter, units_in_packets));
+
+    TdiPktModMeterConfig config;
+    SetPktModMeterConfig(config, table_entry);
+    config.isPktModMeter = units_in_packets;
+
+    RETURN_IF_ERROR(table_data->SetPktModMeterConfig(config));
+  }
+  return ::util::OkStatus();
+}
+
+util::Status Es2kDirectPktModMeterHandler::DoReadDirectMeterEntry(
+    const TdiSdeInterface::TableDataInterface* table_data,
+    const ::p4::v1::TableEntry& table_entry,
+    ::p4::v1::DirectMeterEntry& result) {
+  TdiPktModMeterConfig cfg;
+  RETURN_IF_ERROR(table_data->GetPktModMeterConfig(cfg));
+  SetDirectMeterEntry(result, cfg);
+  return ::util::OkStatus();
+}
+
+}  // namespace tdi
+}  // namespace hal
+}  // namespace stratum

--- a/stratum/hal/lib/tdi/es2k/es2k_direct_pkt_mod_meter_handler.h
+++ b/stratum/hal/lib/tdi/es2k/es2k_direct_pkt_mod_meter_handler.h
@@ -1,0 +1,47 @@
+// Copyright 2020-present Open Networking Foundation
+// Copyright 2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+// ES2K DirectPktModMeter resource handler (interface).
+
+#ifndef ES2K_DIRECT_PKT_MOD_METER_HANDLER_H_
+#define ES2K_DIRECT_PKT_MOD_METER_HANDLER_H_
+
+#include "absl/synchronization/mutex.h"
+#include "p4/v1/p4runtime.pb.h"
+#include "stratum/glue/integral_types.h"
+#include "stratum/glue/status/status.h"
+#include "stratum/glue/status/statusor.h"
+#include "stratum/hal/lib/tdi/es2k/es2k_extern_manager.h"
+#include "stratum/hal/lib/tdi/tdi_resource_handler.h"
+#include "stratum/hal/lib/tdi/tdi_sde_interface.h"
+
+namespace stratum {
+namespace hal {
+namespace tdi {
+
+class Es2kDirectPktModMeterHandler : public TdiResourceHandler {
+ public:
+  Es2kDirectPktModMeterHandler(Es2kExternManager* extern_manager);
+
+  virtual ~Es2kDirectPktModMeterHandler();
+
+  ::util::Status DoBuildTableData(
+      const ::p4::v1::TableEntry& table_entry,
+      TdiSdeInterface::TableDataInterface* table_data,
+      uint32 resource_id) override;
+
+  util::Status DoReadDirectMeterEntry(
+      const TdiSdeInterface::TableDataInterface* table_data,
+      const ::p4::v1::TableEntry& table_entry,
+      ::p4::v1::DirectMeterEntry& result) override;
+
+ protected:
+  Es2kExternManager* extern_manager_;  // not owned by this class
+};
+
+}  // namespace tdi
+}  // namespace hal
+}  // namespace stratum
+
+#endif  // ES2K_DIRECT_PKT_MOD_METER_HANDLER_H_

--- a/stratum/hal/lib/tdi/es2k/es2k_extern_manager.cc
+++ b/stratum/hal/lib/tdi/es2k/es2k_extern_manager.cc
@@ -1,0 +1,190 @@
+// Copyright 2023-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#include "stratum/hal/lib/tdi/es2k/es2k_extern_manager.h"
+
+#include "stratum/glue/logging.h"
+#include "stratum/glue/status/status_macros.h"
+#include "stratum/hal/lib/p4/utils.h"
+#include "stratum/hal/lib/tdi/es2k/es2k_direct_pkt_mod_meter_handler.h"
+#include "stratum/hal/lib/tdi/es2k/es2k_pkt_mod_meter_handler.h"
+
+namespace stratum {
+namespace hal {
+namespace tdi {
+
+Es2kExternManager::Es2kExternManager()
+    : pkt_mod_meter_map_("PacketModMeter"),
+      direct_pkt_mod_meter_map_("DirectPacketModMeter") {}
+
+::util::Status Es2kExternManager::Initialize(TdiSdeInterface* sde_interface,
+                                             P4InfoManager* p4_info_manager,
+                                             absl::Mutex* lock, int device) {
+  RET_CHECK(sde_interface != nullptr);
+  RET_CHECK(p4_info_manager != nullptr);
+  RET_CHECK(lock != nullptr);
+
+  params_.sde_interface = sde_interface;
+  params_.p4_info_manager = p4_info_manager;
+  params_.lock = lock;
+  params_.device = device;
+
+  return ::util::OkStatus();
+}
+
+void Es2kExternManager::RegisterExterns(const ::p4::config::v1::P4Info& p4info,
+                                        const PreambleCallback& preamble_cb) {
+  if (!p4info.externs().empty()) {
+    for (const auto& p4extern : p4info.externs()) {
+      switch (p4extern.extern_type_id()) {
+        case ::p4::config::v1::P4Ids::PACKET_MOD_METER:
+          RegisterPacketModMeters(p4extern, preamble_cb);
+          break;
+        case ::p4::config::v1::P4Ids::DIRECT_PACKET_MOD_METER:
+          RegisterDirectPacketModMeters(p4extern, preamble_cb);
+          break;
+        default:
+          ++stats_.unknown_extern_id;
+          LOG(INFO) << "Unrecognized P4Extern type: "
+                    << p4extern.extern_type_id() << " (ignored)";
+          break;
+      }
+    }
+  }
+}
+
+TdiResourceHandler* Es2kExternManager::FindResourceHandler(uint32 resource_id) {
+  auto iter = resource_handler_map_.find(resource_id);
+  if (iter == resource_handler_map_.end()) {
+    return nullptr;
+  }
+  return iter->second.get();
+}
+
+::util::StatusOr<const ::idpf::PacketModMeter>
+Es2kExternManager::FindPktModMeterByID(uint32 meter_id) const {
+  return pkt_mod_meter_map_.FindByID(meter_id);
+}
+
+::util::StatusOr<const ::idpf::PacketModMeter>
+Es2kExternManager::FindPktModMeterByName(const std::string& meter_name) const {
+  return pkt_mod_meter_map_.FindByName(meter_name);
+}
+
+::util::StatusOr<const ::idpf::DirectPacketModMeter>
+Es2kExternManager::FindDirectPktModMeterByID(uint32 meter_id) const {
+  return direct_pkt_mod_meter_map_.FindByID(meter_id);
+}
+
+::util::StatusOr<const ::idpf::DirectPacketModMeter>
+Es2kExternManager::FindDirectPktModMeterByName(
+    const std::string& meter_name) const {
+  return direct_pkt_mod_meter_map_.FindByName(meter_name);
+}
+
+void Es2kExternManager::RegisterPacketModMeters(
+    const p4::config::v1::Extern& p4extern,
+    const PreambleCallback& preamble_cb) {
+  const auto& instances = p4extern.instances();
+  if (!instances.empty()) {
+    // Instantiate a PktModMeter resource handler.
+    ResourceHandler handler =
+        std::make_shared<Es2kPktModMeterHandler>(params_, this);
+
+    for (const auto& extern_instance : instances) {
+      const auto& preamble = extern_instance.preamble();
+
+      if (!ValidatePreamble(preamble, handler).ok()) continue;
+
+      // Add an entry to the resource map.
+      if (!RegisterResource(preamble, handler).ok()) continue;
+
+      // Create a PacketModMeter configuration object.
+      ::idpf::PacketModMeter pkt_mod_meter;
+      *pkt_mod_meter.mutable_preamble() = preamble;
+
+      p4::config::v1::MeterSpec meter_spec;
+      meter_spec.set_unit(p4::config::v1::MeterSpec::PACKETS);
+      *pkt_mod_meter.mutable_spec() = meter_spec;
+
+      pkt_mod_meter.set_size(1024);
+      pkt_mod_meter.set_index_width(20);
+
+      // Add to vector of objects of this type.
+      meter_objects_.Add(std::move(pkt_mod_meter));
+    }
+
+    // Update P4InfoManager maps.
+    pkt_mod_meter_map_.BuildMaps(meter_objects_, preamble_cb);
+  }
+}
+
+void Es2kExternManager::RegisterDirectPacketModMeters(
+    const p4::config::v1::Extern& p4extern,
+    const PreambleCallback& preamble_cb) {
+  const auto& instances = p4extern.instances();
+  if (!instances.empty()) {
+    // Instantiate a DirectPacketModMeter resource handler.
+    ResourceHandler handler =
+        std::make_shared<Es2kDirectPktModMeterHandler>(this);
+
+    for (const auto& extern_instance : instances) {
+      const auto& preamble = extern_instance.preamble();
+
+      if (!ValidatePreamble(preamble, handler).ok()) continue;
+
+      // Add an entry to the resource map.
+      if (!RegisterResource(preamble, handler).ok()) continue;
+
+      // Create a DirectPacketModMeter configuration object.
+      ::idpf::DirectPacketModMeter direct_pkt_mod_meter;
+      *direct_pkt_mod_meter.mutable_preamble() = preamble;
+
+      p4::config::v1::MeterSpec meter_spec;
+      meter_spec.set_unit(p4::config::v1::MeterSpec::BYTES);
+      *direct_pkt_mod_meter.mutable_spec() = meter_spec;
+
+      // Add to vector of objects of this type.
+      direct_meter_objects_.Add(std::move(direct_pkt_mod_meter));
+    }
+
+    // Update P4InfoManager maps.
+    direct_pkt_mod_meter_map_.BuildMaps(direct_meter_objects_, preamble_cb);
+  }
+}
+
+::util::Status Es2kExternManager::ValidatePreamble(
+    const ::p4::config::v1::Preamble& preamble,
+    const ResourceHandler& handler) {
+  if (preamble.id() == 0) {
+    ++stats_.zero_resource_id;
+    return MAKE_ERROR(ERR_INVALID_P4_INFO)
+           << "P4Info " << handler->resource_type()
+           << " preamble requires a non-zero ID.";
+  }
+
+  if (preamble.name().empty()) {
+    ++stats_.empty_resource_name;
+    return MAKE_ERROR(ERR_INVALID_P4_INFO)
+           << "P4Info " << handler->resource_type()
+           << " preamble requires a non-empty name.";
+  }
+  return ::util::OkStatus();
+}
+
+::util::Status Es2kExternManager::RegisterResource(
+    const ::p4::config::v1::Preamble& preamble,
+    const ResourceHandler& handler) {
+  auto result = resource_handler_map_.emplace(preamble.id(), handler);
+  if (!result.second) {
+    ++stats_.duplicate_resource_id;
+    return MAKE_ERROR(ERR_INVALID_P4_INFO)
+           << "Duplicate P4 object ID " << PrintP4ObjectID(preamble.id())
+           << ".";
+  }
+  return ::util::OkStatus();
+}
+
+}  // namespace tdi
+}  // namespace hal
+}  // namespace stratum

--- a/stratum/hal/lib/tdi/es2k/es2k_extern_manager.h
+++ b/stratum/hal/lib/tdi/es2k/es2k_extern_manager.h
@@ -65,7 +65,9 @@ class Es2kExternManager : public TdiExternManager {
   uint32 pkt_mod_meter_map_size() const { return pkt_mod_meter_map_.size(); }
 
   // Returns the number of entries in the resource handler map.
-  uint32 resource_handler_map_size() const { return resource_handler_map_.size(); }
+  uint32 resource_handler_map_size() const {
+    return resource_handler_map_.size();
+  }
 
   // Returns a reference to the Es2kExternManager statistics.
   const struct Statistics& statistics() { return stats_; }

--- a/stratum/hal/lib/tdi/es2k/es2k_extern_manager.h
+++ b/stratum/hal/lib/tdi/es2k/es2k_extern_manager.h
@@ -1,0 +1,134 @@
+// Copyright 2023-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef STRATUM_HAL_LIB_TDI_ES2K_ES2K_EXTERN_MANAGER_H_
+#define STRATUM_HAL_LIB_TDI_ES2K_ES2K_EXTERN_MANAGER_H_
+
+#include <memory>
+#include <string>
+
+#include "absl/container/flat_hash_map.h"
+#include "idpf/p4info.pb.h"
+#include "p4/config/v1/p4info.pb.h"
+#include "stratum/glue/integral_types.h"
+#include "stratum/glue/status/statusor.h"
+#include "stratum/hal/lib/p4/p4_info_manager.h"
+#include "stratum/hal/lib/p4/p4_resource_map.h"
+#include "stratum/hal/lib/tdi/tdi_extern_manager.h"
+#include "stratum/hal/lib/tdi/tdi_resource_handler.h"
+
+namespace stratum {
+namespace hal {
+namespace tdi {
+
+class Es2kExternManager : public TdiExternManager {
+ public:
+  typedef std::shared_ptr<TdiResourceHandler> ResourceHandler;
+  struct Statistics;
+
+  Es2kExternManager();
+  virtual ~Es2kExternManager() = default;
+
+  // Performs basic initialization. Called by TdiTableManager.
+  ::util::Status Initialize(TdiSdeInterface* sde_interface,
+                            P4InfoManager* p4_info_manager, absl::Mutex* lock,
+                            int device) override;
+
+  // Registers P4Extern resources. Called by P4InfoManager.
+  void RegisterExterns(const ::p4::config::v1::P4Info& p4info,
+                       const PreambleCallback& preamble_cb) override;
+
+  // Returns the handler for the P4 resource with the specified ID,
+  // or null if the resource is not registered.
+  TdiResourceHandler* FindResourceHandler(uint32 resource_id);
+
+  // Retrieve a PacketModMeter configuration.
+  ::util::StatusOr<const ::idpf::PacketModMeter> FindPktModMeterByID(
+      uint32 meter_id) const;
+
+  ::util::StatusOr<const ::idpf::PacketModMeter> FindPktModMeterByName(
+      const std::string& meter_name) const;
+
+  // Retrieve a DirectPacketModMeter configuration.
+  ::util::StatusOr<const ::idpf::DirectPacketModMeter>
+  FindDirectPktModMeterByID(uint32 meter_id) const;
+
+  ::util::StatusOr<const ::idpf::DirectPacketModMeter>
+  FindDirectPktModMeterByName(const std::string& meter_name) const;
+
+  // Returns the number of entries in the DirectPacketModMeter map.
+  uint32 direct_pkt_mod_meter_size() const {
+    return direct_pkt_mod_meter_map_.size();
+  }
+
+  // Returns the number of entries in the PacketModMeter map.
+  uint32 pkt_mod_meter_map_size() const { return pkt_mod_meter_map_.size(); }
+
+  // Returns the number of entries in the resource handler map.
+  uint32 resource_handler_map_size() const { return resource_handler_map_.size(); }
+
+  // Returns a reference to the Es2kExternManager statistics.
+  const struct Statistics& statistics() { return stats_; }
+
+  // Resource handler parameters.
+  struct HandlerParams {
+    HandlerParams()
+        : sde_interface(nullptr),
+          p4_info_manager(nullptr),
+          lock(nullptr),
+          device(0) {}
+    TdiSdeInterface* sde_interface;  // not owned by this class
+    P4InfoManager* p4_info_manager;  // not owned by this class
+    absl::Mutex* lock;               // not owned by this class
+    int device;
+  };
+
+  // Es2kExternManager statistics.
+  struct Statistics {
+    Statistics()
+        : unknown_extern_id(0),
+          zero_resource_id(0),
+          empty_resource_name(0),
+          duplicate_resource_id(0) {}
+    // Number of externs with unrecognized type IDs.
+    uint32 unknown_extern_id;
+    // Number of instances with a resource ID of zero.
+    uint32 zero_resource_id;
+    // Number of instances with an empty name.
+    uint32 empty_resource_name;
+    // Number of instances with a duplicate resource ID.
+    uint32 duplicate_resource_id;
+  };
+
+ private:
+  void RegisterPacketModMeters(const p4::config::v1::Extern& p4extern,
+                               const PreambleCallback& preamble_cb);
+
+  void RegisterDirectPacketModMeters(const p4::config::v1::Extern& p4extern,
+                                     const PreambleCallback& preamble_cb);
+
+  ::util::Status RegisterResource(const ::p4::config::v1::Preamble& preamble,
+                                  const ResourceHandler& resource_handler);
+
+  ::util::Status ValidatePreamble(const ::p4::config::v1::Preamble& preamble,
+                                  const ResourceHandler& handler);
+
+  // One P4ResourceMap for each P4 extern resource type.
+  P4ResourceMap<::idpf::PacketModMeter> pkt_mod_meter_map_;
+  P4ResourceMap<::idpf::DirectPacketModMeter> direct_pkt_mod_meter_map_;
+
+  google::protobuf::RepeatedPtrField<::idpf::PacketModMeter> meter_objects_;
+  google::protobuf::RepeatedPtrField<::idpf::DirectPacketModMeter>
+      direct_meter_objects_;
+
+  absl::flat_hash_map<uint32, ResourceHandler> resource_handler_map_;
+
+  HandlerParams params_;
+  Statistics stats_;
+};
+
+}  // namespace tdi
+}  // namespace hal
+}  // namespace stratum
+
+#endif  // STRATUM_HAL_LIB_TDI_ES2K_ES2K_EXTERN_MANAGER_H_

--- a/stratum/hal/lib/tdi/es2k/es2k_extern_manager_test.cc
+++ b/stratum/hal/lib/tdi/es2k/es2k_extern_manager_test.cc
@@ -1,0 +1,488 @@
+// Copyright 2023-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+// Unit test for Es2kExternManager.
+
+#include "stratum/hal/lib/tdi/es2k/es2k_extern_manager.h"
+#include "stratum/hal/lib/tdi/es2k/es2k_target_factory.h"
+
+#include <iostream>
+#include <typeinfo>
+
+#include <iostream>
+#include <memory>
+#include <string>
+
+#include "absl/memory/memory.h"
+#include "absl/synchronization/mutex.h"
+#include "gtest/gtest.h"
+#include "p4/config/v1/p4info.pb.h"
+#include "stratum/glue/status/status.h"
+#include "stratum/hal/lib/p4/p4_info_manager_mock.h"
+#include "stratum/hal/lib/tdi/tdi_sde_mock.h"
+#include "stratum/lib/utils.h"
+
+namespace stratum {
+namespace hal {
+namespace tdi {
+
+constexpr uint32 PACKET_MOD_METER_ID =
+    ::p4::config::v1::P4Ids::PACKET_MOD_METER;
+constexpr uint32 DIRECT_PACKET_MOD_METER_ID =
+    ::p4::config::v1::P4Ids::DIRECT_PACKET_MOD_METER;
+
+// The bits 31:24 of the resource ID contain the P4 type ID.
+constexpr uint32 kPktModMeterBase = PACKET_MOD_METER_ID << 24;
+constexpr uint32 kDirectPktModMeterBase = DIRECT_PACKET_MOD_METER_ID << 24;
+
+class Es2kExternManagerTest : public testing::Test {
+ protected:
+  Es2kExternManagerTest() : es2k_extern_manager_(new Es2kExternManager) {}
+
+  ::util::Status ProcessPreamble(const ::p4::config::v1::Preamble& preamble,
+                                 const std::string& resource_type);
+
+  void SetUpPreambleCallback();
+
+  void SetUpDirectPacketModMeters();
+  void SetUpDirectPacketModMeterTest();
+  void SetUpPacketModMeters();
+  void SetUpPacketModMeterTest();
+
+  std::unique_ptr<TdiSdeMock> sde_mock_;
+  std::unique_ptr<P4InfoManagerMock> info_manager_mock_;
+  std::unique_ptr<Es2kExternManager> es2k_extern_manager_;
+  PreambleCallback preamble_cb_;
+  ::p4::config::v1::P4Info p4info_;
+  std::unique_ptr<absl::Mutex> lock_;
+};
+
+void Es2kExternManagerTest::SetUpPreambleCallback() {
+  preamble_cb_ = std::bind(&Es2kExternManagerTest::ProcessPreamble, this,
+                           std::placeholders::_1, std::placeholders::_2);
+}
+
+// Dummy preamble processing callback function.
+::util::Status Es2kExternManagerTest::ProcessPreamble(
+    const ::p4::config::v1::Preamble& preamble,
+    const std::string& resource_type) {
+  return ::util::OkStatus();
+}
+
+//----------------------------------------------------------------------
+// Setup tests
+//----------------------------------------------------------------------
+
+TEST_F(Es2kExternManagerTest, TestConstructor) {
+  ASSERT_TRUE(es2k_extern_manager_);
+}
+
+TEST_F(Es2kExternManagerTest, TestCreateInstance) {
+  ASSERT_TRUE(Es2kExternManager::CreateInstance());
+}
+
+TEST_F(Es2kExternManagerTest, TestFactoryCreateInstance) {
+  Es2kTargetFactory target_factory;
+  auto extern_manager = target_factory.CreateTdiExternManager();
+  ASSERT_TRUE(extern_manager);
+}
+
+TEST_F(Es2kExternManagerTest, TestInitialize) {
+  SetUpPreambleCallback();
+  es2k_extern_manager_->RegisterExterns(p4info_, preamble_cb_);
+
+  EXPECT_EQ(es2k_extern_manager_->resource_handler_map_size(), 0);
+  EXPECT_EQ(es2k_extern_manager_->direct_pkt_mod_meter_size(), 0);
+  EXPECT_EQ(es2k_extern_manager_->pkt_mod_meter_map_size(), 0);
+
+  sde_mock_ = absl::make_unique<TdiSdeMock>();
+  info_manager_mock_ = absl::make_unique<P4InfoManagerMock>();
+  lock_ = absl::make_unique<absl::Mutex>();
+
+  auto initialized = es2k_extern_manager_->Initialize(
+      sde_mock_.get(), info_manager_mock_.get(), lock_.get(), 0);
+  EXPECT_TRUE(initialized.ok());
+}
+
+TEST_F(Es2kExternManagerTest, TestInitializeFailure) {
+  SetUpPreambleCallback();
+  es2k_extern_manager_->RegisterExterns(p4info_, preamble_cb_);
+
+  EXPECT_EQ(es2k_extern_manager_->resource_handler_map_size(), 0);
+  EXPECT_EQ(es2k_extern_manager_->direct_pkt_mod_meter_size(), 0);
+  EXPECT_EQ(es2k_extern_manager_->pkt_mod_meter_map_size(), 0);
+
+  auto initialized =
+      es2k_extern_manager_->Initialize(nullptr, nullptr, nullptr, 0);
+  ASSERT_FALSE(initialized.ok());
+}
+
+//----------------------------------------------------------------------
+// DirectPacketModMeter tests
+//----------------------------------------------------------------------
+
+const std::string kDirectPacketModMeterExternText = R"pb(
+  extern_type_id: 134
+  extern_type_name: "DirectPacketModMeter"
+  instances {
+    preamble {
+      id: 2264139482
+      name: "my_control.meter3"
+      alias: "meter3"
+    }
+    info {
+      [type.googleapis.com/idpf.DirectPacketModMeter] {
+        spec {
+          unit: BYTES
+        }
+      }
+    }
+  }
+  instances {
+    preamble {
+      id: 2249256208
+      name: "my_control.meter4"
+      alias: "meter4"
+    }
+    info {
+      [type.googleapis.com/idpf.DirectPacketModMeter] {
+        spec {
+          unit: BYTES
+        }
+      }
+    }
+  }
+)pb";
+
+constexpr char kDirectPacketModMeterTypeName[] = "DirectPacketModMeter";
+constexpr uint32 kDirectPacketModMeterTypeID = 134;
+
+constexpr uint32 kDirectPacketModMeterID1 = 2264139482;  // 0x86F406DA
+constexpr uint32 kDirectPacketModMeterID2 = 2249256208;  // 0x8610ED10
+constexpr char kDirectPacketModMeterName1[] = "my_control.meter3";
+constexpr char kDirectPacketModMeterName2[] = "my_control.meter4";
+
+constexpr uint32 kBadDirectPacketModMeterID = 0x8500ACED;
+constexpr char kBadDirectPacketModMeterName[] = "self_control.meter.99";
+
+//----------------------------------------------------------------------
+
+void Es2kExternManagerTest::SetUpDirectPacketModMeters() {
+  auto p4extern = p4info_.add_externs();
+  ASSERT_TRUE(
+      ParseProtoFromString(kDirectPacketModMeterExternText, p4extern).ok());
+}
+
+void Es2kExternManagerTest::SetUpDirectPacketModMeterTest() {
+  SetUpDirectPacketModMeters();
+  SetUpPreambleCallback();
+  es2k_extern_manager_->RegisterExterns(p4info_, preamble_cb_);
+}
+
+//----------------------------------------------------------------------
+
+TEST_F(Es2kExternManagerTest, TestParseDirectPacketModMeters) {
+  SetUpDirectPacketModMeters();
+  SetUpPreambleCallback();
+  es2k_extern_manager_->RegisterExterns(p4info_, preamble_cb_);
+
+  EXPECT_EQ(es2k_extern_manager_->resource_handler_map_size(), 2);
+  EXPECT_EQ(es2k_extern_manager_->direct_pkt_mod_meter_size(), 2);
+  EXPECT_EQ(es2k_extern_manager_->pkt_mod_meter_map_size(), 0);
+}
+
+TEST_F(Es2kExternManagerTest, TestFindDirectPacketModMeterByID) {
+  SetUpDirectPacketModMeterTest();
+
+  auto directMeter1 =
+      es2k_extern_manager_->FindDirectPktModMeterByID(kDirectPacketModMeterID1);
+  EXPECT_TRUE(directMeter1.ok());
+
+  auto directMeter3 =
+      es2k_extern_manager_->FindDirectPktModMeterByID(kDirectPacketModMeterID2);
+  EXPECT_TRUE(directMeter3.ok());
+}
+
+TEST_F(Es2kExternManagerTest, TestFindDirectPacketModMeterByName) {
+  SetUpDirectPacketModMeterTest();
+
+  auto directMeter2 = es2k_extern_manager_->FindDirectPktModMeterByName(
+      kDirectPacketModMeterName1);
+  EXPECT_TRUE(directMeter2.ok());
+
+  auto directMeter4 = es2k_extern_manager_->FindDirectPktModMeterByName(
+      kDirectPacketModMeterName2);
+  EXPECT_TRUE(directMeter4.ok());
+}
+
+TEST_F(Es2kExternManagerTest, TestFindBadDirectPacketModMeter) {
+  SetUpDirectPacketModMeterTest();
+
+  auto badMeter1 = es2k_extern_manager_->FindDirectPktModMeterByID(
+      kBadDirectPacketModMeterID);
+  EXPECT_FALSE(badMeter1.ok());
+
+  auto badMeter2 = es2k_extern_manager_->FindDirectPktModMeterByName(
+      kBadDirectPacketModMeterName);
+  EXPECT_FALSE(badMeter2.ok());
+}
+
+//----------------------------------------------------------------------
+// PacketModMeter tests
+//----------------------------------------------------------------------
+
+const std::string kPacketModMeterExternText = R"pb(
+  extern_type_id: 133
+  extern_type_name: "PacketModMeter"
+  instances {
+    preamble {
+      id: 2244878476
+      name: "my_control.meter1"
+      alias: "meter1"
+    }
+    info {
+      [type.googleapis.com/idpf.PacketModMeter] {
+        spec {
+          unit: PACKETS
+        }
+        size: 1024
+        index_width: 20
+      }
+    }
+  }
+  instances {
+    preamble {
+      id: 2242552391
+      name: "my_control.meter2"
+      alias: "meter2"
+    }
+    info {
+      [type.googleapis.com/idpf.PacketModMeter] {
+        spec {
+          unit: PACKETS
+        }
+        size: 1024
+        index_width: 20
+      }
+    }
+  }
+)pb";
+
+constexpr uint32 kPacketModMeterID1 = 2244878476;  // 0x85CE208C
+constexpr uint32 kPacketModMeterID2 = 2242552391;  // 0x85AAA247
+constexpr char kPacketModMeterName1[] = "my_control.meter1";
+constexpr char kPacketModMeterName2[] = "my_control.meter2";
+
+constexpr uint32 kBadPacketModMeterID = 0x8500DEAD;
+constexpr char kBadPacketModMeterName[] = "mind_control.meter";
+
+constexpr char kPacketModMeterTypeName[] = "PacketModMeter";
+constexpr uint32 kPacketModMeterTypeID = 133;
+
+//----------------------------------------------------------------------
+
+void Es2kExternManagerTest::SetUpPacketModMeters() {
+  auto p4extern = p4info_.add_externs();
+  ASSERT_TRUE(ParseProtoFromString(kPacketModMeterExternText, p4extern).ok());
+}
+
+void Es2kExternManagerTest::SetUpPacketModMeterTest() {
+  SetUpPacketModMeters();
+  SetUpPreambleCallback();
+  es2k_extern_manager_->RegisterExterns(p4info_, preamble_cb_);
+}
+
+//----------------------------------------------------------------------
+
+TEST_F(Es2kExternManagerTest, TestParsePacketModMeters) {
+  SetUpPacketModMeters();
+  SetUpPreambleCallback();
+  es2k_extern_manager_->RegisterExterns(p4info_, preamble_cb_);
+
+  EXPECT_EQ(es2k_extern_manager_->resource_handler_map_size(), 2);
+  EXPECT_EQ(es2k_extern_manager_->direct_pkt_mod_meter_size(), 0);
+  EXPECT_EQ(es2k_extern_manager_->pkt_mod_meter_map_size(), 2);
+}
+
+TEST_F(Es2kExternManagerTest, TestFindPacketModMeterByID) {
+  SetUpPacketModMeterTest();
+
+  auto directMeter1 =
+      es2k_extern_manager_->FindPktModMeterByID(kPacketModMeterID1);
+  EXPECT_TRUE(directMeter1.ok());
+
+  auto directMeter3 =
+      es2k_extern_manager_->FindPktModMeterByID(kPacketModMeterID2);
+  EXPECT_TRUE(directMeter3.ok());
+}
+
+TEST_F(Es2kExternManagerTest, TestFindPacketModMeterByName) {
+  SetUpPacketModMeterTest();
+
+  auto directMeter2 =
+      es2k_extern_manager_->FindPktModMeterByName(kPacketModMeterName1);
+  EXPECT_TRUE(directMeter2.ok());
+
+  auto directMeter4 =
+      es2k_extern_manager_->FindPktModMeterByName(kPacketModMeterName2);
+  EXPECT_TRUE(directMeter4.ok());
+}
+
+TEST_F(Es2kExternManagerTest, TestFindBadPacketModMeter) {
+  SetUpPacketModMeterTest();
+
+  auto badMeter1 =
+      es2k_extern_manager_->FindPktModMeterByID(kBadPacketModMeterID);
+  EXPECT_FALSE(badMeter1.ok());
+
+  auto badMeter2 =
+      es2k_extern_manager_->FindPktModMeterByName(kBadPacketModMeterName);
+  EXPECT_FALSE(badMeter2.ok());
+}
+
+//----------------------------------------------------------------------
+// Miscellaneous tests
+//----------------------------------------------------------------------
+
+TEST_F(Es2kExternManagerTest, TestFindMeterWhenEmpty) {
+  auto directMeter1 =
+      es2k_extern_manager_->FindPktModMeterByID(kPacketModMeterID1);
+  EXPECT_FALSE(directMeter1.ok());
+
+  auto directMeter2 = es2k_extern_manager_->FindDirectPktModMeterByName(
+      kDirectPacketModMeterName2);
+  EXPECT_FALSE(directMeter2.ok());
+}
+
+TEST_F(Es2kExternManagerTest, TestParseBothExternMeterTypes) {
+  SetUpPacketModMeters();
+  SetUpDirectPacketModMeters();
+  SetUpPreambleCallback();
+  es2k_extern_manager_->RegisterExterns(p4info_, preamble_cb_);
+
+  EXPECT_EQ(es2k_extern_manager_->resource_handler_map_size(), 4);
+  EXPECT_EQ(es2k_extern_manager_->direct_pkt_mod_meter_size(), 2);
+  EXPECT_EQ(es2k_extern_manager_->pkt_mod_meter_map_size(), 2);
+}
+
+TEST_F(Es2kExternManagerTest, TestFindResourceHandler) {
+  SetUpPacketModMeters();
+  SetUpDirectPacketModMeters();
+  SetUpPreambleCallback();
+  es2k_extern_manager_->RegisterExterns(p4info_, preamble_cb_);
+
+  auto handler = es2k_extern_manager_->FindResourceHandler(kPacketModMeterID1);
+  ASSERT_TRUE(handler != nullptr);
+  EXPECT_STREQ(handler->resource_type().c_str(), kPacketModMeterTypeName);
+  EXPECT_EQ(handler->type_id(), kPacketModMeterTypeID);
+}
+
+TEST_F(Es2kExternManagerTest, TestFindDirectResourceHandler) {
+  SetUpPacketModMeters();
+  SetUpDirectPacketModMeters();
+  SetUpPreambleCallback();
+  es2k_extern_manager_->RegisterExterns(p4info_, preamble_cb_);
+
+  auto handler =
+      es2k_extern_manager_->FindResourceHandler(kDirectPacketModMeterID2);
+  ASSERT_TRUE(handler != nullptr);
+  EXPECT_STREQ(handler->resource_type().c_str(), kDirectPacketModMeterTypeName);
+  EXPECT_EQ(handler->type_id(), kDirectPacketModMeterTypeID);
+}
+
+TEST_F(Es2kExternManagerTest, TestFindAbsentResourceHandler) {
+  SetUpDirectPacketModMeters();
+  SetUpPreambleCallback();
+  es2k_extern_manager_->RegisterExterns(p4info_, preamble_cb_);
+
+  auto handler = es2k_extern_manager_->FindResourceHandler(0);
+  ASSERT_TRUE(handler == nullptr);
+}
+
+//----------------------------------------------------------------------
+// Error tests
+//----------------------------------------------------------------------
+
+TEST_F(Es2kExternManagerTest, TestUnknownExternType) {
+  auto p4extern = p4info_.add_externs();
+  p4extern->set_extern_type_id(0);
+  es2k_extern_manager_->RegisterExterns(p4info_, preamble_cb_);
+
+  auto stats = es2k_extern_manager_->statistics();
+  EXPECT_EQ(stats.unknown_extern_id, 1);
+}
+
+constexpr char kZeroPreambleIdText[] = R"pb(
+  extern_type_id: 134
+  extern_type_name: "DirectPacketModMeter"
+  instances {
+    preamble {
+      id: 0
+      name: "my_control.meter3"
+      alias: "meter3"
+    }
+  }
+)pb";
+
+TEST_F(Es2kExternManagerTest, TestZeroPreambleID) {
+  auto p4extern = p4info_.add_externs();
+  ASSERT_TRUE(ParseProtoFromString(kZeroPreambleIdText, p4extern).ok());
+  SetUpPreambleCallback();
+  es2k_extern_manager_->RegisterExterns(p4info_, preamble_cb_);
+
+  auto stats = es2k_extern_manager_->statistics();
+  EXPECT_EQ(stats.zero_resource_id, 1);
+}
+
+constexpr char kEmptyPreambleNameText[] = R"pb(
+  extern_type_id: 134
+  extern_type_name: "DirectPacketModMeter"
+  instances {
+    preamble {
+      id: 5
+      name: ""
+    }
+  }
+)pb";
+
+TEST_F(Es2kExternManagerTest, TestEmptyPreambleName) {
+  auto p4extern = p4info_.add_externs();
+  ASSERT_TRUE(ParseProtoFromString(kEmptyPreambleNameText, p4extern).ok());
+  SetUpPreambleCallback();
+  es2k_extern_manager_->RegisterExterns(p4info_, preamble_cb_);
+
+  auto stats = es2k_extern_manager_->statistics();
+  EXPECT_EQ(stats.empty_resource_name, 1);
+}
+
+const std::string kDuplicateResourceIdText = R"pb(
+  extern_type_id: 133
+  extern_type_name: "PacketModMeter"
+  instances {
+    preamble {
+      id: 2244878476
+      name: "my_control.meter1"
+    }
+  }
+  instances {
+    preamble {
+      id: 2244878476
+      name: "my_control.meter2"
+      alias: "meter2"
+    }
+  }
+)pb";
+
+TEST_F(Es2kExternManagerTest, TestDuplicateResourceId) {
+  auto p4extern = p4info_.add_externs();
+  ASSERT_TRUE(ParseProtoFromString(kDuplicateResourceIdText, p4extern).ok());
+  SetUpPreambleCallback();
+  es2k_extern_manager_->RegisterExterns(p4info_, preamble_cb_);
+
+  auto stats = es2k_extern_manager_->statistics();
+  EXPECT_EQ(stats.duplicate_resource_id, 1);
+}
+
+}  // namespace tdi
+}  // namespace hal
+}  // namespace stratum

--- a/stratum/hal/lib/tdi/es2k/es2k_extern_manager_test.cc
+++ b/stratum/hal/lib/tdi/es2k/es2k_extern_manager_test.cc
@@ -4,12 +4,7 @@
 // Unit test for Es2kExternManager.
 
 #include "stratum/hal/lib/tdi/es2k/es2k_extern_manager.h"
-#include "stratum/hal/lib/tdi/es2k/es2k_target_factory.h"
 
-#include <iostream>
-#include <typeinfo>
-
-#include <iostream>
 #include <memory>
 #include <string>
 
@@ -19,6 +14,7 @@
 #include "p4/config/v1/p4info.pb.h"
 #include "stratum/glue/status/status.h"
 #include "stratum/hal/lib/p4/p4_info_manager_mock.h"
+#include "stratum/hal/lib/tdi/es2k/es2k_target_factory.h"
 #include "stratum/hal/lib/tdi/tdi_sde_mock.h"
 #include "stratum/lib/utils.h"
 

--- a/stratum/hal/lib/tdi/es2k/es2k_pkt_mod_meter_handler.cc
+++ b/stratum/hal/lib/tdi/es2k/es2k_pkt_mod_meter_handler.cc
@@ -1,0 +1,113 @@
+// Copyright 2020-present Open Networking Foundation
+// Copyright 2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+// ES2K PacketModMeter resource handler (implementation).
+
+#include "stratum/hal/lib/tdi/es2k/es2k_pkt_mod_meter_handler.h"
+
+#include "absl/synchronization/mutex.h"
+#include "idpf/p4info.pb.h"
+#include "stratum/glue/status/status_macros.h"
+#include "stratum/hal/lib/tdi/tdi_table_helpers.h"
+
+namespace stratum {
+namespace hal {
+namespace tdi {
+
+using namespace stratum::hal::tdi::helpers;
+
+using HandlerParams = Es2kExternManager::HandlerParams;
+
+Es2kPktModMeterHandler::Es2kPktModMeterHandler(
+    const HandlerParams& params, Es2kExternManager* extern_manager)
+    : TdiResourceHandler("PacketModMeter",
+                         ::p4::config::v1::P4Ids::PACKET_MOD_METER),
+      params_(params),
+      extern_manager_(extern_manager) {}
+
+Es2kPktModMeterHandler::~Es2kPktModMeterHandler() {}
+
+util::Status Es2kPktModMeterHandler::DoReadMeterEntry(
+    std::shared_ptr<TdiSdeInterface::SessionInterface> session,
+    const ::p4::v1::MeterEntry& meter_entry,
+    WriterInterface<::p4::v1::ReadResponse>* writer, uint32 table_id) {
+  bool units_in_packets;
+  {
+    absl::ReaderMutexLock l(params_.lock);
+    ::idpf::PacketModMeter meter;
+    ASSIGN_OR_RETURN(
+        meter, extern_manager_->FindPktModMeterByID(meter_entry.meter_id()));
+    RETURN_IF_ERROR(GetMeterUnitsInPackets(meter, units_in_packets));
+  }
+
+  // Index 0 is a valid value and not a wildcard.
+  absl::optional<uint32> optional_meter_index;
+  if (meter_entry.has_index()) {
+    optional_meter_index = meter_entry.index().index();
+  }
+
+  std::vector<uint32> meter_indices;
+  std::vector<TdiPktModMeterConfig> cfg;
+
+  RETURN_IF_ERROR(params_.sde_interface->ReadPktModMeters(
+      params_.device, session, table_id, optional_meter_index, &meter_indices,
+      cfg));
+
+  ::p4::v1::ReadResponse resp;
+  for (size_t i = 0; i < meter_indices.size(); ++i) {
+    ::p4::v1::MeterEntry result;
+    result.set_meter_id(meter_entry.meter_id());
+    result.mutable_index()->set_index(meter_indices[i]);
+    SetMeterEntry(result, cfg[i]);
+    *resp.add_entities()->mutable_meter_entry() = result;
+  }
+
+  VLOG(1) << "ReadMeterEntry resp " << resp.DebugString();
+  if (!writer->Write(resp)) {
+    return MAKE_ERROR(ERR_INTERNAL) << "Write to stream for failed.";
+  }
+
+  return ::util::OkStatus();
+}
+
+util::Status Es2kPktModMeterHandler::DoWriteMeterEntry(
+    std::shared_ptr<TdiSdeInterface::SessionInterface> session,
+    const ::p4::v1::Update::Type type, const ::p4::v1::MeterEntry& meter_entry,
+    uint32 meter_id) {
+  bool units_in_packets;
+  {
+    absl::ReaderMutexLock l(params_.lock);
+    ::idpf::PacketModMeter meter;
+    ASSIGN_OR_RETURN(
+        meter, extern_manager_->FindPktModMeterByID(meter_entry.meter_id()));
+    RETURN_IF_ERROR(GetMeterUnitsInPackets(meter, units_in_packets));
+  }
+
+  absl::optional<uint32> meter_index;
+  if (meter_entry.has_index()) {
+    meter_index = meter_entry.index().index();
+  } else {
+    return MAKE_ERROR(ERR_INVALID_PARAM) << "Invalid meter entry index";
+  }
+
+  if (meter_entry.has_config()) {
+    TdiPktModMeterConfig config;
+    SetPktModMeterConfig(config, meter_entry);
+    config.isPktModMeter = units_in_packets;
+
+    RETURN_IF_ERROR(params_.sde_interface->WritePktModMeter(
+        params_.device, session, meter_id, meter_index, config));
+  }
+
+  if (type == ::p4::v1::Update::DELETE) {
+    RETURN_IF_ERROR(params_.sde_interface->DeletePktModMeterConfig(
+        params_.device, session, meter_id, meter_index));
+  }
+
+  return ::util::OkStatus();
+}
+
+}  // namespace tdi
+}  // namespace hal
+}  // namespace stratum

--- a/stratum/hal/lib/tdi/es2k/es2k_pkt_mod_meter_handler.h
+++ b/stratum/hal/lib/tdi/es2k/es2k_pkt_mod_meter_handler.h
@@ -1,0 +1,51 @@
+// Copyright 2020-present Open Networking Foundation
+// Copyright 2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+// ES2K PktModMeter resource handler (interface).
+
+#ifndef ES2K_PKT_MOD_METER_HANDLER_H_
+#define ES2K_PKT_MOD_METER_HANDLER_H_
+
+#include "p4/v1/p4runtime.pb.h"
+#include "stratum/glue/integral_types.h"
+#include "stratum/glue/status/status.h"
+#include "stratum/hal/lib/p4/p4_info_manager.h"
+#include "stratum/hal/lib/tdi/es2k/es2k_extern_manager.h"
+#include "stratum/hal/lib/tdi/tdi_resource_handler.h"
+#include "stratum/hal/lib/tdi/tdi_sde_interface.h"
+
+namespace stratum {
+namespace hal {
+namespace tdi {
+
+using HandlerParams = Es2kExternManager::HandlerParams;
+
+class Es2kPktModMeterHandler : public TdiResourceHandler {
+ public:
+  Es2kPktModMeterHandler(const HandlerParams& params,
+                         Es2kExternManager* extern_manager);
+
+  virtual ~Es2kPktModMeterHandler();
+
+  util::Status DoReadMeterEntry(
+      std::shared_ptr<TdiSdeInterface::SessionInterface> session,
+      const ::p4::v1::MeterEntry& meter_entry,
+      WriterInterface<::p4::v1::ReadResponse>* writer,
+      uint32 table_id) override;
+
+  util::Status DoWriteMeterEntry(
+      std::shared_ptr<TdiSdeInterface::SessionInterface> session,
+      const ::p4::v1::Update::Type type,
+      const ::p4::v1::MeterEntry& meter_entry, uint32 meter_id) override;
+
+ protected:
+  const HandlerParams& params_;        // not owned by this class
+  Es2kExternManager* extern_manager_;  // not owned by this class
+};
+
+}  // namespace tdi
+}  // namespace hal
+}  // namespace stratum
+
+#endif  // ES2K_PKT_MOD_METER_HANDLER_H_

--- a/stratum/hal/lib/tdi/es2k/es2k_target_factory.h
+++ b/stratum/hal/lib/tdi/es2k/es2k_target_factory.h
@@ -1,0 +1,32 @@
+// Copyright 2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef STRATUM_HAL_LIB_TDI_ES2K_ES2K_TARGET_FACTORY_H_
+#define STRATUM_HAL_LIB_TDI_ES2K_ES2K_TARGET_FACTORY_H_
+
+#include <memory>
+#include <utility>
+
+#include "stratum/hal/lib/tdi/es2k/es2k_extern_manager.h"
+#include "stratum/hal/lib/tdi/tdi_target_factory.h"
+
+namespace stratum {
+namespace hal {
+namespace tdi {
+
+class Es2kTargetFactory : public TdiTargetFactory {
+ public:
+  Es2kTargetFactory() {}
+  virtual ~Es2kTargetFactory() = default;
+
+  std::unique_ptr<TdiExternManager> CreateTdiExternManager() override {
+    auto es2kPtr = Es2kExternManager::CreateInstance();
+    return std::unique_ptr<TdiExternManager>(std::move(es2kPtr));
+  }
+};
+
+}  // namespace tdi
+}  // namespace hal
+}  // namespace stratum
+
+#endif  // STRATUM_HAL_LIB_TDI_ES2K_ES2K_TARGET_FACTORY_H_

--- a/stratum/hal/lib/tdi/tdi_extern_manager.h
+++ b/stratum/hal/lib/tdi/tdi_extern_manager.h
@@ -1,0 +1,49 @@
+// Copyright 2023-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef STRATUM_HAL_LIB_TDI_TDI_EXTERN_MANAGER_H_
+#define STRATUM_HAL_LIB_TDI_TDI_EXTERN_MANAGER_H_
+
+#include "absl/memory/memory.h"
+#include "p4/config/v1/p4info.pb.h"
+#include "stratum/hal/lib/p4/p4_extern_manager.h"
+#include "stratum/hal/lib/p4/p4_resource_map.h"
+#include "stratum/hal/lib/tdi/tdi_resource_handler.h"
+
+namespace stratum {
+namespace hal {
+namespace tdi {
+
+class TdiExternManager : public P4ExternManager {
+ public:
+  TdiExternManager() {}
+  virtual ~TdiExternManager() = default;
+
+  // Called by TdiTargetFactory.
+  static std::unique_ptr<TdiExternManager> CreateInstance() {
+    return absl::make_unique<TdiExternManager>();
+  }
+
+  // Performs basic initialization. Called by TdiTableManager.
+  virtual ::util::Status Initialize(TdiSdeInterface* sde_interface,
+                                    P4InfoManager* p4_info_manager,
+                                    absl::Mutex* lock, int device) {
+    return ::util::OkStatus();
+  }
+
+  // Registers P4Extern resources. Called by P4InfoManager.
+  void RegisterExterns(const ::p4::config::v1::P4Info& p4info,
+                       const PreambleCallback& preamble_cb) override {}
+
+  // Returns the handler for the P4 resource with the specified ID,
+  // or null if the resource is not registered.
+  virtual TdiResourceHandler* FindResourceHandler(uint32 resource_id) {
+    return nullptr;
+  }
+};
+
+}  // namespace tdi
+}  // namespace hal
+}  // namespace stratum
+
+#endif  // STRATUM_HAL_LIB_TDI_TDI_EXTERN_MANAGER_H_

--- a/stratum/hal/lib/tdi/tdi_resource_handler.h
+++ b/stratum/hal/lib/tdi/tdi_resource_handler.h
@@ -1,0 +1,73 @@
+// Copyright 2020-present Open Networking Foundation
+// Copyright 2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef STRATUM_HAL_LIB_TDI_TDI_RESOURCE_HANDLER_
+#define STRATUM_HAL_LIB_TDI_TDI_RESOURCE_HANDLER_
+
+#include <memory>
+#include <string>
+
+#include "absl/synchronization/mutex.h"
+#include "p4/v1/p4runtime.pb.h"
+#include "stratum/glue/integral_types.h"
+#include "stratum/glue/status/status.h"
+#include "stratum/glue/status/statusor.h"
+#include "stratum/hal/lib/common/writer_interface.h"
+#include "stratum/hal/lib/tdi/tdi_sde_interface.h"
+
+namespace stratum {
+namespace hal {
+namespace tdi {
+
+class TdiResourceHandler {
+ public:
+  TdiResourceHandler(const std::string& resource_type, uint32 type_id)
+      : resource_type_(resource_type), type_id_(type_id) {}
+
+  virtual ~TdiResourceHandler() = default;
+
+  // DirectMeter, DirectCounter, DirectPacketModMeter
+  virtual ::util::Status DoBuildTableData(
+      const ::p4::v1::TableEntry& table_entry,
+      TdiSdeInterface::TableDataInterface* table_data, uint32 resource_id) {
+    return ::util::OkStatus();
+  }
+
+  // DirectMeter, DirectPacketModMeter
+  virtual ::util::Status DoReadDirectMeterEntry(
+      const TdiSdeInterface::TableDataInterface* table_data,
+      const ::p4::v1::TableEntry& table_entry,
+      ::p4::v1::DirectMeterEntry& result) {
+    return ::util::OkStatus();
+  }
+
+  // Meter, PacketModMeter
+  virtual ::util::Status DoReadMeterEntry(
+      std::shared_ptr<TdiSdeInterface::SessionInterface> session,
+      const ::p4::v1::MeterEntry& meter_entry,
+      WriterInterface<::p4::v1::ReadResponse>* writer, uint32 table_id) {
+    return ::util::OkStatus();
+  }
+
+  // Meter, PacketModMeter
+  virtual ::util::Status DoWriteMeterEntry(
+      std::shared_ptr<TdiSdeInterface::SessionInterface> session,
+      const ::p4::v1::Update::Type type,
+      const ::p4::v1::MeterEntry& meter_entry, uint32 meter_id) {
+    return ::util::OkStatus();
+  }
+
+  const std::string& resource_type() const { return resource_type_; }
+  uint32 type_id() const { return type_id_; }
+
+ protected:
+  const std::string resource_type_;
+  const uint32 type_id_;
+};
+
+}  // namespace tdi
+}  // namespace hal
+}  // namespace stratum
+
+#endif  // STRATUM_HAL_LIB_TDI_TDI_RESOURCE_HANDLER_

--- a/stratum/hal/lib/tdi/tdi_table_helpers.cc
+++ b/stratum/hal/lib/tdi/tdi_table_helpers.cc
@@ -1,0 +1,69 @@
+// Copyright 2020-present Open Networking Foundation
+// Copyright 2022-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#include "stratum/hal/lib/tdi/tdi_table_helpers.h"
+
+namespace stratum {
+namespace hal {
+namespace tdi {
+namespace helpers {
+
+// Sets a meter configuration variable from a pair of PolicerMeterConfig
+// and MeterCounterData protobufs.
+void SetPktModMeterConfig(TdiPktModMeterConfig& config,
+                          const ::p4::v1::PolicerMeterConfig& meter_config,
+                          const ::p4::v1::MeterCounterData& counter_data) {
+  config.meter_prof_id = meter_config.policer_meter_prof_id();
+  config.cir_unit = meter_config.policer_spec_cir_unit();
+  config.cburst_unit = meter_config.policer_spec_cbs_unit();
+  config.pir_unit = meter_config.policer_spec_eir_unit();
+  config.pburst_unit = meter_config.policer_spec_ebs_unit();
+  config.cir = meter_config.policer_spec_cir();
+  config.cburst = meter_config.policer_spec_cbs();
+  config.pir = meter_config.policer_spec_eir();
+  config.pburst = meter_config.policer_spec_ebs();
+
+  config.greenBytes = counter_data.green().byte_count();
+  config.greenPackets = counter_data.green().packet_count();
+  config.yellowBytes = counter_data.yellow().byte_count();
+  config.yellowPackets = counter_data.yellow().packet_count();
+  config.redBytes = counter_data.red().byte_count();
+  config.redPackets = counter_data.red().packet_count();
+}
+
+// Sets a PolicerMeterConfig protobuf from a meter configuration variable.
+void SetPolicerMeterConfig(::p4::v1::PolicerMeterConfig* meter_config,
+                           const TdiPktModMeterConfig& cfg) {
+  meter_config->set_policer_meter_prof_id(
+      static_cast<int64>(cfg.meter_prof_id));
+  meter_config->set_policer_spec_cir_unit(static_cast<int64>(cfg.cir_unit));
+  meter_config->set_policer_spec_cbs_unit(static_cast<int64>(cfg.cburst_unit));
+  meter_config->set_policer_spec_eir_unit(static_cast<int64>(cfg.pir_unit));
+  meter_config->set_policer_spec_ebs_unit(static_cast<int64>(cfg.pburst_unit));
+  meter_config->set_policer_spec_cir(static_cast<int64>(cfg.cir));
+  meter_config->set_policer_spec_cbs(static_cast<int64>(cfg.cburst));
+  meter_config->set_policer_spec_eir(static_cast<int64>(cfg.pir));
+  meter_config->set_policer_spec_ebs(static_cast<int64>(cfg.pburst));
+}
+
+// Sets a MeterCounterData protobuf from a meter configuration variable.
+void SetCounterData(::p4::v1::MeterCounterData* counter_data,
+                    const TdiPktModMeterConfig& cfg) {
+  counter_data->mutable_green()->set_byte_count(
+      static_cast<int64>(cfg.greenBytes));
+  counter_data->mutable_green()->set_packet_count(
+      static_cast<int64>(cfg.greenPackets));
+  counter_data->mutable_yellow()->set_byte_count(
+      static_cast<int64>(cfg.yellowBytes));
+  counter_data->mutable_yellow()->set_packet_count(
+      static_cast<int64>(cfg.yellowPackets));
+  counter_data->mutable_red()->set_byte_count(static_cast<int64>(cfg.redBytes));
+  counter_data->mutable_red()->set_packet_count(
+      static_cast<int64>(cfg.redPackets));
+}
+
+}  // namespace helpers
+}  // namespace tdi
+}  // namespace hal
+}  // namespace stratum

--- a/stratum/hal/lib/tdi/tdi_table_helpers.h
+++ b/stratum/hal/lib/tdi/tdi_table_helpers.h
@@ -1,0 +1,92 @@
+// Copyright 2020-present Open Networking Foundation
+// Copyright 2022-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef STRATUM_HAL_LIB_TDI_TDI_TABLE_HELPERS_H_
+#define STRATUM_HAL_LIB_TDI_TDI_TABLE_HELPERS_H_
+
+#include "p4/config/v1/p4info.pb.h"
+#include "p4/v1/p4runtime.pb.h"
+#include "stratum/glue/status/status_macros.h"
+#include "stratum/hal/lib/tdi/tdi_pkt_mod_meter_config.h"
+#include "stratum/public/proto/error.pb.h"
+
+namespace stratum {
+namespace hal {
+namespace tdi {
+namespace helpers {
+
+// Sets a Boolean variable to indicate whether the specified meter is
+// configured to measure traffic in packets (true) or bytes (false).
+template <typename T>
+::util::Status GetMeterUnitsInPackets(const T& meter, bool& units_in_packets) {
+  switch (meter.spec().unit()) {
+    case ::p4::config::v1::MeterSpec::BYTES:
+      units_in_packets = false;
+      break;
+    case ::p4::config::v1::MeterSpec::PACKETS:
+      units_in_packets = true;
+      break;
+    default:
+      return MAKE_ERROR(ERR_INVALID_PARAM) << "Unsupported meter spec on meter "
+                                           << meter.ShortDebugString() << ".";
+  }
+  return ::util::OkStatus();
+}
+
+// Sets a meter configuration variable from a pair of PolicerMeterConfig
+// and MeterCounterData protobufs.
+void SetPktModMeterConfig(TdiPktModMeterConfig& config,
+                          const ::p4::v1::PolicerMeterConfig& meter_config,
+                          const ::p4::v1::MeterCounterData& counter_data);
+
+// Convenience function to set a meter configuration variable from a
+// MeterEntry protobuf.
+inline void SetPktModMeterConfig(TdiPktModMeterConfig& config,
+                                 const ::p4::v1::MeterEntry& meter_entry) {
+  return SetPktModMeterConfig(config,
+                              meter_entry.config().policer_meter_config(),
+                              meter_entry.counter_data());
+}
+
+// Convenience function to set a meter configuration variable from a
+// TableEntry protobuf.
+inline void SetPktModMeterConfig(TdiPktModMeterConfig& config,
+                                 const ::p4::v1::TableEntry& table_entry) {
+  return SetPktModMeterConfig(config,
+                              table_entry.meter_config().policer_meter_config(),
+                              table_entry.meter_counter_data());
+}
+
+// Sets a PolicerMeterConfig protobuf from a meter configuration variable.
+void SetPolicerMeterConfig(::p4::v1::PolicerMeterConfig* meter_config,
+                           const TdiPktModMeterConfig& cfg);
+
+// Sets a MeterCounterData protobuf from a meter configuration variable.
+void SetCounterData(::p4::v1::MeterCounterData* counter_data,
+                    const TdiPktModMeterConfig& cfg);
+
+// Convenience function to set a DirectMeterEntry protobuf from a meter
+// configuration variable.
+inline void SetDirectMeterEntry(::p4::v1::DirectMeterEntry& meter_entry,
+                                const TdiPktModMeterConfig& cfg) {
+  SetPolicerMeterConfig(
+      meter_entry.mutable_config()->mutable_policer_meter_config(), cfg);
+  SetCounterData(meter_entry.mutable_counter_data(), cfg);
+}
+
+// Convenience function to set a MeterEntry protobuf from a meter
+// configuration variable.
+inline void SetMeterEntry(::p4::v1::MeterEntry& meter_entry,
+                          const TdiPktModMeterConfig& cfg) {
+  SetPolicerMeterConfig(
+      meter_entry.mutable_config()->mutable_policer_meter_config(), cfg);
+  SetCounterData(meter_entry.mutable_counter_data(), cfg);
+}
+
+}  // namespace helpers
+}  // namespace tdi
+}  // namespace hal
+}  // namespace stratum
+
+#endif  // STRATUM_HAL_LIB_TDI_TDI_TABLE_HELPERS_H_

--- a/stratum/hal/lib/tdi/tdi_target_factory.h
+++ b/stratum/hal/lib/tdi/tdi_target_factory.h
@@ -1,0 +1,29 @@
+// Copyright 2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef STRATUM_HAL_LIB_TDI_TDI_TARGET_FACTORY_H_
+#define STRATUM_HAL_LIB_TDI_TDI_TARGET_FACTORY_H_
+
+#include <memory>
+
+#include "stratum/hal/lib/tdi/tdi_extern_manager.h"
+
+namespace stratum {
+namespace hal {
+namespace tdi {
+
+class TdiTargetFactory {
+ public:
+  TdiTargetFactory() {}
+  virtual ~TdiTargetFactory() = default;
+
+  virtual std::unique_ptr<TdiExternManager> CreateTdiExternManager() {
+    return TdiExternManager::CreateInstance();
+  }
+};
+
+}  // namespace tdi
+}  // namespace hal
+}  // namespace stratum
+
+#endif  // STRATUM_HAL_LIB_TDI_TDI_TARGET_FACTORY_H_


### PR DESCRIPTION
This CL implements an architecture that can be used to isolate code that depends on the ES2K-specific IDPF extensions to P4Runtime from the rest of the code.

As things stand right now, we cannot upstream our P4InfoManager changes because they break non-IPDK Stratum platforms (barefoot, bcm, fmv2, etc.) unless they are built against our custom P4Runtime. The new architecture adds an interface that allows platform-specific extensions to P4InfoManager to be incorporated at build time.

The architecture also provides a mechanism that supports custom extensions to TdiTableManager to be incorporated at build time.

The IDPF-dependent code goes into the extensions, which are compiled and linked in as part of the ES2K build.

This CL adds the Es2kExternManager class and its relatives, together with a unit test and Bazel updates to support the new components.

It does NOT include the P4InfoManager and TdiTableManager changes that remove the existing IDPF support and replace it with the ExternManager code. The new files will be passive additions to the codebase until this is done (in a subsequent commit).

See issue https://github.com/ipdk-io/stratum-dev/issues/274 for more information. It includes a UML class diagram.

### Development notes

These changes were developed in Draft PR https://github.com/ipdk-io/stratum-dev/pull/272. The CL consists of 37 files, which is a lot to review. It's also downright scary.

To mitigate risk, I reduced the number of changes to `TdiTableManager` and wrote an extensive unit test for `Es2kExternManager`. The latter turned out to be a worthwhile effort: it found several bugs, and the feedback led to a number of revisions to the code being tested. (Error handling has been completely overhauled.) The unit test covers 100% of the UUT.

I also decided to submit the new code first, including the unit test. Fewer files, very little overlap, and 100% safe because the only thing that compiles or links the new code is the unit test.

I copied the new files to a fresh branch, made a few additional edits, and created this PR.

### Code review notes

- `tdi_table_handler.cc` and `tdi_table_handlers.h` were extracted from `tdi_table_manager.cc`. I needed to share the functions with the resource handlers, which were also lifted from the TableManager. The originals will be deleted as part of integrating the old and new code.
- When reviewing the ES2K resource handlers, you can compare the code with the originals in `TdiTableManager`. It should be essentially the same. The ResourceHandler method is named for the TableManager method from which it was lifted, with the addition of a `Do` prefix to distinguish between the TableManager and ResourceManager methods.