### PR TITLE
Vport unit tests

### DIFF
--- a/stratum/hal/lib/tdi/BUILD
+++ b/stratum/hal/lib/tdi/BUILD
@@ -447,6 +447,16 @@ stratum_cc_library(
     ],
 )
 
+stratum_cc_library(
+    name = "tdi_fixed_function_manager_mock",
+    testonly = True,
+    hdrs = ["tdi_fixed_function_manager_mock.h"],
+    deps = [
+        ":tdi_fixed_function_manager",
+        "@com_google_googletest//:gtest",
+    ],
+)
+
 stratum_cc_test(
     name = "tdi_fixed_function_manager_test",
     srcs = ["tdi_fixed_function_manager_test.cc"],

--- a/stratum/hal/lib/tdi/es2k/BUILD
+++ b/stratum/hal/lib/tdi/es2k/BUILD
@@ -137,6 +137,26 @@ stratum_cc_library(
 )
 
 stratum_cc_library(
+    name = "es2k_virtual_port_manager",
+    srcs = ["es2k_virtual_port_manager.cc"],
+    hdrs = ["es2k_virtual_port_manager.h"],
+    deps = [
+        "//stratum/glue:integral_types",
+        "//stratum/glue:logging",
+        "//stratum/glue/status",
+        "//stratum/glue/status:statusor",
+        "//stratum/hal/lib/common:common_cc_proto",
+        "//stratum/hal/lib/tdi:tdi_fixed_function_manager",
+        "//stratum/hal/lib/tdi:tdi_sde_common",
+        "//stratum/hal/lib/tdi:tdi_status",
+        "//stratum/lib/channel",
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/memory",
+        "@com_google_absl//absl/synchronization",
+    ],
+)
+
+stratum_cc_library(
     name = "es2k_port_manager_dummy",
     testonly = True,
     srcs = ["es2k_port_manager_dummy.cc"],

--- a/stratum/hal/lib/tdi/es2k/es2k_virtual_port_manager.cc
+++ b/stratum/hal/lib/tdi/es2k/es2k_virtual_port_manager.cc
@@ -30,11 +30,6 @@
 #include "stratum/hal/lib/tdi/tdi_status.h"
 #include "stratum/lib/channel/channel.h"
 
-extern "C" {
-#include "ipu_pal/port_intf.h"
-#include "ipu_types/ipu_types.h"
-}
-
 #define VPORT_STATE_TABLE_NAME \
   "openconfig-virtual-ports.virtual-ports.virtual-port.state"
 

--- a/stratum/hal/lib/tdi/tdi_fixed_function_manager_mock.h
+++ b/stratum/hal/lib/tdi/tdi_fixed_function_manager_mock.h
@@ -1,0 +1,56 @@
+// Copyright (c) 2025 Intel Corporation.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef STRATUM_HAL_LIB_TDI_TDI_FIXED_FUNCTION_MANAGER_MOCK_H_
+#define STRATUM_HAL_LIB_TDI_TDI_FIXED_FUNCTION_MANAGER_MOCK_H_
+
+#include "gmock/gmock.h"
+#include "stratum/hal/lib/tdi/tdi_fixed_function_manager.h"
+
+namespace stratum {
+namespace hal {
+namespace tdi {
+
+class TdiFixedFunctionManagerMock : public TdiFixedFunctionManager {
+ public:
+  MOCK_METHOD(::util::Status, InitNotificationTableWithCallback,
+              (std::string table_name,
+               void (*ipsec_notif_cb)(uint32_t, uint32_t, bool, uint8_t, char*,
+                                      bool, void*),
+               void* cookie),
+              (override));
+
+  MOCK_METHOD(::util::Status, WriteSadbEntry,
+              (std::shared_ptr<TdiSdeInterface::SessionInterface> session,
+               std::string table_name, const IPsecSadbConfigOp op_type,
+               IPsecSADBConfig& sadb_config),
+              (override));
+
+  MOCK_METHOD(::util::Status, FetchSpi,
+              (std::shared_ptr<TdiSdeInterface::SessionInterface> session,
+               std::string table_name, uint32* spi),
+              (override));
+
+  MOCK_METHOD(::util::Status, FetchVportTableData,
+              (std::shared_ptr<TdiSdeInterface::SessionInterface> session,
+               std::string table_name, uint32 global_resource_id,
+               const char* param_name, uint64* data),
+              (override));
+
+  static std::unique_ptr<TdiFixedFunctionManagerMock> CreateInstance(
+      OperationMode mode, TdiSdeInterface* tdi_sde_interface, int device) {
+    return absl::WrapUnique(
+        new TdiFixedFunctionManagerMock(mode, tdi_sde_interface, device));
+  }
+
+ protected:
+  TdiFixedFunctionManagerMock(OperationMode mode,
+                              TdiSdeInterface* tdi_sde_interface, int device)
+      : TdiFixedFunctionManager(mode, tdi_sde_interface, device) {}
+};
+
+}  // namespace tdi
+}  // namespace hal
+}  // namespace stratum
+
+#endif  // STRATUM_HAL_LIB_TDI_TDI_FIXED_FUNCTION_MANAGER_MOCK_H_

--- a/stratum/hal/lib/tdi/tdi_fixed_function_manager_test.cc
+++ b/stratum/hal/lib/tdi/tdi_fixed_function_manager_test.cc
@@ -398,14 +398,16 @@ TEST_F(TdiFixedFunctionManagerTest, FetchVportTableDataTest) {
       .WillOnce(Return(kTdiRtTableId));
 
   EXPECT_CALL(*sde_wrapper_mock_, CreateTableKey(kTdiRtTableId))
-      .WillOnce(Return(ByMove(::util::StatusOr<std::unique_ptr<TableKeyInterface>>(
-          std::move(table_key_mock)))));
+      .WillOnce(
+          Return(ByMove(::util::StatusOr<std::unique_ptr<TableKeyInterface>>(
+              std::move(table_key_mock)))));
 
   EXPECT_CALL(*sde_wrapper_mock_, CreateTableData(kTdiRtTableId, 0))
-      .WillOnce(Return(ByMove(::util::StatusOr<std::unique_ptr<TableDataInterface>>(
-          std::move(table_data_mock)))));
+      .WillOnce(
+          Return(ByMove(::util::StatusOr<std::unique_ptr<TableDataInterface>>(
+              std::move(table_data_mock)))));
 
-  EXPECT_CALL(*sde_wrapper_mock_, 
+  EXPECT_CALL(*sde_wrapper_mock_,
               GetTableEntry(kDevice1, _, kTdiRtTableId, _, _))
       .WillOnce(Return(::util::OkStatus()));
 
@@ -438,26 +440,25 @@ TEST_F(TdiFixedFunctionManagerTest, FetchVportTableDataTestFailure) {
       .WillOnce(Return(kTdiRtTableId));
 
   EXPECT_CALL(*sde_wrapper_mock_, CreateTableKey(kTdiRtTableId))
-      .WillOnce(Return(ByMove(::util::StatusOr<std::unique_ptr<TableKeyInterface>>(
-          std::move(table_key_mock)))));
+      .WillOnce(
+          Return(ByMove(::util::StatusOr<std::unique_ptr<TableKeyInterface>>(
+              std::move(table_key_mock)))));
 
   EXPECT_CALL(*sde_wrapper_mock_, CreateTableData(kTdiRtTableId, 0))
-      .WillOnce(Return(ByMove(::util::StatusOr<std::unique_ptr<TableDataInterface>>(
-          std::move(table_data_mock)))));
+      .WillOnce(
+          Return(ByMove(::util::StatusOr<std::unique_ptr<TableDataInterface>>(
+              std::move(table_data_mock)))));
 
-  EXPECT_CALL(*sde_wrapper_mock_, 
+  EXPECT_CALL(*sde_wrapper_mock_,
               GetTableEntry(kDevice1, _, kTdiRtTableId, _, _))
       .WillOnce(Return(::util::OkStatus()));
 
   // Execute test
-  EXPECT_THAT(
-      fixed_function_manager_->FetchVportTableData(
-          session_mock, table_name, glort_id, kVsi, &fetched_data),
-      DerivedFromStatus(DefaultError()));
+  EXPECT_THAT(fixed_function_manager_->FetchVportTableData(
+                  session_mock, table_name, glort_id, kVsi, &fetched_data),
+              DerivedFromStatus(DefaultError()));
   EXPECT_EQ(fetched_data, 0);
 }
-
-
 
 }  // namespace tdi
 }  // namespace hal

--- a/stratum/hal/lib/tdi/tdi_fixed_function_manager_test.cc
+++ b/stratum/hal/lib/tdi/tdi_fixed_function_manager_test.cc
@@ -46,6 +46,8 @@ constexpr char ipsecConfigSadbTableName[] =
     "ipsec-offload.ipsec-offload.sad.sad-entry.ipsec-sa-config";
 constexpr char ipsecFetchSpiTableName[] =
     "ipsec-offload.ipsec-offload.ipsec-spi";
+constexpr char vportStateTableName[] =
+    "openconfig-virtual-ports.virtual-ports.virtual-port.state";
 
 class TdiFixedFunctionManagerTest : public ::testing::Test {
  protected:
@@ -372,6 +374,91 @@ TEST_F(TdiFixedFunctionManagerTest, WriteSadbEntryTestFailure) {
                                                       op_type, sadb_config),
               DerivedFromStatus(DefaultError()));
 }
+
+/*
+ * Validates FetchVportTableData method.
+ */
+TEST_F(TdiFixedFunctionManagerTest, FetchVportTableDataTest) {
+  std::string table_name = vportStateTableName;
+  uint64 fetched_data;
+  uint32 glort_id = 5678;
+
+  auto session_mock = std::make_shared<SessionMock>();
+  auto table_key_mock = absl::make_unique<TableKeyMock>();
+  auto table_data_mock = absl::make_unique<TableDataMock>();
+
+  // Set expectations BEFORE moving mocks
+  EXPECT_CALL(*table_key_mock, SetExact(kGlobalResourceId, glort_id))
+      .WillOnce(Return(::util::OkStatus()));
+  EXPECT_CALL(*table_data_mock, GetParam(kVsi, _))
+      .WillOnce(DoAll(SetArgPointee<1>(12), Return(::util::OkStatus())));
+
+  // Configure SDE wrapper AFTER setting mock expectations
+  EXPECT_CALL(*sde_wrapper_mock_, GetTableId(table_name))
+      .WillOnce(Return(kTdiRtTableId));
+
+  EXPECT_CALL(*sde_wrapper_mock_, CreateTableKey(kTdiRtTableId))
+      .WillOnce(Return(ByMove(::util::StatusOr<std::unique_ptr<TableKeyInterface>>(
+          std::move(table_key_mock)))));
+
+  EXPECT_CALL(*sde_wrapper_mock_, CreateTableData(kTdiRtTableId, 0))
+      .WillOnce(Return(ByMove(::util::StatusOr<std::unique_ptr<TableDataInterface>>(
+          std::move(table_data_mock)))));
+
+  EXPECT_CALL(*sde_wrapper_mock_, 
+              GetTableEntry(kDevice1, _, kTdiRtTableId, _, _))
+      .WillOnce(Return(::util::OkStatus()));
+
+  // Execute test
+  EXPECT_OK(fixed_function_manager_->FetchVportTableData(
+      session_mock, table_name, glort_id, kVsi, &fetched_data));
+  EXPECT_EQ(fetched_data, 12);
+}
+
+/*
+ * Validates FetchVportTableData method error handling.
+ */
+TEST_F(TdiFixedFunctionManagerTest, FetchVportTableDataTestFailure) {
+  std::string table_name = vportStateTableName;
+  uint64 fetched_data = 0;
+  uint32 glort_id = 5678;
+
+  auto session_mock = std::make_shared<SessionMock>();
+  auto table_key_mock = absl::make_unique<TableKeyMock>();
+  auto table_data_mock = absl::make_unique<TableDataMock>();
+
+  // Set expectations BEFORE moving mocks
+  EXPECT_CALL(*table_key_mock, SetExact(kGlobalResourceId, glort_id))
+      .WillOnce(Return(::util::OkStatus()));
+  EXPECT_CALL(*table_data_mock, GetParam(kVsi, _))
+      .WillOnce(Return(DefaultError()));
+
+  // Configure SDE wrapper AFTER setting mock expectations
+  EXPECT_CALL(*sde_wrapper_mock_, GetTableId(table_name))
+      .WillOnce(Return(kTdiRtTableId));
+
+  EXPECT_CALL(*sde_wrapper_mock_, CreateTableKey(kTdiRtTableId))
+      .WillOnce(Return(ByMove(::util::StatusOr<std::unique_ptr<TableKeyInterface>>(
+          std::move(table_key_mock)))));
+
+  EXPECT_CALL(*sde_wrapper_mock_, CreateTableData(kTdiRtTableId, 0))
+      .WillOnce(Return(ByMove(::util::StatusOr<std::unique_ptr<TableDataInterface>>(
+          std::move(table_data_mock)))));
+
+  EXPECT_CALL(*sde_wrapper_mock_, 
+              GetTableEntry(kDevice1, _, kTdiRtTableId, _, _))
+      .WillOnce(Return(::util::OkStatus()));
+
+  // Execute test
+  EXPECT_THAT(
+      fixed_function_manager_->FetchVportTableData(
+          session_mock, table_name, glort_id, kVsi, &fetched_data),
+      DerivedFromStatus(DefaultError()));
+  EXPECT_EQ(fetched_data, 0);
+}
+
+
+
 }  // namespace tdi
 }  // namespace hal
 }  // namespace stratum

