### PR TITLE
Pin workflow scripts to Ubuntu 22.04

### DIFF
--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -20,7 +20,7 @@ jobs:
   # clang-format-check
   #---------------------------------------------------------------------
   clang-format-check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Check out stratum repository

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -33,7 +33,7 @@ jobs:
   # dpdk_build_and_test
   #---------------------------------------------------------------------
   dpdk_build_and_test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Clone stratum repository
@@ -73,7 +73,7 @@ jobs:
   # bcm_unit_tests
   #---------------------------------------------------------------------
   bcm_unit_tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Clone stratum repository
@@ -99,7 +99,7 @@ jobs:
   # cdlang_tests (gNMI)
   #---------------------------------------------------------------------
   cdlang_tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Clone stratum repository


### PR DESCRIPTION
- Changed `ubuntu-latest` to `ubuntu-22.04` in the pipeline, in preparation for GitHub bumping ubuntu-latest to 24.04.