### PR TITLE
Update TLS certificate generation script + install as trusted CA

### DIFF
--- a/tools/tls/ca.conf
+++ b/tools/tls/ca.conf
@@ -1,10 +1,11 @@
 # Copyright 2020-present Open Networking Foundation
-# Copyright 2024 Intel Corporation
+# Copyright 2024-2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 [ req ]
 default_bits           = 4096
 distinguished_name     = stratum-ca
 prompt                 = no
+x509_extensions        = ca_ext
 
 [ stratum-ca ]
 C                      = US
@@ -13,3 +14,8 @@ L                      = Menlo Park
 O                      = Open Networking Foundation
 OU                     = Stratum
 CN                     = Stratum CA
+
+[ ca_ext ]
+basicConstraints       = critical, CA:true
+keyUsage               = critical, digitalSignature, keyCertSign, cRLSign
+subjectKeyIdentifier   = hash

--- a/tools/tls/generate-certs.sh
+++ b/tools/tls/generate-certs.sh
@@ -1,58 +1,61 @@
 #!/bin/bash
 # Copyright 2020-present Open Networking Foundation
-# Copyright 2023 Intel Corporation
+# Copyright 2023,2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 set -e
+
 THIS_DIR=$(dirname "${BASH_SOURCE[0]}")
-COMMON_NAME=${COMMON_NAME:-"stratum.local"}
+COMMON_NAME=${COMMON_NAME:-"127.0.0.1"}
 
+echo "Creating certificates for CN=$COMMON_NAME"
+
+# Create directory for certificates
 mkdir -p "$THIS_DIR/certs"
-rm -rf "$THIS_DIR/certs/*"
+rm -rf "$THIS_DIR/certs/"*
 
+# Create temporary server config with environment variables replaced
 SERVER_CONF_FILE="$(mktemp)"
+cat "$THIS_DIR/grpc-server.conf" | sed "s/\${COMMON_NAME}/$COMMON_NAME/g" > "$SERVER_CONF_FILE"
 
-echo "[ req ]
-default_bits           = 4096
-distinguished_name     = stratum
-prompt                 = no
-req_extensions         = req_ext
-
-[ stratum ]
-C                      = US
-ST                     = CA
-L                      = Menlo Park
-O                      = Open Networking Foundation
-OU                     = Stratum
-CN                     = $COMMON_NAME
-
-[ alternate_names ]
-DNS.1                  = $COMMON_NAME
-
-[ req_ext ]
-subjectAltName         = @alternate_names
-" > "$SERVER_CONF_FILE"
-
-# Generate Private keys and certificates for CA
+echo "=== Generating CA certificate ==="
+# Generate CA private key and certificate
 openssl genrsa -out "$THIS_DIR/certs/ca.key" 4096
-openssl req -sha512 -x509 -nodes -new -config "$THIS_DIR/ca.conf" -key "$THIS_DIR/certs/ca.key" \
-                  -days 365 -out "$THIS_DIR/certs/ca.crt"
+openssl req -new -x509 -key "$THIS_DIR/certs/ca.key" -out "$THIS_DIR/certs/ca.crt" \
+    -config "$THIS_DIR/ca.conf" -days 365 -sha512
+echo "CA certificate generated successfully"
 
-# Generate Private keys and certificate signing request(CSR) for Stratum gRPC server
+echo "=== Generating server certificate ==="
+# Generate server private key and CSR
 openssl genrsa -out "$THIS_DIR/certs/stratum.key" 4096
-openssl req -new -config "$SERVER_CONF_FILE" -key "$THIS_DIR/certs/stratum.key" -out "$THIS_DIR/certs/stratum.csr"
+openssl req -new -key "$THIS_DIR/certs/stratum.key" -out "$THIS_DIR/certs/stratum.csr" \
+    -config "$SERVER_CONF_FILE" -sha512
 