--- a/stratum/hal/lib/tdi/tdi_fixed_function_manager_test.cc
+++ b/stratum/hal/lib/tdi/tdi_fixed_function_manager_test.cc
@@ -382,6 +382,7 @@ TEST_F(TdiFixedFunctionManagerTest, FetchVportTableDataTest) {
   std::string table_name = vportStateTableName;
   uint64 fetched_data;
   uint32 glort_id = 5678;
+  uint32 expected_vsi_val = 12;
 
   auto session_mock = std::make_shared<SessionMock>();
   auto table_key_mock = absl::make_unique<TableKeyMock>();
@@ -391,7 +392,8 @@ TEST_F(TdiFixedFunctionManagerTest, FetchVportTableDataTest) {
   EXPECT_CALL(*table_key_mock, SetExact(kGlobalResourceId, glort_id))
       .WillOnce(Return(::util::OkStatus()));
   EXPECT_CALL(*table_data_mock, GetParam(kVsi, _))
-      .WillOnce(DoAll(SetArgPointee<1>(12), Return(::util::OkStatus())));
+      .WillOnce(DoAll(SetArgPointee<1>(expected_vsi_val),
+                      Return(::util::OkStatus())));
 
   // Configure SDE wrapper AFTER setting mock expectations
   EXPECT_CALL(*sde_wrapper_mock_, GetTableId(table_name))
@@ -414,7 +416,7 @@ TEST_F(TdiFixedFunctionManagerTest, FetchVportTableDataTest) {
   // Execute test
   EXPECT_OK(fixed_function_manager_->FetchVportTableData(
       session_mock, table_name, glort_id, kVsi, &fetched_data));
-  EXPECT_EQ(fetched_data, 12);
+  EXPECT_EQ(fetched_data, expected_vsi_val);
 }
 
 /*


### PR DESCRIPTION
This CL includes:

* Adding unit tests and mock classes for more future unit test support in virtual-ports
* Updates to bazel build system and some cleanup of unused code