### PR TITLE
Remove ES2K dependencies from P4InfoManager (1/2) (draft)

### DIFF
--- a/stratum/hal/lib/p4/BUILD
+++ b/stratum/hal/lib/p4/BUILD
@@ -134,6 +134,15 @@ stratum_cc_test(
 )
 
 stratum_cc_library(
+    name = "p4_extern_manager",
+    hdrs = ["p4_extern_manager.h"],
+    deps = [
+        ":p4_resource_map",
+        "@com_github_p4lang_p4runtime//:p4info_cc_proto",
+    ],
+)
+
+stratum_cc_library(
     name = "p4_info_manager",
     srcs = ["p4_info_manager.cc"],
     hdrs = ["p4_info_manager.h"],

--- a/stratum/hal/lib/p4/CMakeLists.txt
+++ b/stratum/hal/lib/p4/CMakeLists.txt
@@ -5,6 +5,7 @@
 #
 
 add_library(stratum_hal_lib_p4_o OBJECT
+    p4_extern_manager.h
     p4_info_manager.cc
     p4_info_manager.h
     p4_resource_map.h

--- a/stratum/hal/lib/p4/p4_extern_manager.h
+++ b/stratum/hal/lib/p4/p4_extern_manager.h
@@ -1,0 +1,29 @@
+// Copyright 2023-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef STRATUM_HAL_LIB_P4_P4_EXTERN_MANAGER_H_
+#define STRATUM_HAL_LIB_P4_P4_EXTERN_MANAGER_H_
+
+#include "p4/config/v1/p4info.pb.h"
+#include "stratum/hal/lib/p4/p4_resource_map.h"
+
+namespace stratum {
+namespace hal {
+
+class P4ExternManager {
+ public:
+  virtual ~P4ExternManager() = default;
+
+  // Called by P4InfoManager to register P4Extern resources.
+  virtual void RegisterExterns(const ::p4::config::v1::P4Info& p4info,
+                               const PreambleCallback& preamble_pb) = 0;
+
+ protected:
+  // Default constructor.
+  P4ExternManager() {}
+};
+
+}  // namespace hal
+}  // namespace stratum
+
+#endif  // STRATUM_HAL_LIB_P4_P4_EXTERN_MANAGER_H_

--- a/stratum/hal/lib/p4/p4_resource_map.h
+++ b/stratum/hal/lib/p4/p4_resource_map.h
@@ -91,8 +91,9 @@ class P4ResourceMap {
     }
   }
 
-  // Accessor.
+  // Accessors.
   const std::string& resource_type() const { return resource_type_; }
+  uint32 size() const { return id_to_resource_map_.size(); }
 
  private:
   // The next two methods create lookup map entries for the input resource.

--- a/stratum/hal/lib/tdi/BUILD
+++ b/stratum/hal/lib/tdi/BUILD
@@ -683,3 +683,31 @@ stratum_cc_test(
         "@com_google_googletest//:gtest_main",
     ],
 )
+
+stratum_cc_library(
+    name = "tdi_extern_manager",
+    hdrs = ["tdi_extern_manager.h"],
+    deps = [
+        "//stratum/hal/lib/p4:p4_extern_manager",
+        "//stratum/hal/lib/p4:p4_resource_map",
+        "@com_github_p4lang_p4runtime//:p4info_cc_proto",
+        "@com_google_absl//absl/memory",
+    ],
+)
+
+stratum_cc_library(
+    name = "tdi_pkt_mod_meter_config",
+    hdrs = ["tdi_pkt_mod_meter_config.h"],
+    deps = [
+        "//stratum/glue:integral_types",
+    ],
+)
+
+stratum_cc_library(
+    name = "tdi_target_factory",
+    hdrs = ["tdi_target_factory.h"],
+    deps = [
+        ":tdi_extern_manager",
+        "@com_google_absl//absl/memory",
+    ],
+)

--- a/stratum/hal/lib/tdi/es2k/BUILD
+++ b/stratum/hal/lib/tdi/es2k/BUILD
@@ -330,3 +330,50 @@ stratum_cc_library(
         "@com_google_googletest//:gtest",
     ],
 )
