### PR TITLE
Replace TdiPktModMeterConfig helper functions with methods

### DIFF
--- a/stratum/hal/lib/tdi/BUILD
+++ b/stratum/hal/lib/tdi/BUILD
@@ -57,6 +57,7 @@ stratum_cc_library(
     ],
     deps = [
         ":tdi_cc_proto",
+        ":tdi_pkt_mod_meter_config",
         "//stratum/glue:integral_types",
         "//stratum/glue/status",
         "//stratum/glue/status:statusor",
@@ -681,5 +682,15 @@ stratum_cc_test(
         "@com_github_p4lang_p4runtime//:p4runtime_cc_grpc",
         "@com_google_absl//absl/strings",
         "@com_google_googletest//:gtest_main",
+    ],
+)
+
+stratum_cc_library(
+    name = "tdi_pkt_mod_meter_config",
+    srcs = ["tdi_pkt_mod_meter_config.cc"],
+    hdrs = ["tdi_pkt_mod_meter_config.h"],
+    deps = [
+        "//stratum/glue:integral_types",
+        "@com_github_p4lang_p4runtime//:p4runtime_cc_proto",
     ],
 )

--- a/stratum/hal/lib/tdi/tdi_pkt_mod_meter_config.cc
+++ b/stratum/hal/lib/tdi/tdi_pkt_mod_meter_config.cc
@@ -1,0 +1,61 @@
+// Copyright 2022-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#include "stratum/hal/lib/tdi/tdi_pkt_mod_meter_config.h"
+
+namespace stratum {
+namespace hal {
+namespace tdi {
+
+void TdiPktModMeterConfig::SetPolicerMeterConfig(
+    const ::p4::v1::PolicerMeterConfig& meter_config) {
+  meter_prof_id = meter_config.policer_meter_prof_id();
+  cir_unit = meter_config.policer_spec_cir_unit();
+  cburst_unit = meter_config.policer_spec_cbs_unit();
+  pir_unit = meter_config.policer_spec_eir_unit();
+  pburst_unit = meter_config.policer_spec_ebs_unit();
+  cir = meter_config.policer_spec_cir();
+  cburst = meter_config.policer_spec_cbs();
+  pir = meter_config.policer_spec_eir();
+  pburst = meter_config.policer_spec_ebs();
+}
+
+void TdiPktModMeterConfig::SetMeterCounterData(
+    const ::p4::v1::MeterCounterData& counter_data) {
+  greenBytes = counter_data.green().byte_count();
+  greenPackets = counter_data.green().packet_count();
+  yellowBytes = counter_data.yellow().byte_count();
+  yellowPackets = counter_data.yellow().packet_count();
+  redBytes = counter_data.red().byte_count();
+  redPackets = counter_data.red().packet_count();
+}
+
+void TdiPktModMeterConfig::GetPolicerMeterConfig(
+    ::p4::v1::PolicerMeterConfig* meter_config) {
+  meter_config->set_policer_meter_prof_id(static_cast<int64>(meter_prof_id));
+  meter_config->set_policer_spec_cir_unit(static_cast<int64>(cir_unit));
+  meter_config->set_policer_spec_cbs_unit(static_cast<int64>(cburst_unit));
+  meter_config->set_policer_spec_eir_unit(static_cast<int64>(pir_unit));
+  meter_config->set_policer_spec_ebs_unit(static_cast<int64>(pburst_unit));
+  meter_config->set_policer_spec_cir(static_cast<int64>(cir));
+  meter_config->set_policer_spec_cbs(static_cast<int64>(cburst));
+  meter_config->set_policer_spec_eir(static_cast<int64>(pir));
+  meter_config->set_policer_spec_ebs(static_cast<int64>(pburst));
+}
+
+void TdiPktModMeterConfig::GetMeterCounterData(
+    ::p4::v1::MeterCounterData* counter_data) {
+  counter_data->mutable_green()->set_byte_count(static_cast<int64>(greenBytes));
+  counter_data->mutable_green()->set_packet_count(
+      static_cast<int64>(greenPackets));
+  counter_data->mutable_yellow()->set_byte_count(
+      static_cast<int64>(yellowBytes));
+  counter_data->mutable_yellow()->set_packet_count(
+      static_cast<int64>(yellowPackets));
+  counter_data->mutable_red()->set_byte_count(static_cast<int64>(redBytes));
+  counter_data->mutable_red()->set_packet_count(static_cast<int64>(redPackets));
+}
+
+}  // namespace tdi
+}  // namespace hal
+}  // namespace stratum

