### PR TITLE
Implement DumpIDsToResourceTypes()

### DIFF
--- a/stratum/hal/lib/p4/p4_info_manager.cc
+++ b/stratum/hal/lib/p4/p4_info_manager.cc
@@ -340,6 +340,13 @@ void P4InfoManager::DumpNamesToIDs() const {
   digest_map_.DumpNamesToIDs();
 }
 
+void P4InfoManager::DumpIDsToResourceTypes() const {
+  for (auto iter : id_to_resource_type_map_) {
+    LOG(INFO) << "ID " << iter.first << ": " << PrintP4ObjectID(iter.first)
+              << " has resource_type " << iter.second;
+  }
+}
+
 ::util::Status P4InfoManager::VerifyRequiredObjects() {
   if (FLAGS_skip_p4_min_objects_check) return ::util::OkStatus();
 

--- a/stratum/hal/lib/p4/p4_info_manager.h
+++ b/stratum/hal/lib/p4/p4_info_manager.h
@@ -158,6 +158,10 @@ class P4InfoManager {
   // entities.
   virtual void DumpNamesToIDs() const;
 
+  // Outputs LOG messages with ID to resource_type translations for all
+  // p4_info_ entities.
+  virtual void DumpIDsToResourceTypes() const;
+
   // Accesses the P4Info - virtual for mock access.
   virtual const ::p4::config::v1::P4Info& p4_info() const { return p4_info_; }
 

--- a/stratum/hal/lib/p4/p4_info_manager_mock.h
+++ b/stratum/hal/lib/p4/p4_info_manager_mock.h
@@ -89,6 +89,7 @@ class P4InfoManagerMock : public P4InfoManager {
       ::util::StatusOr<P4Annotation>(const std::string& p4_object_name));
 
   MOCK_CONST_METHOD0(DumpNamesToIDs, void());
+  MOCK_CONST_METHOD0(DumpIDsToResourceTypes, void());
   MOCK_CONST_METHOD0(p4_info, const ::p4::config::v1::P4Info&());
   MOCK_METHOD0(VerifyRequiredObjects, ::util::Status());
 };


### PR DESCRIPTION
- Added a DumpIDsToResourceTypes() method to P4InfoManager, to complement the existing DumpNamesToIDs() method.