+
+stratum_cc_library(
+    name = "es2k_extern_manager",
+    srcs = ["es2k_extern_manager.cc"],
+    deps = [
+        ":es2k_extern_manager_hdrs",
+        "//stratum/glue/status:status_macros",
+        "//stratum/hal/lib/p4:utils",
+    ],
+)
+
+stratum_cc_library(
+    name = "es2k_extern_manager_hdrs",
+    hdrs = ["es2k_extern_manager.h"],
+    deps = [
+        "//stratum/glue:integral_types",
+        "//stratum/glue/status:statusor",
+        "//stratum/hal/lib/p4:p4_resource_map",
+        "//stratum/hal/lib/tdi:tdi_extern_manager",
+        "@com_github_p4lang_p4runtime//:idpf_p4info_cc_proto",
+        "@com_github_p4lang_p4runtime//:p4info_cc_proto",
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_protobuf//:protobuf",
+    ],
+)
+
+stratum_cc_test(
+    name = "es2k_extern_manager_test",
+    srcs = ["es2k_extern_manager_test.cc"],
+    deps = [
+        ":es2k_extern_manager",
+        ":es2k_target_factory",
+        ":test_main",
+        "@com_github_p4lang_p4runtime//:p4info_cc_proto",
+        "@com_google_absl//absl/memory",
+        "@com_google_googletest//:gtest",
+    ],
+)
+
+stratum_cc_library(
+    name = "es2k_target_factory",
+    hdrs = ["es2k_target_factory.h"],
+    deps = [
+        ":es2k_extern_manager",
+        "//stratum/hal/lib/tdi:tdi_target_factory",
+    ],
+)

--- a/stratum/hal/lib/tdi/es2k/es2k_extern_manager.cc
+++ b/stratum/hal/lib/tdi/es2k/es2k_extern_manager.cc
@@ -1,0 +1,115 @@
+// Copyright 2023-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#include "stratum/hal/lib/tdi/es2k/es2k_extern_manager.h"
+
+#include "stratum/glue/logging.h"
+#include "stratum/glue/status/status_macros.h"
+#include "stratum/hal/lib/p4/utils.h"
+
+namespace stratum {
+namespace hal {
+namespace tdi {
+
+Es2kExternManager::Es2kExternManager()
+    : pkt_mod_meter_map_("PacketModMeter"),
+      direct_pkt_mod_meter_map_("DirectPacketModMeter") {}
+
+void Es2kExternManager::RegisterExterns(const ::p4::config::v1::P4Info& p4info,
+                                        const PreambleCallback& preamble_cb) {
+  if (!p4info.externs().empty()) {
+    for (const auto& p4extern : p4info.externs()) {
+      switch (p4extern.extern_type_id()) {
+        case ::p4::config::v1::P4Ids::PACKET_MOD_METER:
+          RegisterPacketModMeters(p4extern, preamble_cb);
+          break;
+        case ::p4::config::v1::P4Ids::DIRECT_PACKET_MOD_METER:
+          RegisterDirectPacketModMeters(p4extern, preamble_cb);
+          break;
+        default:
+          ++stats_.unknown_extern_id;
+          LOG(INFO) << "Unrecognized P4Extern type: "
+                    << p4extern.extern_type_id() << " (ignored)";
+          break;
+      }
+    }
+  }
+}
+
+::util::StatusOr<const ::idpf::PacketModMeter>
+Es2kExternManager::FindPktModMeterByID(uint32 meter_id) const {
+  return pkt_mod_meter_map_.FindByID(meter_id);
+}
+
+::util::StatusOr<const ::idpf::PacketModMeter>
+Es2kExternManager::FindPktModMeterByName(const std::string& meter_name) const {
+  return pkt_mod_meter_map_.FindByName(meter_name);
+}
+
+::util::StatusOr<const ::idpf::DirectPacketModMeter>
+Es2kExternManager::FindDirectPktModMeterByID(uint32 meter_id) const {
+  return direct_pkt_mod_meter_map_.FindByID(meter_id);
+}
+
+::util::StatusOr<const ::idpf::DirectPacketModMeter>
+Es2kExternManager::FindDirectPktModMeterByName(
+    const std::string& meter_name) const {
+  return direct_pkt_mod_meter_map_.FindByName(meter_name);
+}
+
+void Es2kExternManager::RegisterPacketModMeters(
+    const p4::config::v1::Extern& p4extern,
+    const PreambleCallback& preamble_cb) {
+  const auto& instances = p4extern.instances();
+  if (!instances.empty()) {
+    for (const auto& extern_instance : instances) {
+      const auto& preamble = extern_instance.preamble();
+
+      // Create a PacketModMeter configuration object.
+      ::idpf::PacketModMeter pkt_mod_meter;
+      *pkt_mod_meter.mutable_preamble() = preamble;
+
+      p4::config::v1::MeterSpec meter_spec;
+      meter_spec.set_unit(p4::config::v1::MeterSpec::PACKETS);
+      *pkt_mod_meter.mutable_spec() = meter_spec;
+
+      pkt_mod_meter.set_size(1024);
+      pkt_mod_meter.set_index_width(20);
+
+      // Add to vector of objects of this type.
+      meter_objects_.Add(std::move(pkt_mod_meter));
+    }
+
+    // Update P4InfoManager maps.
+    pkt_mod_meter_map_.BuildMaps(meter_objects_, preamble_cb);
+  }
+}
+
+void Es2kExternManager::RegisterDirectPacketModMeters(
+    const p4::config::v1::Extern& p4extern,
+    const PreambleCallback& preamble_cb) {
+  const auto& instances = p4extern.instances();
+  if (!instances.empty()) {
+    for (const auto& extern_instance : instances) {
+      const auto& preamble = extern_instance.preamble();
+
+      // Create a DirectPacketModMeter configuration object.
+      ::idpf::DirectPacketModMeter direct_pkt_mod_meter;
+      *direct_pkt_mod_meter.mutable_preamble() = preamble;
+
+      p4::config::v1::MeterSpec meter_spec;
+      meter_spec.set_unit(p4::config::v1::MeterSpec::BYTES);
+      *direct_pkt_mod_meter.mutable_spec() = meter_spec;
+
+      // Add to vector of objects of this type.
+      direct_meter_objects_.Add(std::move(direct_pkt_mod_meter));
+    }
+
+    // Update P4InfoManager maps.
+    direct_pkt_mod_meter_map_.BuildMaps(direct_meter_objects_, preamble_cb);
+  }
+}
+
+}  // namespace tdi
+}  // namespace hal
+}  // namespace stratum