--- a/stratum/hal/lib/tdi/tdi_pkt_mod_meter_config.h
+++ b/stratum/hal/lib/tdi/tdi_pkt_mod_meter_config.h
@@ -82,7 +82,7 @@ struct TdiPktModMeterConfig {
     GetMeterCounterData(meter_entry->mutable_counter_data());
   }
 
-  inline void SetMeterEntry(::p4::v1::MeterEntry* meter_entry) {
+  inline void GetMeterEntry(::p4::v1::MeterEntry* meter_entry) {
     GetPolicerMeterConfig(
         meter_entry->mutable_config()->mutable_policer_meter_config());
     GetMeterCounterData(meter_entry->mutable_counter_data());

--- a/stratum/hal/lib/tdi/tdi_pkt_mod_meter_config.h
+++ b/stratum/hal/lib/tdi/tdi_pkt_mod_meter_config.h
@@ -1,9 +1,10 @@
-// Copyright 2022-2023 Intel Corporation
+// Copyright 2022-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 #ifndef STRATUM_HAL_LIB_TDI_TDI_PKT_MOD_METER_CONFIG_
 #define STRATUM_HAL_LIB_TDI_TDI_PKT_MOD_METER_CONFIG_
 
+#include "p4/config/v1/p4runtime.pb.h"
 #include "stratum/glue/integral_types.h"
 
 namespace stratum {
@@ -32,6 +33,7 @@ struct TdiPktModMeterConfig {
 
   ~TdiPktModMeterConfig() = default;
 
+  // PolicerMeterConfig
   uint64 meter_prof_id;  // Meter Profile ID
   uint64 cir_unit;       // Committed Information Rate Unit
   uint64 cburst_unit;    // Committed Burst Unit
@@ -41,13 +43,50 @@ struct TdiPktModMeterConfig {
   uint64 cburst;         // Committed Burst Size
   uint64 pir;            // Peak Information Rate
   uint64 pburst;         // Peak Burst Size
+
+  // MeterCounterData
   uint64 greenBytes;     // Green Byte counter
   uint64 greenPackets;   // Green Packet counter
   uint64 yellowBytes;    // Yellow Byte counter
   uint64 yellowPackets;  // Yellow Packet counter
   uint64 redBytes;       // Red Byte counter
   uint64 redPackets;     // Red Packet counter
+
   bool isPktModMeter;    // Flag to check direct or indirect PacketModMeter
+
+  // 'Set' methods retrieve data from the specified object and store it in
+  // the configuration. The parameter is always a const reference.
+
+  void SetPolicerMeterConfig(const ::p4::v1::PolicerMeterConfig& meter_config);
+  void SetMeterCounterData(const ::p4::v1::MeterCounterData& counter_data);
+
+  inline void SetMeterEntry(const ::p4::v1::MeterEntry& meter_entry) {
+    SetPolicerMeterConfig(meter_entry.config().policer_meter_config);
+    SetMeterCounterData(meter_entry.counter_data());
+  }
+
+  inline void SetTableEntry(const ::p4::v1::TableEntry& table_entry) {
+    SetPolicerMeterConfig(table_entry.meter_config().policer_meter_config());
+    SetMeterCounterData(table_entry.meter_counter_data());
+  }
+
+  // 'Get' methods retrieve data from the configuration and store it in
+  // the specified object. The parameter is always a pointer.
+
+  void GetPolicerMeterConfig(::p4::v1::PolicerMeterConfig* meter_config);
+  void GetMeterCounterData(::p4::v1::MeterCounterData* counter_data);
+
+  inline void GetDirectMeterEntry(::p4::v1::DirectMeterEntry* meter_entry) {
+    GetPolicerMeterConfig(
+        meter_entry->mutable_config()->mutable_policer_meter_config());
+    GetMeterCounterData(meter_entry->mutable_counter_data());
+  }
+
+  inline void SetMeterEntry(::p4::v1::MeterEntry* meter_entry) {
+    GetPolicerMeterConfig(
+        meter_entry->mutable_config()->mutable_policer_meter_config());
+    GetMeterCounterData(meter_entry->mutable_counter_data());
+  }
 };
 
 }  // namespace tdi

--- a/stratum/hal/lib/tdi/tdi_pkt_mod_meter_config.h
+++ b/stratum/hal/lib/tdi/tdi_pkt_mod_meter_config.h
@@ -4,7 +4,7 @@
 #ifndef STRATUM_HAL_LIB_TDI_TDI_PKT_MOD_METER_CONFIG_
 #define STRATUM_HAL_LIB_TDI_TDI_PKT_MOD_METER_CONFIG_
 
-#include "p4/config/v1/p4runtime.pb.h"
+#include "p4/v1/p4runtime.pb.h"
 #include "stratum/glue/integral_types.h"
 
 namespace stratum {
@@ -61,7 +61,7 @@ struct TdiPktModMeterConfig {
   void SetMeterCounterData(const ::p4::v1::MeterCounterData& counter_data);
 
   inline void SetMeterEntry(const ::p4::v1::MeterEntry& meter_entry) {
-    SetPolicerMeterConfig(meter_entry.config().policer_meter_config);
+    SetPolicerMeterConfig(meter_entry.config().policer_meter_config());
     SetMeterCounterData(meter_entry.counter_data());
   }
 

--- a/stratum/hal/lib/tdi/tdi_pkt_mod_meter_config.h
+++ b/stratum/hal/lib/tdi/tdi_pkt_mod_meter_config.h
@@ -52,7 +52,7 @@ struct TdiPktModMeterConfig {
   uint64 redBytes;       // Red Byte counter
   uint64 redPackets;     // Red Packet counter
 
-  bool isPktModMeter;    // Flag to check direct or indirect PacketModMeter
+  bool isPktModMeter;  // Flag to check direct or indirect PacketModMeter
 
   // 'Set' methods retrieve data from the specified object and store it in
   // the configuration. The parameter is always a const reference.

--- a/stratum/hal/lib/tdi/tdi_table_manager.cc
+++ b/stratum/hal/lib/tdi/tdi_table_manager.cc
@@ -67,96 +67,6 @@ template <typename T>
   return ::util::OkStatus();
 }
 
-// Sets a meter configuration variable from a pair of PolicerMeterConfig
-// and MeterCounterData protobufs.
-void SetPktModMeterConfig(TdiPktModMeterConfig& config,
-                          const ::p4::v1::PolicerMeterConfig& meter_config,
-                          const ::p4::v1::MeterCounterData& counter_data) {
-  config.meter_prof_id = meter_config.policer_meter_prof_id();
-  config.cir_unit = meter_config.policer_spec_cir_unit();
-  config.cburst_unit = meter_config.policer_spec_cbs_unit();
-  config.pir_unit = meter_config.policer_spec_eir_unit();
-  config.pburst_unit = meter_config.policer_spec_ebs_unit();
-  config.cir = meter_config.policer_spec_cir();
-  config.cburst = meter_config.policer_spec_cbs();
-  config.pir = meter_config.policer_spec_eir();
-  config.pburst = meter_config.policer_spec_ebs();
-
-  config.greenBytes = counter_data.green().byte_count();
-  config.greenPackets = counter_data.green().packet_count();
-  config.yellowBytes = counter_data.yellow().byte_count();
-  config.yellowPackets = counter_data.yellow().packet_count();
-  config.redBytes = counter_data.red().byte_count();
-  config.redPackets = counter_data.red().packet_count();
-}
-
-// Convenience function to set a meter configuration variable from a
-// MeterEntry protobuf.
-inline void SetPktModMeterConfig(TdiPktModMeterConfig& config,
-                                 const ::p4::v1::MeterEntry& meter_entry) {
-  return SetPktModMeterConfig(config,
-                              meter_entry.config().policer_meter_config(),
-                              meter_entry.counter_data());
-}
-
-// Convenience function to set a meter configuration variable from a
-// TableEntry protobuf.
-inline void SetPktModMeterConfig(TdiPktModMeterConfig& config,
-                                 const ::p4::v1::TableEntry& table_entry) {
-  return SetPktModMeterConfig(config,
-                              table_entry.meter_config().policer_meter_config(),
-                              table_entry.meter_counter_data());
-}
-
-// Sets a PolicerMeterConfig protobuf from a meter configuration variable.
-void SetPolicerMeterConfig(::p4::v1::PolicerMeterConfig* meter_config,
-                           const TdiPktModMeterConfig& cfg) {
-  meter_config->set_policer_meter_prof_id(
-      static_cast<int64>(cfg.meter_prof_id));
-  meter_config->set_policer_spec_cir_unit(static_cast<int64>(cfg.cir_unit));
-  meter_config->set_policer_spec_cbs_unit(static_cast<int64>(cfg.cburst_unit));
-  meter_config->set_policer_spec_eir_unit(static_cast<int64>(cfg.pir_unit));
-  meter_config->set_policer_spec_ebs_unit(static_cast<int64>(cfg.pburst_unit));
-  meter_config->set_policer_spec_cir(static_cast<int64>(cfg.cir));
-  meter_config->set_policer_spec_cbs(static_cast<int64>(cfg.cburst));
-  meter_config->set_policer_spec_eir(static_cast<int64>(cfg.pir));
-  meter_config->set_policer_spec_ebs(static_cast<int64>(cfg.pburst));
-}
-
-// Sets a MeterCounterData protobuf from a meter configuration variable.
-void SetCounterData(::p4::v1::MeterCounterData* counter_data,
-                    const TdiPktModMeterConfig& cfg) {
-  counter_data->mutable_green()->set_byte_count(
-      static_cast<int64>(cfg.greenBytes));
-  counter_data->mutable_green()->set_packet_count(
-      static_cast<int64>(cfg.greenPackets));
-  counter_data->mutable_yellow()->set_byte_count(
-      static_cast<int64>(cfg.yellowBytes));
-  counter_data->mutable_yellow()->set_packet_count(
-      static_cast<int64>(cfg.yellowPackets));
-  counter_data->mutable_red()->set_byte_count(static_cast<int64>(cfg.redBytes));
-  counter_data->mutable_red()->set_packet_count(
-      static_cast<int64>(cfg.redPackets));
-}
-
-// Convenience function to set a DirectMeterEntry protobuf from a meter
-// configuration variable.
-inline void SetDirectMeterEntry(::p4::v1::DirectMeterEntry& meter_entry,
-                                const TdiPktModMeterConfig& cfg) {
-  SetPolicerMeterConfig(
-      meter_entry.mutable_config()->mutable_policer_meter_config(), cfg);
-  SetCounterData(meter_entry.mutable_counter_data(), cfg);
-}
-
-// Convenience function to set a MeterEntry protobuf from a meter
-// configuration variable.
-inline void SetMeterEntry(::p4::v1::MeterEntry& meter_entry,
-                          const TdiPktModMeterConfig& cfg) {
-  SetPolicerMeterConfig(
-      meter_entry.mutable_config()->mutable_policer_meter_config(), cfg);
-  SetCounterData(meter_entry.mutable_counter_data(), cfg);
-}
-
 }  // namespace
 
 TdiTableManager::TdiTableManager(OperationMode mode,
@@ -365,7 +275,7 @@ std::unique_ptr<TdiTableManager> TdiTableManager::CreateInstance(
       RETURN_IF_ERROR(GetMeterUnitsInPackets(meter, units_in_packets));
 
       TdiPktModMeterConfig config;
-      SetPktModMeterConfig(config, table_entry);
+      config.SetTableEntry(table_entry);
       config.isPktModMeter = units_in_packets;
 
       RETURN_IF_ERROR(table_data->SetPktModMeterConfig(config));
@@ -973,7 +883,7 @@ TdiTableManager::ReadDirectMeterEntry(
       // build response entry from returned data
       TdiPktModMeterConfig cfg;
       RETURN_IF_ERROR(table_data->GetPktModMeterConfig(cfg));
-      SetDirectMeterEntry(result, cfg);
+      cfg.GetDirectMeterEntry(&result);
     }
   }
 
@@ -1144,7 +1054,7 @@ TdiTableManager::ReadDirectMeterEntry(
       ::p4::v1::MeterEntry result;
       result.set_meter_id(meter_entry.meter_id());
       result.mutable_index()->set_index(meter_indices[i]);
-      SetMeterEntry(result, cfg[i]);
+      cfg[i].GetMeterEntry(&result);
       *resp.add_entities()->mutable_meter_entry() = result;
     }
 
@@ -1216,7 +1126,7 @@ TdiTableManager::ReadDirectMeterEntry(
 
     if (meter_entry.has_config()) {
       TdiPktModMeterConfig config;
-      SetPktModMeterConfig(config, meter_entry);
+      config.SetMeterEntry(meter_entry);
       config.isPktModMeter = units_in_packets;
 
       RETURN_IF_ERROR(tdi_sde_interface_->WritePktModMeter(


### PR DESCRIPTION
Most of the the helper functions in `tdi_table_manager.cc` get or set data in a `TdiPktModMeterConfig` object.

This CL converts the helper functions to get/set methods of the class itself.

In addition to being more appropriate for C++, it will make it easier to extract the ES2K-specific code from TdiTableManager.