### PR TITLE
Move HAL flag definitions to common file

### DIFF
--- a/stratum/hal/lib/tdi/BUILD
+++ b/stratum/hal/lib/tdi/BUILD
@@ -709,6 +709,17 @@ stratum_cc_library(
 )
 
 stratum_cc_library(
+    name = "tdi_hal_flags",
+    srcs = ["tdi_hal_flags.cc"],
+    hdrs = ["tdi_hal_flags.h"],
+    deps = [
+        "//stratum/lib:constants",
+        "@com_github_gflags_gflags//:gflags",
+        "@com_github_google_glog//:glog",
+    ],
+)
+
+stratum_cc_library(
     name = "tdi_pkt_mod_meter_config",
     srcs = ["tdi_pkt_mod_meter_config.cc"],
     hdrs = ["tdi_pkt_mod_meter_config.h"],

--- a/stratum/hal/lib/tdi/CMakeLists.txt
+++ b/stratum/hal/lib/tdi/CMakeLists.txt
@@ -18,6 +18,8 @@ add_library(stratum_tdi_common_o OBJECT
     tdi_get_meter_units.h
     tdi_global_vars.cc
     tdi_global_vars.h
+    tdi_hal_flags.cc
+    tdi_hal_flags.h
     tdi_id_mapper.cc
     tdi_id_mapper.h
     tdi_node.cc

--- a/stratum/hal/lib/tdi/dpdk/BUILD
+++ b/stratum/hal/lib/tdi/dpdk/BUILD
@@ -2,7 +2,7 @@
 
 # Copyright 2018 Google LLC
 # Copyright 2018-present Open Networking Foundation
-# Copyright 2022-2023 Intel Corporation
+# Copyright 2022-2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
 load(
@@ -235,6 +235,7 @@ stratum_cc_library(
         "//stratum/hal/lib/common:p4_service",
         "//stratum/hal/lib/common:switch_interface",
         "//stratum/hal/lib/common:target_options",
+        "//stratum/hal/lib/tdi:tdi_hal_flags",
         "//stratum/lib:constants",
         "//stratum/lib:macros",
         "//stratum/lib:utils",

--- a/stratum/hal/lib/tdi/dpdk/dpdk_hal.cc
+++ b/stratum/hal/lib/tdi/dpdk/dpdk_hal.cc
@@ -1,6 +1,6 @@
 // Copyright 2018 Google LLC
 // Copyright 2018-present Open Networking Foundation
-// Copyright 2022-2023 Intel Corporation
+// Copyright 2022-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 #include "stratum/hal/lib/tdi/dpdk/dpdk_hal.h"
@@ -19,34 +19,11 @@
 #include "gflags/gflags.h"
 #include "stratum/glue/logging.h"
 #include "stratum/hal/lib/common/target_options.h"
+#include "stratum/hal/lib/tdi/tdi_hal_flags.h"
 #include "stratum/lib/constants.h"
 #include "stratum/lib/macros.h"
 #include "stratum/lib/security/credentials_manager.h"
 #include "stratum/lib/utils.h"
-
-// TODO(unknown): Use FLAG_DEFINE for all flags.
-DEFINE_string(external_stratum_urls, stratum::kExternalStratumUrls,
-              "Comma-separated list of URLs for server to listen to for "
-              "external calls from SDN controller, etc.");
-DEFINE_string(local_stratum_url, stratum::kLocalStratumUrl,
-              "URL for listening to local calls from stratum stub.");
-
-DEFINE_bool(warmboot, false, "Determines whether HAL is in warmboot stage.");
-DEFINE_string(persistent_config_dir, "/etc/stratum/",
-              "The persistent dir where all the config files will be stored.");
-
-DEFINE_int32(grpc_keepalive_time_ms, 600000, "grpc keep alive time");
-DEFINE_int32(grpc_keepalive_timeout_ms, 20000,
-             "grpc keep alive timeout period");
-DEFINE_int32(grpc_keepalive_min_ping_interval, 10000,
-             "grpc keep alive minimum ping interval");
-DEFINE_int32(grpc_keepalive_permit, 1, "grpc keep alive permit");
-DEFINE_uint32(grpc_max_recv_msg_size, 256 * 1024 * 1024,
-              "grpc server max receive message size (0 = gRPC default).");
-DEFINE_uint32(grpc_max_send_msg_size, 0,
-              "grpc server max send message size (0 = gRPC default).");
-DEFINE_bool(grpc_open_insecure_mode, false,
-            "open grpc server ports in insecure mode for gNMI, gNOI, and P4RT");
 
 DECLARE_string(forwarding_pipeline_configs_file);
 

--- a/stratum/hal/lib/tdi/es2k/BUILD
+++ b/stratum/hal/lib/tdi/es2k/BUILD
@@ -31,6 +31,7 @@ stratum_cc_library(
         "//stratum/hal/lib/common:p4_service",
         "//stratum/hal/lib/common:switch_interface",
         "//stratum/hal/lib/common:target_options",
+        "//stratum/hal/lib/tdi:tdi_hal_flags",
         "//stratum/lib:constants",
         "//stratum/lib:macros",
         "//stratum/lib:utils",

--- a/stratum/hal/lib/tdi/es2k/es2k_hal.cc
+++ b/stratum/hal/lib/tdi/es2k/es2k_hal.cc
@@ -1,6 +1,6 @@
 // Copyright 2018 Google LLC
 // Copyright 2018-present Open Networking Foundation
-// Copyright 2022-2023 Intel Corporation
+// Copyright 2022-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 #include "stratum/hal/lib/tdi/es2k/es2k_hal.h"
@@ -19,34 +19,11 @@
 #include "gflags/gflags.h"
 #include "stratum/glue/logging.h"
 #include "stratum/hal/lib/common/target_options.h"
+#include "stratum/hal/lib/tdi/tdi_hal_flags.h"
 #include "stratum/lib/constants.h"
 #include "stratum/lib/macros.h"
 #include "stratum/lib/security/credentials_manager.h"
 #include "stratum/lib/utils.h"
-
-// TODO(unknown): Use FLAG_DEFINE for all flags.
-DEFINE_string(external_stratum_urls, stratum::kExternalStratumUrls,
-              "Comma-separated list of URLs for server to listen to for "
-              "external calls from SDN controller, etc.");
-DEFINE_string(local_stratum_url, stratum::kLocalStratumUrl,
-              "URL for listening to local calls from stratum stub.");
-
-DEFINE_bool(warmboot, false, "Determines whether HAL is in warmboot stage.");
-DEFINE_string(persistent_config_dir, "/etc/stratum/",
-              "The persistent dir where all the config files will be stored.");
-
-DEFINE_int32(grpc_keepalive_time_ms, 600000, "grpc keep alive time");
-DEFINE_int32(grpc_keepalive_timeout_ms, 20000,
-             "grpc keep alive timeout period");
-DEFINE_int32(grpc_keepalive_min_ping_interval, 10000,
-             "grpc keep alive minimum ping interval");
-DEFINE_int32(grpc_keepalive_permit, 1, "grpc keep alive permit");
-DEFINE_uint32(grpc_max_recv_msg_size, 256 * 1024 * 1024,
-              "grpc server max receive message size (0 = gRPC default).");
-DEFINE_uint32(grpc_max_send_msg_size, 0,
-              "grpc server max send message size (0 = gRPC default).");
-DEFINE_bool(grpc_open_insecure_mode, false,
-            "open grpc server ports in insecure mode for gNMI, gNOI, and P4RT");
 
 DECLARE_string(forwarding_pipeline_configs_file);
 

--- a/stratum/hal/lib/tdi/tdi_hal_flags.cc
+++ b/stratum/hal/lib/tdi/tdi_hal_flags.cc
@@ -1,0 +1,33 @@
+// Copyright 2018 Google LLC
+// Copyright 2018-present Open Networking Foundation
+// Copyright 2022-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+// Common HAL command-line flags.
+
+#include "gflags/gflags.h"
+#include "stratum/lib/constants.h"
+
+// TODO(unknown): Use FLAG_DEFINE for all flags.
+DEFINE_string(external_stratum_urls, stratum::kExternalStratumUrls,
+              "Comma-separated list of URLs for server to listen to, for "
+              "external calls from SDN controller, etc.");
+DEFINE_string(local_stratum_url, stratum::kLocalStratumUrl,
+              "URL for listening to local calls from stratum stub.");
+
+DEFINE_bool(warmboot, false, "Determines whether HAL is in warmboot stage.");
+DEFINE_string(persistent_config_dir, "/etc/stratum/",
+              "The persistent dir where all the config files will be stored.");
+
+DEFINE_int32(grpc_keepalive_time_ms, 600000, "grpc keep-alive time");
+DEFINE_int32(grpc_keepalive_timeout_ms, 20000,
+             "grpc keep-alive timeout period");
+DEFINE_int32(grpc_keepalive_min_ping_interval, 10000,
+             "grpc keep-alive minimum ping interval");
+DEFINE_int32(grpc_keepalive_permit, 1, "grpc keep-alive permit");
+DEFINE_uint32(grpc_max_recv_msg_size, 256 * 1024 * 1024,
+              "grpc server max receive message size (0 = gRPC default).");
+DEFINE_uint32(grpc_max_send_msg_size, 0,
+              "grpc server max send message size (0 = gRPC default).");
+DEFINE_bool(grpc_open_insecure_mode, false,
+            "Open grpc server ports in insecure mode for gNMI, gNOI, and P4RT");

--- a/stratum/hal/lib/tdi/tdi_hal_flags.h
+++ b/stratum/hal/lib/tdi/tdi_hal_flags.h
@@ -1,0 +1,36 @@
+// Copyright 2018 Google LLC
+// Copyright 2018-present Open Networking Foundation
+// Copyright 2022-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+// Common HAL command-line flags.
+
+#ifndef STRATUM_HAL_LIB_TDI_TDI_HAL_FLAGS_H_
+#define STRATUM_HAL_LIB_TDI_TDI_HAL_FLAGS_H_
+
+#include "stratum/glue/logging.h"
+
+// External URLs the server listens to.
+DECLARE_string(external_stratum_urls);
+
+// URL for local calls from the stratum stub.
+DECLARE_string(local_stratum_url);
+
+// Whether this is a warm boot.
+DECLARE_bool(warmboot);
+
+// Persistent directory in which config files are stored.
+DECLARE_string(persistent_config_dir);
+
+// gRPC parameters.
+DECLARE_int32(grpc_keepalive_time_ms);
+DECLARE_int32(grpc_keepalive_timeout_ms);
+DECLARE_int32(grpc_keepalive_min_ping_interval);
+DECLARE_int32(grpc_keepalive_permit);
+DECLARE_uint32(grpc_max_recv_msg_size);
+DECLARE_uint32(grpc_max_send_msg_size);
+
+// Whether to open gRPC server ports in insecure mode.
+DECLARE_bool(grpc_open_insecure_mode);
+
+#endif  // STRATUM_HAL_LIB_TDI_TDI_HAL_FLAGS_H_

--- a/stratum/hal/lib/tdi/tofino/BUILD
+++ b/stratum/hal/lib/tdi/tofino/BUILD
@@ -90,6 +90,7 @@ stratum_cc_library(
         "//stratum/hal/lib/common:error_buffer",
         "//stratum/hal/lib/common:p4_service",
         "//stratum/hal/lib/common:switch_interface",
+        "//stratum/hal/lib/tdi:tdi_hal_flags",
         "//stratum/lib:constants",
         "//stratum/lib:macros",
         "//stratum/lib:utils",

--- a/stratum/hal/lib/tdi/tofino/tofino_hal.cc
+++ b/stratum/hal/lib/tdi/tofino/tofino_hal.cc
@@ -1,6 +1,6 @@
 // Copyright 2018 Google LLC
 // Copyright 2018-present Open Networking Foundation
-// Copyright 2022 Intel Corporation
+// Copyright 2022-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
 #include "stratum/hal/lib/tdi/tofino/tofino_hal.h"
@@ -16,31 +16,10 @@
 #include "absl/synchronization/mutex.h"
 #include "gflags/gflags.h"
 #include "stratum/glue/logging.h"
+#include "stratum/hal/lib/tdi/tdi_hal_flags.h"
 #include "stratum/lib/constants.h"
 #include "stratum/lib/macros.h"
 #include "stratum/lib/utils.h"
-
-// TODO(unknown): Use FLAG_DEFINE for all flags.
-DEFINE_string(external_stratum_urls, stratum::kExternalStratumUrls,
-              "Comma-separated list of URLs for server to listen to for "
-              "external calls from SDN controller, etc.");
-DEFINE_string(local_stratum_url, stratum::kLocalStratumUrl,
-              "URL for listening to local calls from stratum stub.");
-
-DEFINE_bool(warmboot, false, "Determines whether HAL is in warmboot stage.");
-DEFINE_string(persistent_config_dir, "/etc/stratum/",
-              "The persistent dir where all the config files will be stored.");
-
-DEFINE_int32(grpc_keepalive_time_ms, 600000, "grpc keep alive time");
-DEFINE_int32(grpc_keepalive_timeout_ms, 20000,
-             "grpc keep alive timeout period");
-DEFINE_int32(grpc_keepalive_min_ping_interval, 10000,
-             "grpc keep alive minimum ping interval");
-DEFINE_int32(grpc_keepalive_permit, 1, "grpc keep alive permit");
-DEFINE_uint32(grpc_max_recv_msg_size, 256 * 1024 * 1024,
-              "grpc server max receive message size (0 = gRPC default).");
-DEFINE_uint32(grpc_max_send_msg_size, 0,
-              "grpc server max send message size (0 = gRPC default).");
 
 namespace stratum {
 namespace hal {


### PR DESCRIPTION
- Extracted the command-line flag definitions used by all three TDI HAL implementations and moved them to a common file.

Among other things, this will simplify the Infrap4d Flags Reference ([DPDK](https://ipdk.io/p4cp-userguide/executables/infrap4d/infrap4d-flags.html#flags-from-dpdk-hal), [ES2K](https://ipdk.io/p4cp-userguide/executables/infrap4d/infrap4d-flags.html#flags-from-es2k-hal)).