--- a/stratum/hal/lib/tdi/es2k/es2k_extern_manager.h
+++ b/stratum/hal/lib/tdi/es2k/es2k_extern_manager.h
@@ -1,0 +1,88 @@
+// Copyright 2023-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef STRATUM_HAL_LIB_TDI_ES2K_ES2K_EXTERN_MANAGER_H_
+#define STRATUM_HAL_LIB_TDI_ES2K_ES2K_EXTERN_MANAGER_H_
+
+#include <memory>
+#include <string>
+
+#include "absl/container/flat_hash_map.h"
+#include "idpf/p4info.pb.h"
+#include "p4/config/v1/p4info.pb.h"
+#include "stratum/glue/integral_types.h"
+#include "stratum/glue/status/statusor.h"
+#include "stratum/hal/lib/p4/p4_resource_map.h"
+#include "stratum/hal/lib/tdi/tdi_extern_manager.h"
+
+namespace stratum {
+namespace hal {
+namespace tdi {
+
+class Es2kExternManager : public TdiExternManager {
+ public:
+  struct Statistics;
+
+  Es2kExternManager();
+  virtual ~Es2kExternManager() = default;
+
+  // Registers P4Extern resources. Called by P4InfoManager.
+  void RegisterExterns(const ::p4::config::v1::P4Info& p4info,
+                       const PreambleCallback& preamble_cb) override;
+
+  // Retrieve a PacketModMeter configuration.
+  ::util::StatusOr<const ::idpf::PacketModMeter> FindPktModMeterByID(
+      uint32 meter_id) const;
+
+  ::util::StatusOr<const ::idpf::PacketModMeter> FindPktModMeterByName(
+      const std::string& meter_name) const;
+
+  // Retrieve a DirectPacketModMeter configuration.
+  ::util::StatusOr<const ::idpf::DirectPacketModMeter>
+  FindDirectPktModMeterByID(uint32 meter_id) const;
+
+  ::util::StatusOr<const ::idpf::DirectPacketModMeter>
+  FindDirectPktModMeterByName(const std::string& meter_name) const;
+
+  // Returns the number of entries in the DirectPacketModMeter map.
+  uint32 direct_pkt_mod_meter_size() const {
+    return direct_pkt_mod_meter_map_.size();
+  }
+
+  // Returns the number of entries in the PacketModMeter map.
+  uint32 pkt_mod_meter_map_size() const { return pkt_mod_meter_map_.size(); }
+
+  // Returns a reference to the Es2kExternManager statistics.
+  const struct Statistics& statistics() { return stats_; }
+
+  // Es2kExternManager statistics.
+  struct Statistics {
+    Statistics() : unknown_extern_id(0) {}
+    // Number of externs with unrecognized type IDs.
+    uint32 unknown_extern_id;
+  };
+
+ private:
+  void RegisterPacketModMeters(const p4::config::v1::Extern& p4extern,
+                               const PreambleCallback& preamble_cb);
+
+  void RegisterDirectPacketModMeters(const p4::config::v1::Extern& p4extern,
+                                     const PreambleCallback& preamble_cb);
+
+  // One P4ResourceMap for each P4 extern resource type.
+  P4ResourceMap<::idpf::PacketModMeter> pkt_mod_meter_map_;
+  P4ResourceMap<::idpf::DirectPacketModMeter> direct_pkt_mod_meter_map_;
+
+  // One meter object per instance in P4Info.
+  google::protobuf::RepeatedPtrField<::idpf::PacketModMeter> meter_objects_;
+  google::protobuf::RepeatedPtrField<::idpf::DirectPacketModMeter>
+      direct_meter_objects_;
+
+  Statistics stats_;
+};
+
+}  // namespace tdi
+}  // namespace hal
+}  // namespace stratum
+
+#endif  // STRATUM_HAL_LIB_TDI_ES2K_ES2K_EXTERN_MANAGER_H_

