### PR TITLE
Update default key bits in conf file for cert generation

### DIFF
--- a/tools/tls/ca.conf
+++ b/tools/tls/ca.conf
@@ -1,7 +1,8 @@
 # Copyright 2020-present Open Networking Foundation
+# Copyright 2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 [ req ]
-default_bits           = 2048
+default_bits           = 4096
 distinguished_name     = stratum-ca
 prompt                 = no
 

--- a/tools/tls/generate-certs.sh
+++ b/tools/tls/generate-certs.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # Copyright 2020-present Open Networking Foundation
+# Copyright 2023 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 set -e
 THIS_DIR=$(dirname "${BASH_SOURCE[0]}")

--- a/tools/tls/grpc-client.conf
+++ b/tools/tls/grpc-client.conf
@@ -1,7 +1,8 @@
 # Copyright 2020-present Open Networking Foundation
+# Copyright 2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 [ req ]
-default_bits           = 2048
+default_bits           = 4096
 distinguished_name     = grpc-client
 prompt                 = no
 


### PR DESCRIPTION
Default key bits was using 2048. Updating this to 4096, which is the recommended value (the generates-certs already updates to use 4096, but this CL brings it in line with expectation)