### PR TITLE
Fix bug found by WriteIndirectMeterEntryTest test case

### DIFF
--- a/stratum/hal/lib/tdi/tdi_table_manager.cc
+++ b/stratum/hal/lib/tdi/tdi_table_manager.cc
@@ -1077,11 +1077,11 @@ TdiTableManager::ReadDirectMeterEntry(
       << "Missing meter id in MeterEntry " << meter_entry.ShortDebugString()
       << ".";
 
-  ASSIGN_OR_RETURN(uint32 meter_id,
+  ASSIGN_OR_RETURN(uint32 meter_rt_id,
                    tdi_sde_interface_->GetTdiRtId(meter_entry.meter_id()));
 
-  ASSIGN_OR_RETURN(auto resource_type,
-                   p4_info_manager_->FindResourceTypeByID(meter_id));
+  ASSIGN_OR_RETURN(auto resource_type, p4_info_manager_->FindResourceTypeByID(
+                                           meter_entry.meter_id()));
 
   if (resource_type == "Meter" && meter_entry.has_config()) {
     bool units_in_packets;  // or bytes
@@ -1100,7 +1100,7 @@ TdiTableManager::ReadDirectMeterEntry(
     }
 
     RETURN_IF_ERROR(tdi_sde_interface_->WriteIndirectMeter(
-        device_, session, meter_id, meter_index, units_in_packets,
+        device_, session, meter_rt_id, meter_index, units_in_packets,
         meter_entry.config().cir(), meter_entry.config().cburst(),
         meter_entry.config().pir(), meter_entry.config().pburst()));
   }
@@ -1129,12 +1129,12 @@ TdiTableManager::ReadDirectMeterEntry(
       config.isPktModMeter = units_in_packets;
 
       RETURN_IF_ERROR(tdi_sde_interface_->WritePktModMeter(
-          device_, session, meter_id, meter_index, config));
+          device_, session, meter_rt_id, meter_index, config));
     }
 
     if (type == ::p4::v1::Update::DELETE) {
       RETURN_IF_ERROR(tdi_sde_interface_->DeletePktModMeterConfig(
-          device_, session, meter_id, meter_index));
+          device_, session, meter_rt_id, meter_index));
     }
   }
 

--- a/stratum/hal/lib/tdi/tdi_table_manager_test.cc
+++ b/stratum/hal/lib/tdi/tdi_table_manager_test.cc
@@ -264,7 +264,6 @@ TEST_F(TdiTableManagerTest, WriteDirectMeterEntryTest) {
       session_mock, ::p4::v1::Update::MODIFY, entry));
 }
 
-// See https://github.com/ipdk-io/stratum-dev/issues/306.
 TEST_F(TdiTableManagerTest, WriteIndirectMeterEntryTest) {
   ASSERT_OK(PushTestConfig());
   constexpr int kP4MeterId = 55555;

--- a/stratum/hal/lib/tdi/tdi_table_manager_test.cc
+++ b/stratum/hal/lib/tdi/tdi_table_manager_test.cc
@@ -265,7 +265,7 @@ TEST_F(TdiTableManagerTest, WriteDirectMeterEntryTest) {
 }
 
 // See https://github.com/ipdk-io/stratum-dev/issues/306.
-TEST_F(TdiTableManagerTest, DISABLED_WriteIndirectMeterEntryTest) {
+TEST_F(TdiTableManagerTest, WriteIndirectMeterEntryTest) {
   ASSERT_OK(PushTestConfig());
   constexpr int kP4MeterId = 55555;
   constexpr int kTdiRtTableId = 11111;

--- a/stratum/hal/lib/tdi/tdi_table_manager_test.cc
+++ b/stratum/hal/lib/tdi/tdi_table_manager_test.cc
@@ -324,7 +324,7 @@ TEST_F(TdiTableManagerTest, RejectMeterEntryModifyWithoutMeterId) {
   EXPECT_THAT(ret.error_message(), HasSubstr("Missing meter id"));
 }
 
-// See https://github.com/ipdk-io/stratum-dev/issues/306.
+// See https://github.com/ipdk-io/stratum-dev/issues/314.
 TEST_F(TdiTableManagerTest, DISABLED_RejectMeterEntryInsertDelete) {
   ASSERT_OK(PushTestConfig());
   auto session_mock = std::make_shared<SessionMock>();
@@ -357,7 +357,7 @@ TEST_F(TdiTableManagerTest, DISABLED_RejectMeterEntryInsertDelete) {
   EXPECT_EQ(ERR_INVALID_PARAM, ret.error_code());
 }
 
-// See https://github.com/ipdk-io/stratum-dev/issues/306.
+// See https://github.com/ipdk-io/stratum-dev/issues/315.
 TEST_F(TdiTableManagerTest, DISABLED_ReadSingleIndirectMeterEntryTest) {
   ASSERT_OK(PushTestConfig());
   auto session_mock = std::make_shared<SessionMock>();


### PR DESCRIPTION
- The `WriteIndirectMeterEntryTest` test case failed because `WriteMeterEntry()` was calling `FindResourceTypeByID()` with the ID returned by `GetTdiRtId()`, not a P4 resource ID. Changed it to look up `meter_entry.meter_id()` instead.

- Also renamed the variable to which the value returned by `GetTdiRtId()` is assigned, from `meter_id` to `meter_rt_id`, in hopes of reducing confusion in the future.

- Reenabled the test case.

See issue https://github.com/ipdk-io/stratum-dev/issues/306 for a description of the problem.