### PR TITLE
Address IDPF dependencies in P4InfoManager (draft)

### DIFF
--- a/stratum/hal/bin/tdi/dpdk/BUILD
+++ b/stratum/hal/bin/tdi/dpdk/BUILD
@@ -48,5 +48,6 @@ stratum_cc_binary(
         "//stratum/hal/lib/tdi:tdi_pre_manager",
         "//stratum/hal/lib/tdi:tdi_sde_wrapper",
         "//stratum/hal/lib/tdi:tdi_table_manager",
+        "//stratum/hal/lib/tdi:tdi_target_factory",
     ] + stratum_dpdk_common_deps,
 )

--- a/stratum/hal/bin/tdi/dpdk/dpdk_main.cc
+++ b/stratum/hal/bin/tdi/dpdk/dpdk_main.cc
@@ -1,6 +1,6 @@
 // Copyright 2018-2019 Barefoot Networks, Inc.
 // Copyright 2020-present Open Networking Foundation
-// Copyright 2022-2023 Intel Corporation
+// Copyright 2022-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 #include <map>
@@ -28,6 +28,7 @@
 #include "stratum/hal/lib/tdi/tdi_packetio_manager.h"
 #include "stratum/hal/lib/tdi/tdi_pre_manager.h"
 #include "stratum/hal/lib/tdi/tdi_table_manager.h"
+#include "stratum/hal/lib/tdi/tdi_target_factory.h"
 #include "stratum/lib/macros.h"
 #include "stratum/lib/security/auth_policy_checker.h"
 