--- a/stratum/hal/lib/tdi/es2k/es2k_extern_manager_test.cc
+++ b/stratum/hal/lib/tdi/es2k/es2k_extern_manager_test.cc
@@ -1,0 +1,353 @@
+// Copyright 2023-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+// Unit test for Es2kExternManager.
+
+#include "stratum/hal/lib/tdi/es2k/es2k_extern_manager.h"
+
+#include <memory>
+#include <string>
+
+#include "absl/memory/memory.h"
+#include "gtest/gtest.h"
+#include "p4/config/v1/p4info.pb.h"
+#include "stratum/glue/status/status.h"
+#include "stratum/hal/lib/tdi/es2k/es2k_target_factory.h"
+#include "stratum/lib/utils.h"
+
+namespace stratum {
+namespace hal {
+namespace tdi {
+
+constexpr uint32 PACKET_MOD_METER_ID =
+    ::p4::config::v1::P4Ids::PACKET_MOD_METER;
+constexpr uint32 DIRECT_PACKET_MOD_METER_ID =
+    ::p4::config::v1::P4Ids::DIRECT_PACKET_MOD_METER;
+
+// The bits 31:24 of the resource ID contain the P4 type ID.
+constexpr uint32 kPktModMeterBase = PACKET_MOD_METER_ID << 24;
+constexpr uint32 kDirectPktModMeterBase = DIRECT_PACKET_MOD_METER_ID << 24;
+
+class Es2kExternManagerTest : public testing::Test {
+ protected:
+  Es2kExternManagerTest() : es2k_extern_manager_(new Es2kExternManager) {}
+
+  ::util::Status ProcessPreamble(const ::p4::config::v1::Preamble& preamble,
+                                 const std::string& resource_type);
+
+  void SetUpPreambleCallback();
+
+  void SetUpDirectPacketModMeters();
+  void SetUpDirectPacketModMeterTest();
+  void SetUpPacketModMeters();
+  void SetUpPacketModMeterTest();
+
+  std::unique_ptr<Es2kExternManager> es2k_extern_manager_;
+  PreambleCallback preamble_cb_;
+  ::p4::config::v1::P4Info p4info_;
+  std::unique_ptr<absl::Mutex> lock_;
+};
+
+void Es2kExternManagerTest::SetUpPreambleCallback() {
+  preamble_cb_ = std::bind(&Es2kExternManagerTest::ProcessPreamble, this,
+                           std::placeholders::_1, std::placeholders::_2);
+}
+
+// Dummy preamble processing callback function.
+::util::Status Es2kExternManagerTest::ProcessPreamble(
+    const ::p4::config::v1::Preamble& preamble,
+    const std::string& resource_type) {
+  return ::util::OkStatus();
+}
+
+//----------------------------------------------------------------------
+// Setup tests
+//----------------------------------------------------------------------
+
+TEST_F(Es2kExternManagerTest, TestConstructor) {
+  ASSERT_TRUE(es2k_extern_manager_);
+}
+
+TEST_F(Es2kExternManagerTest, TestCreateInstance) {
+  ASSERT_TRUE(Es2kExternManager::CreateInstance());
+}
+
+TEST_F(Es2kExternManagerTest, TestFactoryCreateInstance) {
+  Es2kTargetFactory target_factory;
+  auto extern_manager = target_factory.CreateTdiExternManager();
+  ASSERT_TRUE(extern_manager);
+}
+
+//----------------------------------------------------------------------
+// DirectPacketModMeter tests
+//----------------------------------------------------------------------
+
+const std::string kDirectPacketModMeterExternText = R"pb(
+  extern_type_id: 134
+  extern_type_name: "DirectPacketModMeter"
+  instances {
+    preamble {
+      id: 2264139482
+      name: "my_control.meter3"
+      alias: "meter3"
+    }
+    info {
+      [type.googleapis.com/idpf.DirectPacketModMeter] {
+        spec {
+          unit: BYTES
+        }
+      }
+    }
+  }
+  instances {
+    preamble {
+      id: 2249256208
+      name: "my_control.meter4"
+      alias: "meter4"
+    }
+    info {
+      [type.googleapis.com/idpf.DirectPacketModMeter] {
+        spec {
+          unit: BYTES
+        }
+      }
+    }
+  }
+)pb";
+
+constexpr char kDirectPacketModMeterTypeName[] = "DirectPacketModMeter";
+constexpr uint32 kDirectPacketModMeterTypeID = 134;
+
+constexpr uint32 kDirectPacketModMeterID1 = 2264139482;  // 0x86F406DA
+constexpr uint32 kDirectPacketModMeterID2 = 2249256208;  // 0x8610ED10
+constexpr char kDirectPacketModMeterName1[] = "my_control.meter3";
+constexpr char kDirectPacketModMeterName2[] = "my_control.meter4";
+
+constexpr uint32 kBadDirectPacketModMeterID = 0x8500ACED;
+constexpr char kBadDirectPacketModMeterName[] = "self_control.meter.99";
+
+//----------------------------------------------------------------------
+
+void Es2kExternManagerTest::SetUpDirectPacketModMeters() {
+  auto p4extern = p4info_.add_externs();
+  ASSERT_TRUE(
+      ParseProtoFromString(kDirectPacketModMeterExternText, p4extern).ok());
+}
+
+void Es2kExternManagerTest::SetUpDirectPacketModMeterTest() {
+  SetUpDirectPacketModMeters();
+  SetUpPreambleCallback();
+  es2k_extern_manager_->RegisterExterns(p4info_, preamble_cb_);
+}
+
+//----------------------------------------------------------------------
+
+TEST_F(Es2kExternManagerTest, TestParseDirectPacketModMeters) {
+  SetUpDirectPacketModMeters();
+  SetUpPreambleCallback();
+  es2k_extern_manager_->RegisterExterns(p4info_, preamble_cb_);
+
+  EXPECT_EQ(es2k_extern_manager_->direct_pkt_mod_meter_size(), 2);
+  EXPECT_EQ(es2k_extern_manager_->pkt_mod_meter_map_size(), 0);
+}
+
+TEST_F(Es2kExternManagerTest, TestFindDirectPacketModMeterByID) {
+  SetUpDirectPacketModMeterTest();
+
+  auto directMeter1 =
+      es2k_extern_manager_->FindDirectPktModMeterByID(kDirectPacketModMeterID1);
+  EXPECT_TRUE(directMeter1.ok());
+
+  auto directMeter3 =
+      es2k_extern_manager_->FindDirectPktModMeterByID(kDirectPacketModMeterID2);
+  EXPECT_TRUE(directMeter3.ok());
+}
+
+TEST_F(Es2kExternManagerTest, TestFindDirectPacketModMeterByName) {
+  SetUpDirectPacketModMeterTest();
+
+  auto directMeter2 = es2k_extern_manager_->FindDirectPktModMeterByName(
+      kDirectPacketModMeterName1);
+  EXPECT_TRUE(directMeter2.ok());
+
+  auto directMeter4 = es2k_extern_manager_->FindDirectPktModMeterByName(
+      kDirectPacketModMeterName2);
+  EXPECT_TRUE(directMeter4.ok());
+}
+
+TEST_F(Es2kExternManagerTest, TestFindBadDirectPacketModMeter) {
+  SetUpDirectPacketModMeterTest();
+
+  auto badMeter1 = es2k_extern_manager_->FindDirectPktModMeterByID(
+      kBadDirectPacketModMeterID);
+  EXPECT_FALSE(badMeter1.ok());
+
+  auto badMeter2 = es2k_extern_manager_->FindDirectPktModMeterByName(
+      kBadDirectPacketModMeterName);
+  EXPECT_FALSE(badMeter2.ok());
+}
+
+//----------------------------------------------------------------------
+// PacketModMeter tests
+//----------------------------------------------------------------------
+
+const std::string kPacketModMeterExternText = R"pb(
+  extern_type_id: 133
+  extern_type_name: "PacketModMeter"
+  instances {
+    preamble {
+      id: 2244878476
+      name: "my_control.meter1"
+      alias: "meter1"
+    }
+    info {
+      [type.googleapis.com/idpf.PacketModMeter] {
+        spec {
+          unit: PACKETS
+        }
+        size: 1024
+        index_width: 20
+      }
+    }
+  }
+  instances {
+    preamble {
+      id: 2242552391
+      name: "my_control.meter2"
+      alias: "meter2"
+    }
+    info {
+      [type.googleapis.com/idpf.PacketModMeter] {
+        spec {
+          unit: PACKETS
+        }
+        size: 1024
+        index_width: 20
+      }
+    }
+  }
+)pb";
+
+constexpr uint32 kPacketModMeterID1 = 2244878476;  // 0x85CE208C
+constexpr uint32 kPacketModMeterID2 = 2242552391;  // 0x85AAA247
+constexpr char kPacketModMeterName1[] = "my_control.meter1";
+constexpr char kPacketModMeterName2[] = "my_control.meter2";
+
+constexpr uint32 kBadPacketModMeterID = 0x8500DEAD;
+constexpr char kBadPacketModMeterName[] = "mind_control.meter";
+
+constexpr char kPacketModMeterTypeName[] = "PacketModMeter";
+constexpr uint32 kPacketModMeterTypeID = 133;
+
+//----------------------------------------------------------------------
+
+void Es2kExternManagerTest::SetUpPacketModMeters() {
+  auto p4extern = p4info_.add_externs();
+  ASSERT_TRUE(ParseProtoFromString(kPacketModMeterExternText, p4extern).ok());
+}
+
+void Es2kExternManagerTest::SetUpPacketModMeterTest() {
+  SetUpPacketModMeters();
+  SetUpPreambleCallback();
+  es2k_extern_manager_->RegisterExterns(p4info_, preamble_cb_);
+}
+
+//----------------------------------------------------------------------
+
+TEST_F(Es2kExternManagerTest, TestParsePacketModMeters) {
+  SetUpPacketModMeters();
+  SetUpPreambleCallback();
+  es2k_extern_manager_->RegisterExterns(p4info_, preamble_cb_);
+
+  EXPECT_EQ(es2k_extern_manager_->direct_pkt_mod_meter_size(), 0);
+  EXPECT_EQ(es2k_extern_manager_->pkt_mod_meter_map_size(), 2);
+}
+
+TEST_F(Es2kExternManagerTest, TestFindPacketModMeterByID) {
+  SetUpPacketModMeterTest();
+
+  auto directMeter1 =
+      es2k_extern_manager_->FindPktModMeterByID(kPacketModMeterID1);
+  EXPECT_TRUE(directMeter1.ok());
+
+  auto directMeter3 =
+      es2k_extern_manager_->FindPktModMeterByID(kPacketModMeterID2);
+  EXPECT_TRUE(directMeter3.ok());
+}
+
+TEST_F(Es2kExternManagerTest, TestFindPacketModMeterByName) {
+  SetUpPacketModMeterTest();
+
+  auto directMeter2 =
+      es2k_extern_manager_->FindPktModMeterByName(kPacketModMeterName1);
+  EXPECT_TRUE(directMeter2.ok());
+
+  auto directMeter4 =
+      es2k_extern_manager_->FindPktModMeterByName(kPacketModMeterName2);
+  EXPECT_TRUE(directMeter4.ok());
+}
+
+TEST_F(Es2kExternManagerTest, TestFindBadPacketModMeter) {
+  SetUpPacketModMeterTest();
+
+  auto badMeter1 =
+      es2k_extern_manager_->FindPktModMeterByID(kBadPacketModMeterID);
+  EXPECT_FALSE(badMeter1.ok());
+
+  auto badMeter2 =
+      es2k_extern_manager_->FindPktModMeterByName(kBadPacketModMeterName);
+  EXPECT_FALSE(badMeter2.ok());
+}
+
+//----------------------------------------------------------------------
+// Miscellaneous tests
+//----------------------------------------------------------------------
+
+TEST_F(Es2kExternManagerTest, TestFindMeterWhenEmpty) {
+  auto directMeter1 =
+      es2k_extern_manager_->FindPktModMeterByID(kPacketModMeterID1);
+  EXPECT_FALSE(directMeter1.ok());
+
+  auto directMeter2 = es2k_extern_manager_->FindDirectPktModMeterByName(
+      kDirectPacketModMeterName2);
+  EXPECT_FALSE(directMeter2.ok());
+}
+
+TEST_F(Es2kExternManagerTest, TestParseBothExternMeterTypes) {
+  SetUpPacketModMeters();
+  SetUpDirectPacketModMeters();
+  SetUpPreambleCallback();
+  es2k_extern_manager_->RegisterExterns(p4info_, preamble_cb_);
+
+  EXPECT_EQ(es2k_extern_manager_->direct_pkt_mod_meter_size(), 2);
+  EXPECT_EQ(es2k_extern_manager_->pkt_mod_meter_map_size(), 2);
+}
+
+//----------------------------------------------------------------------
+// Error tests
+//----------------------------------------------------------------------
+
+TEST_F(Es2kExternManagerTest, TestUnknownExternType) {
+  auto p4extern = p4info_.add_externs();
+  p4extern->set_extern_type_id(0);
+  es2k_extern_manager_->RegisterExterns(p4info_, preamble_cb_);
+
+  auto stats = es2k_extern_manager_->statistics();
+  EXPECT_EQ(stats.unknown_extern_id, 1);
+}
+
+constexpr char kZeroPreambleIdText[] = R"pb(
+  extern_type_id: 134
+  extern_type_name: "DirectPacketModMeter"
+  instances {
+    preamble {
+      id: 0
+      name: "my_control.meter3"
+      alias: "meter3"
+    }
+  }
+)pb";
+
+}  // namespace tdi
+}  // namespace hal
+}  // namespace stratum

