### PR TITLE
Add init of DirectTSMeter

### DIFF
--- a/stratum/hal/lib/p4/p4_info_manager.cc
+++ b/stratum/hal/lib/p4/p4_info_manager.cc
@@ -40,6 +40,7 @@ P4InfoManager::P4InfoManager(const ::p4::config::v1::P4Info& p4_info)
       direct_meter_map_("Direct-Meter"),
       pkt_mod_meter_map_("PacketModMeter"),
       direct_pkt_mod_meter_map_("DirectPacketModMeter"),
+      direct_ts_meter_map_("DirectTSMeter"),
       value_set_map_("ValueSet"),
       register_map_("Register"),
       digest_map_("Digest"),
@@ -55,6 +56,7 @@ P4InfoManager::P4InfoManager()
       direct_meter_map_("Direct-Meter"),
       pkt_mod_meter_map_("PacketModMeter"),
       direct_pkt_mod_meter_map_("DirectPacketModMeter"),
+      direct_ts_meter_map_("DirectTSMeter"),
       value_set_map_("ValueSet"),
       register_map_("Register"),
       digest_map_("Digest"),
@@ -107,6 +109,9 @@ P4InfoManager::~P4InfoManager() {}
         case ::p4::config::v1::P4Ids_Prefix_DIRECT_PACKET_MOD_METER:
           InitDirectPacketModMeters(p4extern);
           break;
+        case ::idpf::P4Ids_Prefix_DIRECT_TSMETER:
+          InitDirectTSMeters(p4extern);
+          break;
         default:
           LOG(INFO) << "Unrecognized p4_info extern type: "
                     << p4extern.extern_type_id() << " (ignored)";
@@ -135,6 +140,22 @@ void P4InfoManager::InitDirectPacketModMeters(
     direct_meter_objects_.Add(std::move(direct_pkt_mod_meter));
   }
   direct_pkt_mod_meter_map_.BuildMaps(direct_meter_objects_, preamble_cb);
+}
+
+void P4InfoManager::InitDirectTSMeters(const p4::config::v1::Extern& p4extern) {
+  const auto& extern_instances = p4extern.instances();
+  PreambleCallback preamble_cb =
+      std::bind(&P4InfoManager::ProcessPreamble, this, std::placeholders::_1,
+                std::placeholders::_2);
+  for (const auto& extern_instance : extern_instances) {
+    ::idpf::DirectTSMeter direct_ts_meter;
+    *direct_ts_meter.mutable_preamble() = extern_instance.preamble();
+    p4::config::v1::MeterSpec meter_spec;
+    meter_spec.set_unit(p4::config::v1::MeterSpec::PACKETS);
+    *direct_ts_meter.mutable_spec() = meter_spec;
+    direct_ts_meter_objects_.Add(std::move(direct_ts_meter));
+  }
+  direct_ts_meter_map_.BuildMaps(direct_ts_meter_objects_, preamble_cb);
 }
 
 void P4InfoManager::InitPacketModMeters(

--- a/stratum/hal/lib/p4/p4_info_manager.h
+++ b/stratum/hal/lib/p4/p4_info_manager.h
@@ -287,6 +287,7 @@ class P4InfoManager {
   ::util::Status VerifyTableXrefs();
 
   void InitDirectPacketModMeters(const p4::config::v1::Extern& p4extern);
+  void InitDirectTSMeters(const p4::config::v1::Extern& p4extern);
   void InitPacketModMeters(const p4::config::v1::Extern& p4extern);
 
   // Functions to validate name and ID presence in message preamble.
@@ -309,6 +310,7 @@ class P4InfoManager {
   P4ResourceMap<::p4::config::v1::DirectMeter> direct_meter_map_;
   P4ResourceMap<::idpf::PacketModMeter> pkt_mod_meter_map_;
   P4ResourceMap<::idpf::DirectPacketModMeter> direct_pkt_mod_meter_map_;
+  P4ResourceMap<::idpf::DirectTSMeter> direct_ts_meter_map_;
   P4ResourceMap<::p4::config::v1::ValueSet> value_set_map_;
   P4ResourceMap<::p4::config::v1::Register> register_map_;
   P4ResourceMap<::p4::config::v1::Digest> digest_map_;
@@ -323,6 +325,8 @@ class P4InfoManager {
   google::protobuf::RepeatedPtrField<::idpf::PacketModMeter> all_meter_objects_;
   google::protobuf::RepeatedPtrField<::idpf::DirectPacketModMeter>
       direct_meter_objects_;
+  google::protobuf::RepeatedPtrField<::idpf::DirectTSMeter>
+      direct_ts_meter_objects_;
 };
 
 }  // namespace hal

--- a/stratum/hal/lib/tdi/tdi_table_manager.cc
+++ b/stratum/hal/lib/tdi/tdi_table_manager.cc
@@ -222,7 +222,6 @@ std::unique_ptr<TdiTableManager> TdiTableManager::CreateInstance(
       return MAKE_ERROR(ERR_UNIMPLEMENTED)
              << "Unsupported action type: " << table_entry.action().type_case();
   }
-
   ASSIGN_OR_RETURN(auto table,
                    p4_info_manager_->FindTableByID(table_entry.table_id()));
 


### PR DESCRIPTION
Initialization of `DirectTSMeter` was missing from P4InfoManager, which was causing a failure in adding the resource of type DirectTSMeter.
