### PR TITLE
Copy grpc-server.conf to share folder for dpdk target

### DIFF
--- a/stratum/hal/bin/tdi/dpdk/CMakeLists.txt
+++ b/stratum/hal/bin/tdi/dpdk/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Build file for //stratum/hal/bin/tdi/dpdk
 #
-# Copyright 2022-2023 Intel Corporation
+# Copyright 2022-2023,2025 Intel Corporation
 # SPDX-License-Identifier: Apache 2.0
 #
 
@@ -14,6 +14,7 @@ install(
         dpdk_skip_p4.conf
         ${STRATUM_SOURCE_DIR}/tools/tls/ca.conf
         ${STRATUM_SOURCE_DIR}/tools/tls/grpc-client.conf
+        ${STRATUM_SOURCE_DIR}/tools/tls/grpc-server.conf
     DESTINATION
         ${CMAKE_INSTALL_DATAROOTDIR}/stratum/dpdk
 )

--- a/stratum/hal/bin/tdi/es2k/CMakeLists.txt
+++ b/stratum/hal/bin/tdi/es2k/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Build file for //stratum/hal/bin/tdi/es2k
 #
-# Copyright 2022-2023 Intel Corporation
+# Copyright 2022-2023,2025 Intel Corporation
 # SPDX-License-Identifier: Apache 2.0
 #
 


### PR DESCRIPTION
During compile-time, the CMakeLists.txt file copies the conf files to ./install/share/stratum/dpdk folder

It can then be exported/copied to other locations as needed
