### PR TITLE
Fix coding error in ReadMeterEntry()

### DIFF
--- a/stratum/hal/lib/tdi/tdi_table_manager.cc
+++ b/stratum/hal/lib/tdi/tdi_table_manager.cc
@@ -977,8 +977,8 @@ TdiTableManager::ReadDirectMeterEntry(
   ASSIGN_OR_RETURN(uint32 table_id,
                    tdi_sde_interface_->GetTdiRtId(meter_entry.meter_id()));
 
-  ASSIGN_OR_RETURN(auto resource_type,
-                   p4_info_manager_->FindResourceTypeByID(table_id));
+  ASSIGN_OR_RETURN(auto resource_type, p4_info_manager_->FindResourceTypeByID(
+                                           meter_entry.meter_id()));
 
   if (resource_type == "Meter") {
     {

--- a/stratum/hal/lib/tdi/tdi_table_manager_test.cc
+++ b/stratum/hal/lib/tdi/tdi_table_manager_test.cc
@@ -358,8 +358,7 @@ TEST_F(TdiTableManagerTest, DISABLED_RejectMeterEntryInsertDelete) {
   EXPECT_EQ(ERR_INVALID_PARAM, ret.error_code());
 }
 
-// See https://github.com/ipdk-io/stratum-dev/issues/306.
-TEST_F(TdiTableManagerTest, DISABLED_ReadSingleIndirectMeterEntryTest) {
+TEST_F(TdiTableManagerTest, ReadSingleIndirectMeterEntryTest) {
   ASSERT_OK(PushTestConfig());
   auto session_mock = std::make_shared<SessionMock>();
   constexpr int kP4MeterId = 55555;


### PR DESCRIPTION
- The ReadSingleIndirectMeterEntryTest test case failed because ReadMeterEntry() was calling FindResourceTypeByID() with the table_id instead of meter_entry.meter_id(). Corrected this, and the test case passes.

- Reenabled the ReadSingleIndirectMeterEntryTest test case.

This PR addresses issue https://github.com/ipdk-io/stratum-dev/issues/315.