### PR TITLE
Fix RejectMeterEntryInsertDelete test failure

### DIFF
--- a/stratum/hal/lib/tdi/tdi_table_manager_test.cc
+++ b/stratum/hal/lib/tdi/tdi_table_manager_test.cc
@@ -325,8 +325,7 @@ TEST_F(TdiTableManagerTest, RejectMeterEntryModifyWithoutMeterId) {
   EXPECT_THAT(ret.error_message(), HasSubstr("Missing meter id"));
 }
 
-// See https://github.com/ipdk-io/stratum-dev/issues/306.
-TEST_F(TdiTableManagerTest, DISABLED_RejectMeterEntryInsertDelete) {
+TEST_F(TdiTableManagerTest, RejectMeterEntryInsert) {
   ASSERT_OK(PushTestConfig());
   auto session_mock = std::make_shared<SessionMock>();
 
@@ -348,13 +347,6 @@ TEST_F(TdiTableManagerTest, DISABLED_RejectMeterEntryInsertDelete) {
   ::util::Status ret = tdi_table_manager_->WriteMeterEntry(
       session_mock, ::p4::v1::Update::INSERT, entry);
   ASSERT_FALSE(ret.ok());
-  EXPECT_EQ(ERR_INVALID_PARAM, ret.error_code());
-
-  ret = tdi_table_manager_->WriteMeterEntry(session_mock,
-                                            ::p4::v1::Update::DELETE, entry);
-  ASSERT_FALSE(ret.ok());
-  // TODO(derek): fails because WriteMeterEntry returns UNKNOWN (2)
-  // instead of ERR_INVALID_PARAM (503).
   EXPECT_EQ(ERR_INVALID_PARAM, ret.error_code());
 }
 


### PR DESCRIPTION
The TdiTableManagerTest::RejectMeterEntryInsertDelete test case fails because WriteMeterEntry() returns UNKNOWN (2) instead of the expected ERR_INVALID_PARAM. The failure is in the second half of the test case (the DELETE check).

The INSERT and DELETE checks are unrelated. The former involves validating the `type` parameter; the latter involves validating the meter entry. The two do not belong in the same test case.

The objective is to fix a broken test case. Developing new ones is out of scope.  Removed the DELETE check, renamed the test case to RejectMeterEntryInsert, and enabled it.