--- a/stratum/hal/lib/tdi/es2k/es2k_target_factory.h
+++ b/stratum/hal/lib/tdi/es2k/es2k_target_factory.h
@@ -1,0 +1,32 @@
+// Copyright 2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef STRATUM_HAL_LIB_TDI_ES2K_ES2K_TARGET_FACTORY_H_
+#define STRATUM_HAL_LIB_TDI_ES2K_ES2K_TARGET_FACTORY_H_
+
+#include <memory>
+#include <utility>
+
+#include "stratum/hal/lib/tdi/es2k/es2k_extern_manager.h"
+#include "stratum/hal/lib/tdi/tdi_target_factory.h"
+
+namespace stratum {
+namespace hal {
+namespace tdi {
+
+class Es2kTargetFactory : public TdiTargetFactory {
+ public:
+  Es2kTargetFactory() {}
+  virtual ~Es2kTargetFactory() = default;
+
+  std::unique_ptr<TdiExternManager> CreateTdiExternManager() override {
+    auto es2kPtr = Es2kExternManager::CreateInstance();
+    return std::unique_ptr<TdiExternManager>(std::move(es2kPtr));
+  }
+};
+
+}  // namespace tdi
+}  // namespace hal
+}  // namespace stratum
+
+#endif  // STRATUM_HAL_LIB_TDI_ES2K_ES2K_TARGET_FACTORY_H_

