### PR TITLE
Fix timeout in p4_service_test

### DIFF
--- a/stratum/hal/lib/common/BUILD
+++ b/stratum/hal/lib/common/BUILD
@@ -599,7 +599,7 @@ stratum_cc_library(
 
 stratum_cc_test(
     name = "p4_service_test",
-    timeout = moderate,
+    size = "medium",
     srcs = [
         "p4_service_test.cc",
     ],

--- a/stratum/hal/lib/common/BUILD
+++ b/stratum/hal/lib/common/BUILD
@@ -2,7 +2,7 @@
 
 # Copyright 2018 Google LLC
 # Copyright 2018-present Open Networking Foundation
-# Copyright 2022-2023 Intel Corporation
+# Copyright 2022-2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
 load(
@@ -599,6 +599,7 @@ stratum_cc_library(
 
 stratum_cc_test(
     name = "p4_service_test",
+    timeout = moderate,
     srcs = [
         "p4_service_test.cc",
     ],

--- a/stratum/lib/p4runtime/BUILD
+++ b/stratum/lib/p4runtime/BUILD
@@ -24,7 +24,7 @@ config_setting(
 )
 
 IPDK_ROLE_FIX = select({
-    ":es2k_target": ["IPDK_ROLE_FIX"],
+#   ":es2k_target": ["IPDK_ROLE_FIX"],
     "//conditions:default": [],
 })
 


### PR DESCRIPTION
- Disabled the `define=["IPDK_ROLE_FIX"]` attribute when building `sdn_controller_manager` with Bazel. It triggers test case failures in `p4_service_test` and increases test time to more than 90s.

- Specified `size="medium"` on `p4_service_test`.  The default is `"short"` (60s), and a successful test currently takes ~72s.