### PR TITLE
Skip TDI ID mapper for DirectTSMeter extern type

### DIFF
--- a/stratum/hal/lib/tdi/tdi_id_mapper.cc
+++ b/stratum/hal/lib/tdi/tdi_id_mapper.cc
@@ -66,8 +66,8 @@ std::unique_ptr<TdiIdMapper> TdiIdMapper::CreateInstance() {
         continue;
       }
       if (p4extern.extern_type_id() == kTnaExternActionSelectorId) {
-        // DirectTSMeter (extern id 132) externs must be skipped because they
-        // are not present in tdi.json
+        // DirectTSMeter (extern id 132) externs must be skipped as
+        // it will not present in tdi.json
         continue;
       }
       for (const auto& extern_instance : p4extern.instances()) {

--- a/stratum/hal/lib/tdi/tdi_id_mapper.cc
+++ b/stratum/hal/lib/tdi/tdi_id_mapper.cc
@@ -65,6 +65,11 @@ std::unique_ptr<TdiIdMapper> TdiIdMapper::CreateInstance() {
           p4extern.extern_type_id() != kTnaExternActionSelectorId) {
         continue;
       }
+      if (p4extern.extern_type_id() == kTnaExternActionSelectorId) {
+        // DirectTSMeter (extern id 132) externs must be skipped because they
+        // are not present in tdi.json
+        continue;
+      }
       for (const auto& extern_instance : p4extern.instances()) {
         RETURN_IF_ERROR(BuildMapping(extern_instance.preamble().id(),
                                      extern_instance.preamble().name(),


### PR DESCRIPTION
The fxp_policer-meters set-pipe fails with the P4 change with new DirectTSMeter data type added. This is due to the attempted mapping (while the TDI.json does not contain such resource), which should be skipped in the DirectTSMeter case