--- a/stratum/hal/lib/tdi/tdi_extern_manager.h
+++ b/stratum/hal/lib/tdi/tdi_extern_manager.h
@@ -1,0 +1,35 @@
+// Copyright 2023-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef STRATUM_HAL_LIB_TDI_TDI_EXTERN_MANAGER_H_
+#define STRATUM_HAL_LIB_TDI_TDI_EXTERN_MANAGER_H_
+
+#include "absl/memory/memory.h"
+#include "p4/config/v1/p4info.pb.h"
+#include "stratum/hal/lib/p4/p4_extern_manager.h"
+#include "stratum/hal/lib/p4/p4_resource_map.h"
+
+namespace stratum {
+namespace hal {
+namespace tdi {
+
+class TdiExternManager : public P4ExternManager {
+ public:
+  TdiExternManager() {}
+  virtual ~TdiExternManager() = default;
+
+  // Called by TdiTargetFactory.
+  static std::unique_ptr<TdiExternManager> CreateInstance() {
+    return absl::make_unique<TdiExternManager>();
+  }
+
+  // Registers P4Extern resources. Called by P4InfoManager.
+  void RegisterExterns(const ::p4::config::v1::P4Info& p4info,
+                       const PreambleCallback& preamble_cb) override {}
+};
+
+}  // namespace tdi
+}  // namespace hal
+}  // namespace stratum
+
+#endif  // STRATUM_HAL_LIB_TDI_TDI_EXTERN_MANAGER_H_