@@ -109,8 +110,10 @@ void ParseCommandLine(int argc, char* argv[], bool remove_flags) {
   VLOG(1) << "Switch SKU: " << sde_wrapper->GetChipType(device_id);
   /* ========== */
 
-  auto table_manager =
-      TdiTableManager::CreateInstance(mode, sde_wrapper, device_id);
+  TdiTargetFactory target_factory;
+
+  auto table_manager = TdiTableManager::CreateInstance(
+      mode, sde_wrapper, target_factory, device_id);
 
   auto action_profile_manager =
       TdiActionProfileManager::CreateInstance(sde_wrapper, device_id);

--- a/stratum/hal/bin/tdi/es2k/BUILD
+++ b/stratum/hal/bin/tdi/es2k/BUILD
@@ -2,7 +2,7 @@
 
 # Copyright 2018 Google LLC
 # Copyright 2018-present Open Networking Foundation
-# Copyright 2022-2023 Intel Corporation
+# Copyright 2022-2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
 load("//bazel:rules.bzl", "HOST_ARCHES", "stratum_cc_binary")
@@ -44,6 +44,7 @@ stratum_cc_binary(
         "//stratum/hal/lib/tdi/es2k:es2k_sde_utils",
         "//stratum/hal/lib/tdi/es2k:es2k_sde_wrapper",
         "//stratum/hal/lib/tdi/es2k:es2k_switch",
+        "//stratum/hal/lib/tdi/es2k:es2k_target_factory",
         "//stratum/hal/lib/tdi:tdi_action_profile_manager",
         "//stratum/hal/lib/tdi:tdi_counter_manager",
         "//stratum/hal/lib/tdi:tdi_pre_manager",

--- a/stratum/hal/bin/tdi/es2k/es2k_main.cc
+++ b/stratum/hal/bin/tdi/es2k/es2k_main.cc
@@ -24,6 +24,7 @@
 #include "stratum/hal/lib/tdi/es2k/es2k_port_manager.h"
 #include "stratum/hal/lib/tdi/es2k/es2k_sde_wrapper.h"
 #include "stratum/hal/lib/tdi/es2k/es2k_switch.h"
+#include "stratum/hal/lib/tdi/es2k/es2k_target_factory.h"
 #include "stratum/hal/lib/tdi/tdi_action_profile_manager.h"
 #include "stratum/hal/lib/tdi/tdi_counter_manager.h"
 #include "stratum/hal/lib/tdi/tdi_fixed_function_manager.h"
@@ -114,8 +115,10 @@ void ParseCommandLine(int argc, char* argv[], bool remove_flags) {
   VLOG(1) << "SDE version: " << sde_wrapper->GetSdeVersion();
   VLOG(1) << "Switch SKU: " << sde_wrapper->GetChipType(device_id);
 
-  auto table_manager =
-      TdiTableManager::CreateInstance(mode, sde_wrapper, device_id);
+  Es2kTargetFactory target_factory;
+
+  auto table_manager = TdiTableManager::CreateInstance(
+      mode, sde_wrapper, target_factory, device_id);
 
   auto fixed_function_manager =
       TdiFixedFunctionManager::CreateInstance(mode, sde_wrapper, device_id);

--- a/stratum/hal/bin/tdi/tofino/BUILD
+++ b/stratum/hal/bin/tdi/tofino/BUILD
@@ -49,6 +49,7 @@ stratum_cc_binary(
         "//stratum/hal/lib/tdi:tdi_pre_manager",
         "//stratum/hal/lib/tdi:tdi_sde_wrapper",
         "//stratum/hal/lib/tdi:tdi_table_manager",
+        "//stratum/hal/lib/tdi:tdi_target_factory",
     ] + stratum_common_deps,
 )
 

--- a/stratum/hal/bin/tdi/tofino/tofino_main.cc
+++ b/stratum/hal/bin/tdi/tofino/tofino_main.cc
@@ -1,6 +1,6 @@
 // Copyright 2018-2019 Barefoot Networks, Inc.
 // Copyright 2020-present Open Networking Foundation
-// Copyright 2022-2023 Intel Corporation
+// Copyright 2022-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 #include "gflags/gflags.h"
@@ -13,6 +13,7 @@
 #include "stratum/hal/lib/tdi/tdi_node.h"
 #include "stratum/hal/lib/tdi/tdi_pre_manager.h"
 #include "stratum/hal/lib/tdi/tdi_table_manager.h"
+#include "stratum/hal/lib/tdi/tdi_target_factory.h"
 #include "stratum/hal/lib/tdi/tofino/tofino_chassis_manager.h"
 #include "stratum/hal/lib/tdi/tofino/tofino_hal.h"
 #include "stratum/hal/lib/tdi/tofino/tofino_port_manager.h"
@@ -58,8 +59,10 @@ namespace tdi {
   VLOG(1) << "SDE version: " << sde_wrapper->GetSdeVersion();
   VLOG(1) << "Switch SKU: " << sde_wrapper->GetChipType(device_id);
 
-  auto table_manager =
-      TdiTableManager::CreateInstance(mode, sde_wrapper, device_id);
+  TdiTargetFactory target_factory;
+
+  auto table_manager = TdiTableManager::CreateInstance(
+      mode, sde_wrapper, target_factory, device_id);
 
   auto action_profile_manager =
       TdiActionProfileManager::CreateInstance(sde_wrapper, device_id);

--- a/stratum/hal/lib/p4/BUILD
+++ b/stratum/hal/lib/p4/BUILD
@@ -134,10 +134,20 @@ stratum_cc_test(
 )
 
 stratum_cc_library(
+    name = "p4_extern_manager",
+    hdrs = ["p4_extern_manager.h"],
+    deps = [
+        ":p4_resource_map",
+        "@com_github_p4lang_p4runtime//:p4info_cc_proto",
+    ],
+)
+
+stratum_cc_library(
     name = "p4_info_manager",
     srcs = ["p4_info_manager.cc"],
     hdrs = ["p4_info_manager.h"],
     deps = [
+        ":p4_extern_manager",
         ":p4_resource_map",
         ":utils",
         "//stratum/glue:logging",

--- a/stratum/hal/lib/p4/CMakeLists.txt
+++ b/stratum/hal/lib/p4/CMakeLists.txt
@@ -5,6 +5,7 @@
 #
 
 add_library(stratum_hal_lib_p4_o OBJECT
+    p4_extern_manager.h
     p4_info_manager.cc
     p4_info_manager.h
     p4_resource_map.h

--- a/stratum/hal/lib/p4/p4_extern_manager.h
+++ b/stratum/hal/lib/p4/p4_extern_manager.h
@@ -1,0 +1,29 @@
+// Copyright 2023-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef STRATUM_HAL_LIB_P4_P4_EXTERN_MANAGER_H_
+#define STRATUM_HAL_LIB_P4_P4_EXTERN_MANAGER_H_
+
+#include "p4/config/v1/p4info.pb.h"
+#include "stratum/hal/lib/p4/p4_resource_map.h"
+
+namespace stratum {
+namespace hal {
+
+class P4ExternManager {
+ public:
+  virtual ~P4ExternManager() = default;
+
+  // Called by P4InfoManager to register P4Extern resources.
+  virtual void RegisterExterns(const ::p4::config::v1::P4Info& p4info,
+                               const PreambleCallback& preamble_pb) = 0;
+
+ protected:
+  // Default constructor.
+  P4ExternManager() {}
+};
+
+}  // namespace hal
+}  // namespace stratum
+
+#endif  // STRATUM_HAL_LIB_P4_P4_EXTERN_MANAGER_H_

--- a/stratum/hal/lib/p4/p4_info_manager.cc
+++ b/stratum/hal/lib/p4/p4_info_manager.cc
@@ -13,7 +13,6 @@
 #include "absl/strings/strip.h"
 #include "absl/strings/substitute.h"
 #include "gflags/gflags.h"
-#include "idpf/p4info.pb.h"
 #include "p4/config/v1/p4info.pb.h"
 #include "stratum/glue/gtl/map_util.h"
 #include "stratum/lib/macros.h"
@@ -38,8 +37,6 @@ P4InfoManager::P4InfoManager(const ::p4::config::v1::P4Info& p4_info)
       direct_counter_map_("Direct-Counter"),
       meter_map_("Meter"),
       direct_meter_map_("Direct-Meter"),
-      pkt_mod_meter_map_("PacketModMeter"),
-      direct_pkt_mod_meter_map_("DirectPacketModMeter"),
       value_set_map_("ValueSet"),
       register_map_("Register"),
       digest_map_("Digest"),
@@ -53,8 +50,6 @@ P4InfoManager::P4InfoManager()
       direct_counter_map_("Direct-Counter"),
       meter_map_("Meter"),
       direct_meter_map_("Direct-Meter"),
-      pkt_mod_meter_map_("PacketModMeter"),
-      direct_pkt_mod_meter_map_("DirectPacketModMeter"),
       value_set_map_("ValueSet"),
       register_map_("Register"),
       digest_map_("Digest"),
@@ -104,64 +99,9 @@ P4InfoManager::~P4InfoManager() {}
     extern_manager->RegisterExterns(p4_info_, preamble_cb);
   }
 
-  // This code depends on a proposed change to the P4Runtime specification,
-  // and is provisional.
-  if (!p4_info_.externs().empty()) {
-    for (const auto& p4extern : p4_info_.externs()) {
-      switch (p4extern.extern_type_id()) {
-        case ::p4::config::v1::P4Ids_Prefix_PACKET_MOD_METER:
-          InitPacketModMeters(p4extern);
-          break;
-        case ::p4::config::v1::P4Ids_Prefix_DIRECT_PACKET_MOD_METER:
-          InitDirectPacketModMeters(p4extern);
-          break;
-        default:
-          LOG(INFO) << "Unrecognized p4_info extern type: "
-                    << p4extern.extern_type_id() << " (ignored)";
-          break;
-      }
-    }
-  }
-
   APPEND_STATUS_IF_ERROR(status, VerifyTableXrefs());
 
   return status;
-}
-
-void P4InfoManager::InitDirectPacketModMeters(
-    const p4::config::v1::Extern& p4extern) {
-  const auto& extern_instances = p4extern.instances();
-  PreambleCallback preamble_cb =
-      std::bind(&P4InfoManager::ProcessPreamble, this, std::placeholders::_1,
-                std::placeholders::_2);
-  for (const auto& extern_instance : extern_instances) {
-    ::idpf::DirectPacketModMeter direct_pkt_mod_meter;
-    *direct_pkt_mod_meter.mutable_preamble() = extern_instance.preamble();
-    p4::config::v1::MeterSpec meter_spec;
-    meter_spec.set_unit(p4::config::v1::MeterSpec::BYTES);
-    *direct_pkt_mod_meter.mutable_spec() = meter_spec;
-    direct_meter_objects_.Add(std::move(direct_pkt_mod_meter));
-  }
-  direct_pkt_mod_meter_map_.BuildMaps(direct_meter_objects_, preamble_cb);
-}
-
-void P4InfoManager::InitPacketModMeters(
-    const p4::config::v1::Extern& p4extern) {
-  const auto& extern_instances = p4extern.instances();
-  PreambleCallback preamble_cb =
-      std::bind(&P4InfoManager::ProcessPreamble, this, std::placeholders::_1,
-                std::placeholders::_2);
-  for (const auto& extern_instance : extern_instances) {
-    ::idpf::PacketModMeter pkt_mod_meter;
-    *pkt_mod_meter.mutable_preamble() = extern_instance.preamble();
-    p4::config::v1::MeterSpec meter_spec;
-    meter_spec.set_unit(p4::config::v1::MeterSpec::PACKETS);
-    pkt_mod_meter.set_size(1024);
-    pkt_mod_meter.set_index_width(20);
-    *pkt_mod_meter.mutable_spec() = meter_spec;
-    all_meter_objects_.Add(std::move(pkt_mod_meter));
-  }
-  pkt_mod_meter_map_.BuildMaps(all_meter_objects_, preamble_cb);
 }
 
 // FindTable
@@ -239,29 +179,6 @@ P4InfoManager::FindDirectMeterByID(uint32 meter_id) const {
 ::util::StatusOr<const ::p4::config::v1::DirectMeter>
 P4InfoManager::FindDirectMeterByName(const std::string& meter_name) const {
   return direct_meter_map_.FindByName(meter_name);
-}
-
-// FindPktModMeter
-::util::StatusOr<const ::idpf::PacketModMeter>
-P4InfoManager::FindPktModMeterByID(uint32 meter_id) const {
-  return pkt_mod_meter_map_.FindByID(meter_id);
-}
-
-::util::StatusOr<const ::idpf::PacketModMeter>
-P4InfoManager::FindPktModMeterByName(const std::string& meter_name) const {
-  return pkt_mod_meter_map_.FindByName(meter_name);
-}
-
-// FindDirectPktModMeter
-::util::StatusOr<const ::idpf::DirectPacketModMeter>
-P4InfoManager::FindDirectPktModMeterByID(uint32 meter_id) const {
-  return direct_pkt_mod_meter_map_.FindByID(meter_id);
-}
-
-::util::StatusOr<const ::idpf::DirectPacketModMeter>
-P4InfoManager::FindDirectPktModMeterByName(
-    const std::string& meter_name) const {
-  return direct_pkt_mod_meter_map_.FindByName(meter_name);
 }
 
 // FindValueSet

--- a/stratum/hal/lib/p4/p4_info_manager.h
+++ b/stratum/hal/lib/p4/p4_info_manager.h
@@ -15,7 +15,6 @@
 #include "absl/container/flat_hash_map.h"
 #include "absl/container/flat_hash_set.h"
 #include "google/protobuf/repeated_field.h"
-#include "idpf/p4info.pb.h"
 #include "p4/config/v1/p4info.pb.h"
 #include "stratum/glue/integral_types.h"
 #include "stratum/glue/logging.h"
@@ -108,16 +107,6 @@ class P4InfoManager {
   virtual ::util::StatusOr<const ::p4::config::v1::DirectMeter>
   FindDirectMeterByName(const std::string& meter_name) const;
 
-  virtual ::util::StatusOr<const ::idpf::PacketModMeter> FindPktModMeterByID(
-      uint32 meter_id) const;
-  virtual ::util::StatusOr<const ::idpf::PacketModMeter> FindPktModMeterByName(
-      const std::string& meter_name) const;
-
-  virtual ::util::StatusOr<const ::idpf::DirectPacketModMeter>
-  FindDirectPktModMeterByID(uint32 meter_id) const;
-  virtual ::util::StatusOr<const ::idpf::DirectPacketModMeter>
-  FindDirectPktModMeterByName(const std::string& meter_name) const;
-
   virtual ::util::StatusOr<const ::p4::config::v1::ValueSet> FindValueSetByID(
       uint32 value_set_id) const;
   virtual ::util::StatusOr<const ::p4::config::v1::ValueSet> FindValueSetByName(
@@ -194,9 +183,6 @@ class P4InfoManager {
   // Verifies cross-references from Tables to Actions and Header Fields.
   ::util::Status VerifyTableXrefs();
 
-  void InitDirectPacketModMeters(const p4::config::v1::Extern& p4extern);
-  void InitPacketModMeters(const p4::config::v1::Extern& p4extern);
-
   // Functions to validate name and ID presence in message preamble.
   static ::util::Status VerifyID(const ::p4::config::v1::Preamble& preamble,
                                  const std::string& resource_type);
@@ -215,8 +201,6 @@ class P4InfoManager {
   P4ResourceMap<::p4::config::v1::DirectCounter> direct_counter_map_;
   P4ResourceMap<::p4::config::v1::Meter> meter_map_;
   P4ResourceMap<::p4::config::v1::DirectMeter> direct_meter_map_;
-  P4ResourceMap<::idpf::PacketModMeter> pkt_mod_meter_map_;
-  P4ResourceMap<::idpf::DirectPacketModMeter> direct_pkt_mod_meter_map_;
   P4ResourceMap<::p4::config::v1::ValueSet> value_set_map_;
   P4ResourceMap<::p4::config::v1::Register> register_map_;
   P4ResourceMap<::p4::config::v1::Digest> digest_map_;
@@ -227,10 +211,6 @@ class P4InfoManager {
   absl::flat_hash_map<std::string, const ::p4::config::v1::Preamble*>
       all_resource_names_;
   absl::flat_hash_map<uint32, std::string> id_to_resource_type_map_;
-
-  google::protobuf::RepeatedPtrField<::idpf::PacketModMeter> all_meter_objects_;
-  google::protobuf::RepeatedPtrField<::idpf::DirectPacketModMeter>
-      direct_meter_objects_;
 };
 
 }  // namespace hal

--- a/stratum/hal/lib/p4/p4_info_manager.h
+++ b/stratum/hal/lib/p4/p4_info_manager.h
@@ -22,6 +22,7 @@
 #include "stratum/glue/status/status.h"
 #include "stratum/glue/status/status_macros.h"
 #include "stratum/glue/status/statusor.h"
+#include "stratum/hal/lib/p4/p4_extern_manager.h"
 #include "stratum/hal/lib/p4/p4_resource_map.h"
 #include "stratum/hal/lib/p4/utils.h"
 #include "stratum/lib/macros.h"
@@ -65,7 +66,8 @@ class P4InfoManager {
   // verify the overall correctness of its P4Info.  For example, it confirms
   // that all header field and action ID references in table definitions refer
   // to validly defined P4 resources.
-  virtual ::util::Status InitializeAndVerify();
+  virtual ::util::Status InitializeAndVerify(
+      P4ExternManager* extern_manager = nullptr);
 
   // These methods look up P4 resource information that corresponds to the input
   // ID or name.  A successful lookup returns a copy of the resource data

--- a/stratum/hal/lib/p4/p4_info_manager_mock.h
+++ b/stratum/hal/lib/p4/p4_info_manager_mock.h
@@ -68,22 +68,6 @@ class P4InfoManagerMock : public P4InfoManager {
                      ::util::StatusOr<const ::p4::config::v1::DirectMeter>(
                          const std::string& meter_name));
 
-  // FindPktModMeter
-  MOCK_CONST_METHOD1(
-      FindPktModMeterByID,
-      ::util::StatusOr<const ::idpf::PacketModMeter>(uint32 meter_id));
-  MOCK_CONST_METHOD1(FindPktModMeterByName,
-                     ::util::StatusOr<const ::idpf::PacketModMeter>(
-                         const std::string& meter_name));
-
-  // FindDirectPktModMeter
-  MOCK_CONST_METHOD1(
-      FindDirectPktModMeterByID,
-      ::util::StatusOr<const ::idpf::DirectPacketModMeter>(uint32 meter_id));
-  MOCK_CONST_METHOD1(FindDirectPktModMeterByName,
-                     ::util::StatusOr<const ::idpf::DirectPacketModMeter>(
-                         const std::string& meter_name));
-
   // FindValueSet
   MOCK_CONST_METHOD1(
       FindValueSetByID,
@@ -103,6 +87,7 @@ class P4InfoManagerMock : public P4InfoManager {
   MOCK_CONST_METHOD1(
       GetSwitchStackAnnotations,
       ::util::StatusOr<P4Annotation>(const std::string& p4_object_name));
+
   MOCK_CONST_METHOD0(DumpNamesToIDs, void());
   MOCK_CONST_METHOD0(p4_info, const ::p4::config::v1::P4Info&());
   MOCK_METHOD0(VerifyRequiredObjects, ::util::Status());

--- a/stratum/hal/lib/p4/p4_resource_map.h
+++ b/stratum/hal/lib/p4/p4_resource_map.h
@@ -91,8 +91,9 @@ class P4ResourceMap {
     }
   }
 
-  // Accessor.
+  // Accessors.
   const std::string& resource_type() const { return resource_type_; }
+  uint32 size() const { return id_to_resource_map_.size(); }
 
  private:
   // The next two methods create lookup map entries for the input resource.

--- a/stratum/hal/lib/tdi/BUILD
+++ b/stratum/hal/lib/tdi/BUILD
@@ -51,10 +51,7 @@ target_sdk_headers = select({
 
 stratum_cc_library(
     name = "tdi_sde_interface",
-    hdrs = [
-        "tdi_pkt_mod_meter_config.h",
-        "tdi_sde_interface.h",
-    ],
+    hdrs = ["tdi_sde_interface.h"],
     deps = [
         ":tdi_cc_proto",
         ":tdi_pkt_mod_meter_config",
@@ -292,8 +289,11 @@ stratum_cc_library(
     hdrs = ["tdi_table_manager.h"],
     deps = [
         ":tdi_cc_proto",
+        ":tdi_extern_manager",
         ":tdi_get_meter_units",
+        ":tdi_pkt_mod_meter_config",
         ":tdi_sde_interface",
+        ":tdi_target_factory",
         ":utils",
         "//stratum/glue:integral_types",
         "//stratum/glue:logging",
@@ -309,7 +309,6 @@ stratum_cc_library(
         "//stratum/lib:timer_daemon",
         "//stratum/lib:utils",
         "//stratum/public/proto:error_cc_proto",
-        "@com_github_p4lang_p4runtime//:idpf_p4info_cc_proto",
         "@com_github_p4lang_p4runtime//:p4info_cc_proto",
         "@com_github_p4lang_p4runtime//:p4runtime_cc_grpc",
         "@com_google_absl//absl/container:flat_hash_map",

--- a/stratum/hal/lib/tdi/BUILD
+++ b/stratum/hal/lib/tdi/BUILD
@@ -687,6 +687,20 @@ stratum_cc_test(
 )
 
 stratum_cc_library(
+    name = "tdi_extern_manager",
+    srcs = ["tdi_extern_manager.cc"],
+    hdrs = ["tdi_extern_manager.h"],
+    deps = [
+        "//stratum/hal/lib/p4:p4_extern_manager",
+        "//stratum/hal/lib/p4:p4_info_manager",
+        "//stratum/hal/lib/p4:p4_resource_map",
+        "@com_github_p4lang_p4runtime//:idpf_p4info_cc_proto",
+        "@com_github_p4lang_p4runtime//:p4info_cc_proto",
+        "@com_google_absl//absl/memory",
+    ],
+)
+
+stratum_cc_library(
     name = "tdi_get_meter_units",
     hdrs = ["tdi_get_meter_units.h"],
     deps = [

--- a/stratum/hal/lib/tdi/BUILD
+++ b/stratum/hal/lib/tdi/BUILD
@@ -718,3 +718,12 @@ stratum_cc_library(
         "@com_github_p4lang_p4runtime//:p4runtime_cc_proto",
     ],
 )
+
+stratum_cc_library(
+    name = "tdi_target_factory",
+    hdrs = ["tdi_target_factory.h"],
+    deps = [
+        ":tdi_extern_manager",
+        "@com_google_absl//absl/memory",
+    ],
+)

--- a/stratum/hal/lib/tdi/CMakeLists.txt
+++ b/stratum/hal/lib/tdi/CMakeLists.txt
@@ -11,9 +11,11 @@
 add_library(stratum_tdi_common_o OBJECT
     tdi_action_profile_manager.cc
     tdi_action_profile_manager.h
-    tdi_status.h
     tdi_counter_manager.cc
     tdi_counter_manager.h
+    tdi_extern_manager.cc
+    tdi_extern_manager.h
+    tdi_get_meter_units.h
     tdi_global_vars.cc
     tdi_global_vars.h
     tdi_id_mapper.cc
@@ -24,6 +26,8 @@ add_library(stratum_tdi_common_o OBJECT
     tdi_packetio_manager.h
     tdi_pipeline_utils.cc
     tdi_pipeline_utils.h
+    tdi_pkt_mod_meter_config.cc
+    tdi_pkt_mod_meter_config.h
     tdi_port_manager.cc
     tdi_port_manager.h
     tdi_pre_manager.cc
@@ -46,8 +50,10 @@ add_library(stratum_tdi_common_o OBJECT
     tdi_sde_utils.h
     tdi_sde_wrapper.cc
     tdi_sde_wrapper.h
+    tdi_status.h
     tdi_table_manager.cc
     tdi_table_manager.h
+    tdi_target_factory.h
     utils.cc
     utils.h
 )

--- a/stratum/hal/lib/tdi/es2k/BUILD
+++ b/stratum/hal/lib/tdi/es2k/BUILD
@@ -356,3 +356,12 @@ stratum_cc_library(
         "@com_google_protobuf//:protobuf",
     ],
 )
+
+stratum_cc_library(
+    name = "es2k_target_factory",
+    hdrs = ["es2k_target_factory.h"],
+    deps = [
+        ":es2k_extern_manager",
+        "//stratum/hal/lib/tdi:tdi_target_factory",
+    ],
+)

--- a/stratum/hal/lib/tdi/es2k/BUILD
+++ b/stratum/hal/lib/tdi/es2k/BUILD
@@ -365,3 +365,16 @@ stratum_cc_library(
         "//stratum/hal/lib/tdi:tdi_target_factory",
     ],
 )
+
+stratum_cc_test(
+    name = "es2k_extern_manager_test",
+    srcs = ["es2k_extern_manager_test.cc"],
+    deps = [
+        ":es2k_extern_manager",
+        ":es2k_target_factory",
+        ":test_main",
+        "@com_github_p4lang_p4runtime//:p4info_cc_proto",
+        "@com_google_absl//absl/memory",
+        "@com_google_googletest//:gtest",
+    ],
+)

--- a/stratum/hal/lib/tdi/es2k/BUILD
+++ b/stratum/hal/lib/tdi/es2k/BUILD
@@ -330,3 +330,29 @@ stratum_cc_library(
         "@com_google_googletest//:gtest",
     ],
 )
+
+stratum_cc_library(
+    name = "es2k_extern_manager",
+    srcs = ["es2k_extern_manager.cc"],
+    deps = [
+        ":es2k_extern_manager_hdrs",
+        "//stratum/glue/status:status_macros",
+        "//stratum/hal/lib/p4:utils",
+    ],
+)
+
+stratum_cc_library(
+    name = "es2k_extern_manager_hdrs",
+    hdrs = ["es2k_extern_manager.h"],
+    deps = [
+        "//stratum/glue:integral_types",
+        "//stratum/glue/status:statusor",
+        "//stratum/hal/lib/p4:p4_info_manager",
+        "//stratum/hal/lib/p4:p4_resource_map",
+        "//stratum/hal/lib/tdi:tdi_extern_manager",
+        "@com_github_p4lang_p4runtime//:idpf_p4info_cc_proto",
+        "@com_github_p4lang_p4runtime//:p4info_cc_proto",
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_protobuf//:protobuf",
+    ],
+)

--- a/stratum/hal/lib/tdi/es2k/CMakeLists.txt
+++ b/stratum/hal/lib/tdi/es2k/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Build file for //stratum/hal/lib/tdi/es2k
 #
-# Copyright 2022-2023 Intel Corporation
+# Copyright 2022-2024 Intel Corporation
 # SPDX-License-Identifier: Apache 2.0
 #
 
@@ -11,6 +11,8 @@
 target_sources(stratum_tdi_target_o PRIVATE
     es2k_chassis_manager.cc
     es2k_chassis_manager.h
+    es2k_extern_manager.cc
+    es2k_extern_manager.h
     es2k_hal.cc
     es2k_hal.h
     es2k_node.cc
@@ -24,4 +26,5 @@ target_sources(stratum_tdi_target_o PRIVATE
     es2k_sde_wrapper.cc
     es2k_switch.cc
     es2k_switch.h
+    es2k_target_factory.h
 )

--- a/stratum/hal/lib/tdi/es2k/es2k_extern_manager.cc
+++ b/stratum/hal/lib/tdi/es2k/es2k_extern_manager.cc
@@ -1,0 +1,115 @@
+// Copyright 2023-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#include "stratum/hal/lib/tdi/es2k/es2k_extern_manager.h"
+
+#include "stratum/glue/logging.h"
+#include "stratum/glue/status/status_macros.h"
+#include "stratum/hal/lib/p4/utils.h"
+
+namespace stratum {
+namespace hal {
+namespace tdi {
+
+Es2kExternManager::Es2kExternManager()
+    : pkt_mod_meter_map_("PacketModMeter"),
+      direct_pkt_mod_meter_map_("DirectPacketModMeter") {}
+
+void Es2kExternManager::RegisterExterns(const ::p4::config::v1::P4Info& p4info,
+                                        const PreambleCallback& preamble_cb) {
+  if (!p4info.externs().empty()) {
+    for (const auto& p4extern : p4info.externs()) {
+      switch (p4extern.extern_type_id()) {
+        case ::p4::config::v1::P4Ids::PACKET_MOD_METER:
+          RegisterPacketModMeters(p4extern, preamble_cb);
+          break;
+        case ::p4::config::v1::P4Ids::DIRECT_PACKET_MOD_METER:
+          RegisterDirectPacketModMeters(p4extern, preamble_cb);
+          break;
+        default:
+          ++stats_.unknown_extern_id;
+          LOG(INFO) << "Unrecognized P4Extern type: "
+                    << p4extern.extern_type_id() << " (ignored)";
+          break;
+      }
+    }
+  }
+}
+
+::util::StatusOr<const ::idpf::PacketModMeter>
+Es2kExternManager::FindPktModMeterByID(uint32 meter_id) const {
+  return pkt_mod_meter_map_.FindByID(meter_id);
+}
+
+::util::StatusOr<const ::idpf::PacketModMeter>
+Es2kExternManager::FindPktModMeterByName(const std::string& meter_name) const {
+  return pkt_mod_meter_map_.FindByName(meter_name);
+}
+
+::util::StatusOr<const ::idpf::DirectPacketModMeter>
+Es2kExternManager::FindDirectPktModMeterByID(uint32 meter_id) const {
+  return direct_pkt_mod_meter_map_.FindByID(meter_id);
+}
+
+::util::StatusOr<const ::idpf::DirectPacketModMeter>
+Es2kExternManager::FindDirectPktModMeterByName(
+    const std::string& meter_name) const {
+  return direct_pkt_mod_meter_map_.FindByName(meter_name);
+}
+
+void Es2kExternManager::RegisterPacketModMeters(
+    const p4::config::v1::Extern& p4extern,
+    const PreambleCallback& preamble_cb) {
+  const auto& instances = p4extern.instances();
+  if (!instances.empty()) {
+    for (const auto& extern_instance : instances) {
+      const auto& preamble = extern_instance.preamble();
+
+      // Create a PacketModMeter configuration object.
+      ::idpf::PacketModMeter pkt_mod_meter;
+      *pkt_mod_meter.mutable_preamble() = preamble;
+
+      p4::config::v1::MeterSpec meter_spec;
+      meter_spec.set_unit(p4::config::v1::MeterSpec::PACKETS);
+      *pkt_mod_meter.mutable_spec() = meter_spec;
+
+      pkt_mod_meter.set_size(1024);
+      pkt_mod_meter.set_index_width(20);
+
+      // Add to vector of objects of this type.
+      meter_objects_.Add(std::move(pkt_mod_meter));
+    }
+
+    // Update P4InfoManager maps.
+    pkt_mod_meter_map_.BuildMaps(meter_objects_, preamble_cb);
+  }
+}
+
+void Es2kExternManager::RegisterDirectPacketModMeters(
+    const p4::config::v1::Extern& p4extern,
+    const PreambleCallback& preamble_cb) {
+  const auto& instances = p4extern.instances();
+  if (!instances.empty()) {
+    for (const auto& extern_instance : instances) {
+      const auto& preamble = extern_instance.preamble();
+
+      // Create a DirectPacketModMeter configuration object.
+      ::idpf::DirectPacketModMeter direct_pkt_mod_meter;
+      *direct_pkt_mod_meter.mutable_preamble() = preamble;
+
+      p4::config::v1::MeterSpec meter_spec;
+      meter_spec.set_unit(p4::config::v1::MeterSpec::BYTES);
+      *direct_pkt_mod_meter.mutable_spec() = meter_spec;
+
+      // Add to vector of objects of this type.
+      direct_meter_objects_.Add(std::move(direct_pkt_mod_meter));
+    }
+
+    // Update P4InfoManager maps.
+    direct_pkt_mod_meter_map_.BuildMaps(direct_meter_objects_, preamble_cb);
+  }
+}
+
+}  // namespace tdi
+}  // namespace hal
+}  // namespace stratum

--- a/stratum/hal/lib/tdi/es2k/es2k_extern_manager.h
+++ b/stratum/hal/lib/tdi/es2k/es2k_extern_manager.h
@@ -1,0 +1,88 @@
+// Copyright 2023-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef STRATUM_HAL_LIB_TDI_ES2K_ES2K_EXTERN_MANAGER_H_
+#define STRATUM_HAL_LIB_TDI_ES2K_ES2K_EXTERN_MANAGER_H_
+
+#include <memory>
+#include <string>
+
+#include "absl/container/flat_hash_map.h"
+#include "idpf/p4info.pb.h"
+#include "p4/config/v1/p4info.pb.h"
+#include "stratum/glue/integral_types.h"
+#include "stratum/glue/status/statusor.h"
+#include "stratum/hal/lib/p4/p4_resource_map.h"
+#include "stratum/hal/lib/tdi/tdi_extern_manager.h"
+
+namespace stratum {
+namespace hal {
+namespace tdi {
+
+class Es2kExternManager : public TdiExternManager {
+ public:
+  struct Statistics;
+
+  Es2kExternManager();
+  virtual ~Es2kExternManager() = default;
+
+  // Registers P4Extern resources. Called by P4InfoManager.
+  void RegisterExterns(const ::p4::config::v1::P4Info& p4info,
+                       const PreambleCallback& preamble_cb) override;
+
+  // Retrieve a PacketModMeter configuration.
+  ::util::StatusOr<const ::idpf::PacketModMeter> FindPktModMeterByID(
+      uint32 meter_id) const override;
+
+  ::util::StatusOr<const ::idpf::PacketModMeter> FindPktModMeterByName(
+      const std::string& meter_name) const override;
+
+  // Retrieve a DirectPacketModMeter configuration.
+  ::util::StatusOr<const ::idpf::DirectPacketModMeter>
+  FindDirectPktModMeterByID(uint32 meter_id) const override;
+
+  ::util::StatusOr<const ::idpf::DirectPacketModMeter>
+  FindDirectPktModMeterByName(const std::string& meter_name) const override;
+
+  // Returns the number of entries in the DirectPacketModMeter map.
+  uint32 direct_pkt_mod_meter_size() const {
+    return direct_pkt_mod_meter_map_.size();
+  }
+
+  // Returns the number of entries in the PacketModMeter map.
+  uint32 pkt_mod_meter_map_size() const { return pkt_mod_meter_map_.size(); }
+
+  // Returns a reference to the Es2kExternManager statistics.
+  const struct Statistics& statistics() { return stats_; }
+
+  // Es2kExternManager statistics.
+  struct Statistics {
+    Statistics() : unknown_extern_id(0) {}
+    // Number of externs with unrecognized type IDs.
+    uint32 unknown_extern_id;
+  };
+
+ private:
+  void RegisterPacketModMeters(const p4::config::v1::Extern& p4extern,
+                               const PreambleCallback& preamble_cb);
+
+  void RegisterDirectPacketModMeters(const p4::config::v1::Extern& p4extern,
+                                     const PreambleCallback& preamble_cb);
+
+  // One P4ResourceMap for each P4 extern resource type.
+  P4ResourceMap<::idpf::PacketModMeter> pkt_mod_meter_map_;
+  P4ResourceMap<::idpf::DirectPacketModMeter> direct_pkt_mod_meter_map_;
+
+  // One meter object per instance in P4Info.
+  google::protobuf::RepeatedPtrField<::idpf::PacketModMeter> meter_objects_;
+  google::protobuf::RepeatedPtrField<::idpf::DirectPacketModMeter>
+      direct_meter_objects_;
+
+  Statistics stats_;
+};
+
+}  // namespace tdi
+}  // namespace hal
+}  // namespace stratum
+
+#endif  // STRATUM_HAL_LIB_TDI_ES2K_ES2K_EXTERN_MANAGER_H_

--- a/stratum/hal/lib/tdi/es2k/es2k_extern_manager_test.cc
+++ b/stratum/hal/lib/tdi/es2k/es2k_extern_manager_test.cc
@@ -1,0 +1,353 @@
+// Copyright 2023-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+// Unit test for Es2kExternManager.
+
+#include "stratum/hal/lib/tdi/es2k/es2k_extern_manager.h"
+
+#include <memory>
+#include <string>
+
+#include "absl/memory/memory.h"
+#include "gtest/gtest.h"
+#include "p4/config/v1/p4info.pb.h"
+#include "stratum/glue/status/status.h"
+#include "stratum/hal/lib/tdi/es2k/es2k_target_factory.h"
+#include "stratum/lib/utils.h"
+
+namespace stratum {
+namespace hal {
+namespace tdi {
+
+constexpr uint32 PACKET_MOD_METER_ID =
+    ::p4::config::v1::P4Ids::PACKET_MOD_METER;
+constexpr uint32 DIRECT_PACKET_MOD_METER_ID =
+    ::p4::config::v1::P4Ids::DIRECT_PACKET_MOD_METER;
+
+// The bits 31:24 of the resource ID contain the P4 type ID.
+constexpr uint32 kPktModMeterBase = PACKET_MOD_METER_ID << 24;
+constexpr uint32 kDirectPktModMeterBase = DIRECT_PACKET_MOD_METER_ID << 24;
+
+class Es2kExternManagerTest : public testing::Test {
+ protected:
+  Es2kExternManagerTest() : es2k_extern_manager_(new Es2kExternManager) {}
+
+  ::util::Status ProcessPreamble(const ::p4::config::v1::Preamble& preamble,
+                                 const std::string& resource_type);
+
+  void SetUpPreambleCallback();
+
+  void SetUpDirectPacketModMeters();
+  void SetUpDirectPacketModMeterTest();
+  void SetUpPacketModMeters();
+  void SetUpPacketModMeterTest();
+
+  std::unique_ptr<Es2kExternManager> es2k_extern_manager_;
+  PreambleCallback preamble_cb_;
+  ::p4::config::v1::P4Info p4info_;
+  std::unique_ptr<absl::Mutex> lock_;
+};
+
+void Es2kExternManagerTest::SetUpPreambleCallback() {
+  preamble_cb_ = std::bind(&Es2kExternManagerTest::ProcessPreamble, this,
+                           std::placeholders::_1, std::placeholders::_2);
+}
+
+// Dummy preamble processing callback function.
+::util::Status Es2kExternManagerTest::ProcessPreamble(
+    const ::p4::config::v1::Preamble& preamble,
+    const std::string& resource_type) {
+  return ::util::OkStatus();
+}
+
+//----------------------------------------------------------------------
+// Setup tests
+//----------------------------------------------------------------------
+
+TEST_F(Es2kExternManagerTest, TestConstructor) {
+  ASSERT_TRUE(es2k_extern_manager_);
+}
+
+TEST_F(Es2kExternManagerTest, TestCreateInstance) {
+  ASSERT_TRUE(Es2kExternManager::CreateInstance());
+}
+
+TEST_F(Es2kExternManagerTest, TestFactoryCreateInstance) {
+  Es2kTargetFactory target_factory;
+  auto extern_manager = target_factory.CreateTdiExternManager();
+  ASSERT_TRUE(extern_manager);
+}
+
+//----------------------------------------------------------------------
+// DirectPacketModMeter tests
+//----------------------------------------------------------------------
+
+const std::string kDirectPacketModMeterExternText = R"pb(
+  extern_type_id: 134
+  extern_type_name: "DirectPacketModMeter"
+  instances {
+    preamble {
+      id: 2264139482
+      name: "my_control.meter3"
+      alias: "meter3"
+    }
+    info {
+      [type.googleapis.com/idpf.DirectPacketModMeter] {
+        spec {
+          unit: BYTES
+        }
+      }
+    }
+  }
+  instances {
+    preamble {
+      id: 2249256208
+      name: "my_control.meter4"
+      alias: "meter4"
+    }
+    info {
+      [type.googleapis.com/idpf.DirectPacketModMeter] {
+        spec {
+          unit: BYTES
+        }
+      }
+    }
+  }
+)pb";
+
+constexpr char kDirectPacketModMeterTypeName[] = "DirectPacketModMeter";
+constexpr uint32 kDirectPacketModMeterTypeID = 134;
+
+constexpr uint32 kDirectPacketModMeterID1 = 2264139482;  // 0x86F406DA
+constexpr uint32 kDirectPacketModMeterID2 = 2249256208;  // 0x8610ED10
+constexpr char kDirectPacketModMeterName1[] = "my_control.meter3";
+constexpr char kDirectPacketModMeterName2[] = "my_control.meter4";
+
+constexpr uint32 kBadDirectPacketModMeterID = 0x8500ACED;
+constexpr char kBadDirectPacketModMeterName[] = "self_control.meter.99";
+
+//----------------------------------------------------------------------
+
+void Es2kExternManagerTest::SetUpDirectPacketModMeters() {
+  auto p4extern = p4info_.add_externs();
+  ASSERT_TRUE(
+      ParseProtoFromString(kDirectPacketModMeterExternText, p4extern).ok());
+}
+
+void Es2kExternManagerTest::SetUpDirectPacketModMeterTest() {
+  SetUpDirectPacketModMeters();
+  SetUpPreambleCallback();
+  es2k_extern_manager_->RegisterExterns(p4info_, preamble_cb_);
+}
+
+//----------------------------------------------------------------------
+
+TEST_F(Es2kExternManagerTest, TestParseDirectPacketModMeters) {
+  SetUpDirectPacketModMeters();
+  SetUpPreambleCallback();
+  es2k_extern_manager_->RegisterExterns(p4info_, preamble_cb_);
+
+  EXPECT_EQ(es2k_extern_manager_->direct_pkt_mod_meter_size(), 2);
+  EXPECT_EQ(es2k_extern_manager_->pkt_mod_meter_map_size(), 0);
+}
+
+TEST_F(Es2kExternManagerTest, TestFindDirectPacketModMeterByID) {
+  SetUpDirectPacketModMeterTest();
+
+  auto directMeter1 =
+      es2k_extern_manager_->FindDirectPktModMeterByID(kDirectPacketModMeterID1);
+  EXPECT_TRUE(directMeter1.ok());
+
+  auto directMeter3 =
+      es2k_extern_manager_->FindDirectPktModMeterByID(kDirectPacketModMeterID2);
+  EXPECT_TRUE(directMeter3.ok());
+}
+
+TEST_F(Es2kExternManagerTest, TestFindDirectPacketModMeterByName) {
+  SetUpDirectPacketModMeterTest();
+
+  auto directMeter2 = es2k_extern_manager_->FindDirectPktModMeterByName(
+      kDirectPacketModMeterName1);
+  EXPECT_TRUE(directMeter2.ok());
+
+  auto directMeter4 = es2k_extern_manager_->FindDirectPktModMeterByName(
+      kDirectPacketModMeterName2);
+  EXPECT_TRUE(directMeter4.ok());
+}
+
+TEST_F(Es2kExternManagerTest, TestFindBadDirectPacketModMeter) {
+  SetUpDirectPacketModMeterTest();
+
+  auto badMeter1 = es2k_extern_manager_->FindDirectPktModMeterByID(
+      kBadDirectPacketModMeterID);
+  EXPECT_FALSE(badMeter1.ok());
+
+  auto badMeter2 = es2k_extern_manager_->FindDirectPktModMeterByName(
+      kBadDirectPacketModMeterName);
+  EXPECT_FALSE(badMeter2.ok());
+}
+
+//----------------------------------------------------------------------
+// PacketModMeter tests
+//----------------------------------------------------------------------
+
+const std::string kPacketModMeterExternText = R"pb(
+  extern_type_id: 133
+  extern_type_name: "PacketModMeter"
+  instances {
+    preamble {
+      id: 2244878476
+      name: "my_control.meter1"
+      alias: "meter1"
+    }
+    info {
+      [type.googleapis.com/idpf.PacketModMeter] {
+        spec {
+          unit: PACKETS
+        }
+        size: 1024
+        index_width: 20
+      }
+    }
+  }
+  instances {
+    preamble {
+      id: 2242552391
+      name: "my_control.meter2"
+      alias: "meter2"
+    }
+    info {
+      [type.googleapis.com/idpf.PacketModMeter] {
+        spec {
+          unit: PACKETS
+        }
+        size: 1024
+        index_width: 20
+      }
+    }
+  }
+)pb";
+
+constexpr uint32 kPacketModMeterID1 = 2244878476;  // 0x85CE208C
+constexpr uint32 kPacketModMeterID2 = 2242552391;  // 0x85AAA247
+constexpr char kPacketModMeterName1[] = "my_control.meter1";
+constexpr char kPacketModMeterName2[] = "my_control.meter2";
+
+constexpr uint32 kBadPacketModMeterID = 0x8500DEAD;
+constexpr char kBadPacketModMeterName[] = "mind_control.meter";
+
+constexpr char kPacketModMeterTypeName[] = "PacketModMeter";
+constexpr uint32 kPacketModMeterTypeID = 133;
+
+//----------------------------------------------------------------------
+
+void Es2kExternManagerTest::SetUpPacketModMeters() {
+  auto p4extern = p4info_.add_externs();
+  ASSERT_TRUE(ParseProtoFromString(kPacketModMeterExternText, p4extern).ok());
+}
+
+void Es2kExternManagerTest::SetUpPacketModMeterTest() {
+  SetUpPacketModMeters();
+  SetUpPreambleCallback();
+  es2k_extern_manager_->RegisterExterns(p4info_, preamble_cb_);
+}
+
+//----------------------------------------------------------------------
+
+TEST_F(Es2kExternManagerTest, TestParsePacketModMeters) {
+  SetUpPacketModMeters();
+  SetUpPreambleCallback();
+  es2k_extern_manager_->RegisterExterns(p4info_, preamble_cb_);
+
+  EXPECT_EQ(es2k_extern_manager_->direct_pkt_mod_meter_size(), 0);
+  EXPECT_EQ(es2k_extern_manager_->pkt_mod_meter_map_size(), 2);
+}
+
+TEST_F(Es2kExternManagerTest, TestFindPacketModMeterByID) {
+  SetUpPacketModMeterTest();
+
+  auto directMeter1 =
+      es2k_extern_manager_->FindPktModMeterByID(kPacketModMeterID1);
+  EXPECT_TRUE(directMeter1.ok());
+
+  auto directMeter3 =
+      es2k_extern_manager_->FindPktModMeterByID(kPacketModMeterID2);
+  EXPECT_TRUE(directMeter3.ok());
+}
+
+TEST_F(Es2kExternManagerTest, TestFindPacketModMeterByName) {
+  SetUpPacketModMeterTest();
+
+  auto directMeter2 =
+      es2k_extern_manager_->FindPktModMeterByName(kPacketModMeterName1);
+  EXPECT_TRUE(directMeter2.ok());
+
+  auto directMeter4 =
+      es2k_extern_manager_->FindPktModMeterByName(kPacketModMeterName2);
+  EXPECT_TRUE(directMeter4.ok());
+}
+
+TEST_F(Es2kExternManagerTest, TestFindBadPacketModMeter) {
+  SetUpPacketModMeterTest();
+
+  auto badMeter1 =
+      es2k_extern_manager_->FindPktModMeterByID(kBadPacketModMeterID);
+  EXPECT_FALSE(badMeter1.ok());
+
+  auto badMeter2 =
+      es2k_extern_manager_->FindPktModMeterByName(kBadPacketModMeterName);
+  EXPECT_FALSE(badMeter2.ok());
+}
+
+//----------------------------------------------------------------------
+// Miscellaneous tests
+//----------------------------------------------------------------------
+
+TEST_F(Es2kExternManagerTest, TestFindMeterWhenEmpty) {
+  auto directMeter1 =
+      es2k_extern_manager_->FindPktModMeterByID(kPacketModMeterID1);
+  EXPECT_FALSE(directMeter1.ok());
+
+  auto directMeter2 = es2k_extern_manager_->FindDirectPktModMeterByName(
+      kDirectPacketModMeterName2);
+  EXPECT_FALSE(directMeter2.ok());
+}
+
+TEST_F(Es2kExternManagerTest, TestParseBothExternMeterTypes) {
+  SetUpPacketModMeters();
+  SetUpDirectPacketModMeters();
+  SetUpPreambleCallback();
+  es2k_extern_manager_->RegisterExterns(p4info_, preamble_cb_);
+
+  EXPECT_EQ(es2k_extern_manager_->direct_pkt_mod_meter_size(), 2);
+  EXPECT_EQ(es2k_extern_manager_->pkt_mod_meter_map_size(), 2);
+}
+
+//----------------------------------------------------------------------
+// Error tests
+//----------------------------------------------------------------------
+
+TEST_F(Es2kExternManagerTest, TestUnknownExternType) {
+  auto p4extern = p4info_.add_externs();
+  p4extern->set_extern_type_id(0);
+  es2k_extern_manager_->RegisterExterns(p4info_, preamble_cb_);
+
+  auto stats = es2k_extern_manager_->statistics();
+  EXPECT_EQ(stats.unknown_extern_id, 1);
+}
+
+constexpr char kZeroPreambleIdText[] = R"pb(
+  extern_type_id: 134
+  extern_type_name: "DirectPacketModMeter"
+  instances {
+    preamble {
+      id: 0
+      name: "my_control.meter3"
+      alias: "meter3"
+    }
+  }
+)pb";
+
+}  // namespace tdi
+}  // namespace hal
+}  // namespace stratum

--- a/stratum/hal/lib/tdi/es2k/es2k_target_factory.h
+++ b/stratum/hal/lib/tdi/es2k/es2k_target_factory.h
@@ -1,0 +1,32 @@
+// Copyright 2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef STRATUM_HAL_LIB_TDI_ES2K_ES2K_TARGET_FACTORY_H_
+#define STRATUM_HAL_LIB_TDI_ES2K_ES2K_TARGET_FACTORY_H_
+
+#include <memory>
+#include <utility>
+
+#include "stratum/hal/lib/tdi/es2k/es2k_extern_manager.h"
+#include "stratum/hal/lib/tdi/tdi_target_factory.h"
+
+namespace stratum {
+namespace hal {
+namespace tdi {
+
+class Es2kTargetFactory : public TdiTargetFactory {
+ public:
+  Es2kTargetFactory() {}
+  virtual ~Es2kTargetFactory() = default;
+
+  std::unique_ptr<TdiExternManager> CreateTdiExternManager() override {
+    auto es2kPtr = Es2kExternManager::CreateInstance();
+    return std::unique_ptr<TdiExternManager>(std::move(es2kPtr));
+  }
+};
+
+}  // namespace tdi
+}  // namespace hal
+}  // namespace stratum
+
+#endif  // STRATUM_HAL_LIB_TDI_ES2K_ES2K_TARGET_FACTORY_H_

--- a/stratum/hal/lib/tdi/tdi_extern_manager.cc
+++ b/stratum/hal/lib/tdi/tdi_extern_manager.cc
@@ -1,0 +1,39 @@
+// Copyright 2023-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#include "stratum/hal/lib/tdi/tdi_extern_manager.h"
+
+#include "stratum/glue/status/status_macros.h"
+
+namespace stratum {
+namespace hal {
+namespace tdi {
+
+constexpr char kNotSupported[] = " not supported for this target.";
+
+// Retrieve a PacketModMeter configuration.
+::util::StatusOr<const ::idpf::PacketModMeter>
+TdiExternManager::FindPktModMeterByID(uint32 meter_id) const {
+  return MAKE_ERROR(ERR_UNIMPLEMENTED) << __func__ << kNotSupported;
+}
+
+::util::StatusOr<const ::idpf::PacketModMeter>
+TdiExternManager::FindPktModMeterByName(const std::string& meter_name) const {
+  return MAKE_ERROR(ERR_UNIMPLEMENTED) << __func__ << kNotSupported;
+}
+
+// Retrieve a DirectPacketModMeter configuration.
+::util::StatusOr<const ::idpf::DirectPacketModMeter>
+TdiExternManager::FindDirectPktModMeterByID(uint32 meter_id) const {
+  return MAKE_ERROR(ERR_UNIMPLEMENTED) << __func__ << kNotSupported;
+}
+
+::util::StatusOr<const ::idpf::DirectPacketModMeter>
+TdiExternManager::FindDirectPktModMeterByName(
+    const std::string& meter_name) const {
+  return MAKE_ERROR(ERR_UNIMPLEMENTED) << __func__ << kNotSupported;
+}
+
+}  // namespace tdi
+}  // namespace hal
+}  // namespace stratum

--- a/stratum/hal/lib/tdi/tdi_extern_manager.h
+++ b/stratum/hal/lib/tdi/tdi_extern_manager.h
@@ -1,0 +1,53 @@
+// Copyright 2023-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef STRATUM_HAL_LIB_TDI_TDI_EXTERN_MANAGER_H_
+#define STRATUM_HAL_LIB_TDI_TDI_EXTERN_MANAGER_H_
+
+#include "absl/memory/memory.h"
+#include "idpf/p4info.pb.h"
+#include "p4/config/v1/p4info.pb.h"
+#include "stratum/glue/integral_types.h"
+#include "stratum/glue/status/statusor.h"
+#include "stratum/hal/lib/p4/p4_extern_manager.h"
+#include "stratum/hal/lib/p4/p4_info_manager.h"
+#include "stratum/hal/lib/p4/p4_resource_map.h"
+
+namespace stratum {
+namespace hal {
+namespace tdi {
+
+class TdiExternManager : public P4ExternManager {
+ public:
+  TdiExternManager() {}
+  virtual ~TdiExternManager() = default;
+
+  // Called by TdiTargetFactory.
+  static std::unique_ptr<TdiExternManager> CreateInstance() {
+    return absl::make_unique<TdiExternManager>();
+  }
+
+  // Registers P4Extern resources. Called by P4InfoManager.
+  void RegisterExterns(const ::p4::config::v1::P4Info& p4info,
+                       const PreambleCallback& preamble_cb) override {}
+
+  // Retrieve a PacketModMeter configuration.
+  virtual ::util::StatusOr<const ::idpf::PacketModMeter> FindPktModMeterByID(
+      uint32 meter_id) const;
+
+  virtual ::util::StatusOr<const ::idpf::PacketModMeter> FindPktModMeterByName(
+      const std::string& meter_name) const;
+
+  // Retrieve a DirectPacketModMeter configuration.
+  virtual ::util::StatusOr<const ::idpf::DirectPacketModMeter>
+  FindDirectPktModMeterByID(uint32 meter_id) const;
+
+  virtual ::util::StatusOr<const ::idpf::DirectPacketModMeter>
+  FindDirectPktModMeterByName(const std::string& meter_name) const;
+};
+
+}  // namespace tdi
+}  // namespace hal
+}  // namespace stratum
+
+#endif  // STRATUM_HAL_LIB_TDI_TDI_EXTERN_MANAGER_H_

--- a/stratum/hal/lib/tdi/tdi_table_manager.cc
+++ b/stratum/hal/lib/tdi/tdi_table_manager.cc
@@ -13,11 +13,12 @@
 #include "absl/strings/match.h"
 #include "absl/synchronization/notification.h"
 #include "gflags/gflags.h"
-#include "idpf/p4info.pb.h"
 #include "p4/config/v1/p4info.pb.h"
 #include "stratum/glue/status/status_macros.h"
+#include "stratum/hal/lib/p4/p4_info_manager.h"
 #include "stratum/hal/lib/p4/utils.h"
 #include "stratum/hal/lib/tdi/tdi_constants.h"
+#include "stratum/hal/lib/tdi/tdi_extern_manager.h"
 #include "stratum/hal/lib/tdi/tdi_get_meter_units.h"
 #include "stratum/hal/lib/tdi/tdi_pkt_mod_meter_config.h"
 #include "stratum/hal/lib/tdi/utils.h"
@@ -49,27 +50,38 @@ namespace hal {
 namespace tdi {
 
 TdiTableManager::TdiTableManager(OperationMode mode,
-                                 TdiSdeInterface* tdi_sde_interface, int device)
+                                 TdiSdeInterface* tdi_sde_interface,
+                                 TdiTargetFactory& tdi_target_factory,
+                                 int device)
     : mode_(mode),
       tdi_sde_interface_(ABSL_DIE_IF_NULL(tdi_sde_interface)),
       p4_info_manager_(nullptr),
+      tdi_target_factory_(tdi_target_factory),
+      tdi_extern_manager_(nullptr),
       device_(device) {}
 
 std::unique_ptr<TdiTableManager> TdiTableManager::CreateInstance(
-    OperationMode mode, TdiSdeInterface* tdi_sde_interface, int device) {
-  return absl::WrapUnique(new TdiTableManager(mode, tdi_sde_interface, device));
+    OperationMode mode, TdiSdeInterface* tdi_sde_interface,
+    TdiTargetFactory& tdi_target_factory, int device) {
+  return absl::WrapUnique(
+      new TdiTableManager(mode, tdi_sde_interface, tdi_target_factory, device));
 }
 
 ::util::Status TdiTableManager::PushForwardingPipelineConfig(
     const TdiDeviceConfig& config) {
   absl::WriterMutexLock l(&lock_);
   RET_CHECK(config.programs_size() == 1) << "Only one P4 program is supported.";
+
   const auto& program = config.programs(0);
   const auto& p4_info = program.p4info();
   std::unique_ptr<P4InfoManager> p4_info_manager =
       absl::make_unique<P4InfoManager>(p4_info);
-  RETURN_IF_ERROR(p4_info_manager->InitializeAndVerify());
+
+  auto extern_manager = tdi_target_factory_.CreateTdiExternManager();
+  RETURN_IF_ERROR(p4_info_manager->InitializeAndVerify(extern_manager.get()));
+
   p4_info_manager_ = std::move(p4_info_manager);
+  tdi_extern_manager_ = std::move(extern_manager);
 
   return ::util::OkStatus();
 }
@@ -250,7 +262,8 @@ std::unique_ptr<TdiTableManager> TdiTableManager::CreateInstance(
         table_entry.has_meter_config()) {
       bool units_in_packets;  // or bytes
       ASSIGN_OR_RETURN(
-          auto meter, p4_info_manager_->FindDirectPktModMeterByID(resource_id));
+          auto meter,
+          tdi_extern_manager_->FindDirectPktModMeterByID(resource_id));
       RETURN_IF_ERROR(GetMeterUnitsInPackets(meter, units_in_packets));
 
       TdiPktModMeterConfig config;
@@ -1011,8 +1024,8 @@ TdiTableManager::ReadDirectMeterEntry(
     {
       absl::ReaderMutexLock l(&lock_);
       ::idpf::PacketModMeter meter;
-      ASSIGN_OR_RETURN(
-          meter, p4_info_manager_->FindPktModMeterByID(meter_entry.meter_id()));
+      ASSIGN_OR_RETURN(meter, tdi_extern_manager_->FindPktModMeterByID(
+                                  meter_entry.meter_id()));
       RETURN_IF_ERROR(GetMeterUnitsInPackets(meter, units_in_packets));
     }
 
@@ -1091,8 +1104,8 @@ TdiTableManager::ReadDirectMeterEntry(
     {
       absl::ReaderMutexLock l(&lock_);
       ::idpf::PacketModMeter meter;
-      ASSIGN_OR_RETURN(
-          meter, p4_info_manager_->FindPktModMeterByID(meter_entry.meter_id()));
+      ASSIGN_OR_RETURN(meter, tdi_extern_manager_->FindPktModMeterByID(
+                                  meter_entry.meter_id()));
       RETURN_IF_ERROR(GetMeterUnitsInPackets(meter, units_in_packets));
     }
 

--- a/stratum/hal/lib/tdi/tdi_table_manager.h
+++ b/stratum/hal/lib/tdi/tdi_table_manager.h
@@ -20,6 +20,7 @@
 #include "stratum/hal/lib/p4/p4_info_manager.h"
 #include "stratum/hal/lib/tdi/tdi.pb.h"
 #include "stratum/hal/lib/tdi/tdi_sde_interface.h"
+#include "stratum/hal/lib/tdi/tdi_target_factory.h"
 
 namespace stratum {
 namespace hal {
@@ -101,13 +102,15 @@ class TdiTableManager {
 
   // Creates a table manager instance.
   static std::unique_ptr<TdiTableManager> CreateInstance(
-      OperationMode mode, TdiSdeInterface* tdi_sde_interface, int device);
+      OperationMode mode, TdiSdeInterface* tdi_sde_interface,
+      TdiTargetFactory& tdi_target_factory, int device);
 
  private:
   // Private constructor, we can create the instance by using `CreateInstance`
   // function only.
   explicit TdiTableManager(OperationMode mode,
-                           TdiSdeInterface* tdi_sde_interface, int device);
+                           TdiSdeInterface* tdi_sde_interface,
+                           TdiTargetFactory& tdi_target_factory, int device);
 
   ::util::Status BuildTableKey(const ::p4::v1::TableEntry& table_entry,
                                TdiSdeInterface::TableKeyInterface* table_key)
@@ -169,6 +172,12 @@ class TdiTableManager {
   // TODO(max): Maybe this manager should be created in the node and passed down
   // to all feature managers.
   std::unique_ptr<P4InfoManager> p4_info_manager_ GUARDED_BY(lock_);
+
+  // Factory to create polymorphic objects for the TDI target.
+  TdiTargetFactory& tdi_target_factory_;
+
+  // Helper class to manage P4 Externs.
+  std::unique_ptr<TdiExternManager> tdi_extern_manager_ GUARDED_BY(lock_);
 
   // Fixed zero-based Tofino device number corresponding to the node/ASIC
   // managed by this class instance. Assigned in the class constructor.

--- a/stratum/hal/lib/tdi/tdi_table_manager_test.cc
+++ b/stratum/hal/lib/tdi/tdi_table_manager_test.cc
@@ -43,7 +43,8 @@ class TdiTableManagerTest : public ::testing::Test {
   void SetUp() override {
     tdi_sde_wrapper_mock_ = absl::make_unique<NiceMock<TdiSdeMock>>();
     tdi_table_manager_ = TdiTableManager::CreateInstance(
-        OPERATION_MODE_STANDALONE, tdi_sde_wrapper_mock_.get(), kDevice1);
+        OPERATION_MODE_STANDALONE, tdi_sde_wrapper_mock_.get(),
+        tdi_target_factory_, kDevice1);
   }
 
   ::util::Status PushTestConfig() {
@@ -142,6 +143,7 @@ class TdiTableManagerTest : public ::testing::Test {
 
   static constexpr int kDevice1 = 0;
 
+  TdiTargetFactory tdi_target_factory_;
   std::unique_ptr<TdiSdeMock> tdi_sde_wrapper_mock_;
   std::unique_ptr<TdiTableManager> tdi_table_manager_;
 };

--- a/stratum/hal/lib/tdi/tdi_target_factory.h
+++ b/stratum/hal/lib/tdi/tdi_target_factory.h
@@ -1,0 +1,29 @@
+// Copyright 2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef STRATUM_HAL_LIB_TDI_TDI_TARGET_FACTORY_H_
+#define STRATUM_HAL_LIB_TDI_TDI_TARGET_FACTORY_H_
+
+#include <memory>
+
+#include "stratum/hal/lib/tdi/tdi_extern_manager.h"
+
+namespace stratum {
+namespace hal {
+namespace tdi {
+
+class TdiTargetFactory {
+ public:
+  TdiTargetFactory() {}
+  virtual ~TdiTargetFactory() = default;
+
+  virtual std::unique_ptr<TdiExternManager> CreateTdiExternManager() {
+    return TdiExternManager::CreateInstance();
+  }
+};
+
+}  // namespace tdi
+}  // namespace hal
+}  // namespace stratum
+
+#endif  // STRATUM_HAL_LIB_TDI_TDI_TARGET_FACTORY_H_


### PR DESCRIPTION
This PR addresses the issue of P4InfoManager containing ES2K-specific code and dependencies (https://github.com/ipdk-io/stratum-dev/issues/274).

It is a rollup of the following individual PRs, which have been partitioned for ease of review.

- https://github.com/ipdk-io/stratum-dev/pull/283
- https://github.com/ipdk-io/stratum-dev/pull/284
- https://github.com/ipdk-io/stratum-dev/pull/285
- https://github.com/ipdk-io/stratum-dev/pull/286

These changes were then integrated with `TdiTableManager` and `P4InfoManager`, and a couple of updates were made to `es2k_extern_manager_test`.