-# Sing a certificate for Stratum with CA
-openssl x509 -sha512 -req -in "$THIS_DIR/certs/stratum.csr" -CA "$THIS_DIR/certs/ca.crt" \
-             -CAkey "$THIS_DIR/certs/ca.key" -CAcreateserial \
-             -out "$THIS_DIR/certs/stratum.crt" -days 30 \
-             -extensions req_ext -extfile "$SERVER_CONF_FILE"
+# Sign server certificate with CA
+openssl x509 -req -in "$THIS_DIR/certs/stratum.csr" -CA "$THIS_DIR/certs/ca.crt" \
+    -CAkey "$THIS_DIR/certs/ca.key" -CAcreateserial -out "$THIS_DIR/certs/stratum.crt" \
+    -days 30 -sha512 -extfile "$SERVER_CONF_FILE" -extensions server_ext
+echo "Server certificate generated successfully"
 
-# (Optional) Generate Private keys and certificate for gRPC client
+echo "=== Generating client certificate ==="
+# Generate client private key and CSR
 openssl genrsa -out "$THIS_DIR/certs/client.key" 4096
-openssl req -new -config "$THIS_DIR/grpc-client.conf" -key "$THIS_DIR/certs/client.key" -out "$THIS_DIR/certs/client.csr"
-openssl x509 -sha512 -req -in "$THIS_DIR/certs/client.csr" -CA "$THIS_DIR/certs/ca.crt" \
-             -CAkey "$THIS_DIR/certs/ca.key" -CAcreateserial \
-             -out "$THIS_DIR/certs/client.crt" -days 30
+openssl req -new -key "$THIS_DIR/certs/client.key" -out "$THIS_DIR/certs/client.csr" \
+    -config "$THIS_DIR/grpc-client.conf" -sha512
+
+# Sign client certificate with CA
+openssl x509 -req -in "$THIS_DIR/certs/client.csr" -CA "$THIS_DIR/certs/ca.crt" \
+    -CAkey "$THIS_DIR/certs/ca.key" -CAcreateserial -out "$THIS_DIR/certs/client.crt" \
+    -days 30 -sha512 -extfile "$THIS_DIR/grpc-client.conf" -extensions client_ext
+echo "Client certificate generated successfully"
+
+# Install CA certificate to system trust store
+echo "=== Installing CA certificate to system trust store ==="
+cp "$THIS_DIR/certs/ca.crt" /etc/pki/ca-trust/source/anchors/
+update-ca-trust extract
+echo "CA certificate installation complete"
 
 # Cleanup
 rm "$SERVER_CONF_FILE"
+
+echo "=== Certificate generation completed successfully ==="
+echo ""

--- a/tools/tls/grpc-client.conf
+++ b/tools/tls/grpc-client.conf
@@ -1,10 +1,11 @@
 # Copyright 2020-present Open Networking Foundation
-# Copyright 2024 Intel Corporation
+# Copyright 2024-2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 [ req ]
 default_bits           = 4096
 distinguished_name     = grpc-client
 prompt                 = no
+req_extensions         = client_ext
 
 [ grpc-client ]
 C                      = US
@@ -13,3 +14,8 @@ L                      = Menlo Park
 O                      = Open Networking Foundation
 OU                     = Stratum
 CN                     = Stratum client certificate
+
+[ client_ext ]
+basicConstraints       = CA:false
+keyUsage               = critical, digitalSignature, keyEncipherment
+extendedKeyUsage       = clientAuth

--- a/tools/tls/grpc-server.conf
+++ b/tools/tls/grpc-server.conf
@@ -1,0 +1,27 @@
+# Copyright 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+[ req ]
+default_bits           = 4096
+distinguished_name     = stratum
+prompt                 = no
+req_extensions         = server_ext
+
+[ stratum ]
+C                      = US
+ST                     = CA
+L                      = Menlo Park
+O                      = Open Networking Foundation
+OU                     = Stratum
+CN                     = ${COMMON_NAME}
+
+[ server_ext ]
+basicConstraints       = CA:false
+keyUsage               = critical, digitalSignature, keyEncipherment
+extendedKeyUsage       = serverAuth
+subjectAltName         = @alt_names
+
+[ alt_names ]
+DNS.1                  = ${COMMON_NAME}
+DNS.2                  = localhost
+IP.1                   = ${COMMON_NAME}
+IP.2                   = 127.0.0.1


### PR DESCRIPTION
This CL introduces TLS certificate generation conf and script changes to take into account latest RL9.4 lib updates. 

The `generate-certs.sh` has also been updated to install the RootCA as a trusted CA in the system.