--- a/stratum/hal/lib/tdi/tdi_target_factory.h
+++ b/stratum/hal/lib/tdi/tdi_target_factory.h
@@ -1,0 +1,29 @@
+// Copyright 2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef STRATUM_HAL_LIB_TDI_TDI_TARGET_FACTORY_H_
+#define STRATUM_HAL_LIB_TDI_TDI_TARGET_FACTORY_H_
+
+#include <memory>
+
+#include "stratum/hal/lib/tdi/tdi_extern_manager.h"
+
+namespace stratum {
+namespace hal {
+namespace tdi {
+
+class TdiTargetFactory {
+ public:
+  TdiTargetFactory() {}
+  virtual ~TdiTargetFactory() = default;
+
+  virtual std::unique_ptr<TdiExternManager> CreateTdiExternManager() {
+    return TdiExternManager::CreateInstance();
+  }
+};
+
+}  // namespace tdi
+}  // namespace hal
+}  // namespace stratum
+
+#endif  // STRATUM_HAL_LIB_TDI_TDI_TARGET_FACTORY_H_


### PR DESCRIPTION
We cannot upstream our modifications to P4InfoManager in their current form because they are ES2K-specific and make the module (which is common to all Stratum platforms) depend directly on a non-standard version of P4Runtime.

This CL defines a family of classes that allow a platform to supply an extension that implements custom P4Extern processing without requiring changes to P4InfoManager itself.

It also includes an implementation of an extension for ES2K, and a unit test for the ES2K extension.

A subsequent commit will replace the ES2K-specific code in P4InfoManager with support for the extension mechanism, and it will modify TdiTableManager to supply the extension.

See issue https://github.com/ipdk-io/stratum-dev/issues/274 for design information.

> [!NOTE]
> This PR has been broken into four smaller PRs, to make it easier to review.
> - https://github.com/ipdk-io/stratum-dev/pull/283
> - https://github.com/ipdk-io/stratum-dev/pull/284
> - https://github.com/ipdk-io/stratum-dev/pull/285
> - https://github.com/ipdk-io/stratum-dev/pull/286